### PR TITLE
Adjust horizontal alignment of sign in modal

### DIFF
--- a/app/styles/_sign_in_screen.scss
+++ b/app/styles/_sign_in_screen.scss
@@ -2,9 +2,9 @@
     max-width: 300px;
     margin: 0 auto;
     position: absolute;
+    transform: translate(-142px, -165px);
     top: 50%;
-    transform: translateY(-165px);
-    left: 40%;
+    left: 50%;
     background: $blue_light3;
     padding: 20px;
     border-radius: 10px;


### PR DESCRIPTION
Resolves #132

Used a horizontal translate transform equal to half of the computed modal (similar to what is being done for vertical alignment)