### PR TITLE
Address #277: Localization for Imaging Module

### DIFF
--- a/app/components/nav-menu.js
+++ b/app/components/nav-menu.js
@@ -27,7 +27,6 @@ export default Ember.Component.extend(UserSession, {
 
   actions: {
     toggleContent: function() {
-      // debugger;
       this.set('isShowing', !this.get('isShowing'));
       this.sendAction('callNavAction', this.nav);
     },

--- a/app/controllers/abstract-edit-controller.js
+++ b/app/controllers/abstract-edit-controller.js
@@ -7,11 +7,12 @@ export default Ember.Controller.extend(EditPanelProps, IsUpdateDisabled, ModalHe
   cancelAction: 'allItems',
 
   cancelButtonText: function() {
+    let i18n = this.get('i18n');
     var hasDirtyAttributes = this.get('model.hasDirtyAttributes');
     if (hasDirtyAttributes) {
-      return 'Cancel';
+      return i18n.t('buttons.cancel');
     } else {
-      return 'Return';
+      return i18n.t('buttons.return_button');
     }
   }.property('model.hasDirtyAttributes'),
 
@@ -43,10 +44,11 @@ export default Ember.Controller.extend(EditPanelProps, IsUpdateDisabled, ModalHe
 
   updateButtonAction: 'update',
   updateButtonText: function() {
+    let i18n = this.get('i18n');
     if (this.get('model.isNew')) {
-      return 'Add';
+      return i18n.t('buttons.add');
     } else {
-      return 'Update';
+      return i18n.t('buttons.update');
     }
   }.property('model.isNew'),
   updateCapability: null,

--- a/app/imaging/completed/route.js
+++ b/app/imaging/completed/route.js
@@ -1,5 +1,6 @@
+import { translationMacro as t } from 'ember-i18n';
 import ImagingIndexRoute from 'hospitalrun/imaging/index/route';
 export default ImagingIndexRoute.extend({
-  pageTitle: 'Completed Imaging',
+  pageTitle: t('imaging.titles.completed_imaging'),
   searchStatus: 'Completed'
 });

--- a/app/imaging/completed/template.hbs
+++ b/app/imaging/completed/template.hbs
@@ -3,10 +3,10 @@
     <table class="table">
       <tr class="table-header">
           <th>{{t 'labels.date_requested'}}</th>
-          <th>Date Completed</th>
+          <th>{{t 'labels.date_completed'}}</th>
           <th>{{t 'labels.patient'}}</th>
-          <th>{{t 'labels.imaging_type'}}</th>
-          <th>Results</th>
+          <th>{{t 'labels.imaging_type '}}</th>
+          <th>{{t 'labels.results'}}</th>
           <th>{{t 'labels.notes'}}</th>
       </tr>
       {{#each model as |imaging|}}
@@ -22,7 +22,7 @@
     </table>
   {{else}}
       <div class="alert alert-info">
-          <p>No completed items found.</p>
+          <p>{{t 'imaging.messages.no_completed'}}</p>
       </div>
   {{/if}}
 {{/item-listing}}

--- a/app/imaging/edit/controller.js
+++ b/app/imaging/edit/controller.js
@@ -69,6 +69,7 @@ export default AbstractEditController.extend(ChargeActions, PatientSubmodule, {
   },
 
   additionalButtons: function() {
+    let i18n = this.get('i18n');
     var canComplete = this.get('canComplete'),
       isValid = this.get('model.isValid');
     if (isValid && canComplete) {
@@ -76,7 +77,7 @@ export default AbstractEditController.extend(ChargeActions, PatientSubmodule, {
         buttonAction: 'completeImaging',
         buttonIcon: 'glyphicon glyphicon-ok',
         class: 'btn btn-primary on-white',
-        buttonText: 'Complete'
+        buttonText: i18n.t('buttons.complete')
       }];
     }
   }.property('canComplete', 'model.isValid'),
@@ -97,16 +98,17 @@ export default AbstractEditController.extend(ChargeActions, PatientSubmodule, {
   updateCapability: 'add_imaging',
 
   afterUpdate: function(saveResponse, multipleRecords) {
+    let i18n = this.get('i18n');
     this.updateLookupLists();
     var afterDialogAction,
       alertTitle,
       alertMessage;
     if (this.get('model.status') === 'Completed') {
-      alertTitle = 'Imaging Request Completed';
-      alertMessage = 'The imaging request has been completed.';
+      alertTitle = i18n.t('imaging.alerts.completed_title');
+      alertMessage = i18n.t('imaging.alerts.completed_message');
     } else {
-      alertTitle = 'Imaging Request Saved';
-      alertMessage = 'The imaging request has been saved.';
+      alertTitle = i18n.t('imaging.alerts.saved_title');
+      alertMessage = i18n.t('imaging.alerts.saved_message');
     }
     if (multipleRecords) {
       afterDialogAction = this.get('cancelAction');

--- a/app/imaging/edit/route.js
+++ b/app/imaging/edit/route.js
@@ -1,11 +1,12 @@
+import { translationMacro as t } from 'ember-i18n';
 import AbstractEditRoute from 'hospitalrun/routes/abstract-edit-route';
 import ChargeRoute from 'hospitalrun/mixins/charge-route';
 import Ember from 'ember';
 import PatientListRoute from 'hospitalrun/mixins/patient-list-route';
 export default AbstractEditRoute.extend(ChargeRoute, PatientListRoute, {
-  editTitle: 'Edit Imaging Request',
+  editTitle: t('imaging.titles.edit_title'),
   modelName: 'imaging',
-  newTitle: 'New Imaging Request',
+  newTitle: t('imaging.titles.new_title'),
   pricingCategory: 'Imaging',
 
   getNewData: function() {

--- a/app/imaging/edit/template.hbs
+++ b/app/imaging/edit/template.hbs
@@ -1,21 +1,21 @@
 {{#edit-panel editPanelProps=editPanelProps}}
   {{#em-form model=model submitButton=false }}
     {{#if model.selectPatient}}
-      {{patient-typeahead property="patientTypeAhead" label="Patient" content=patientList selection=selectedPatient class="required patient-input"}}
+      {{patient-typeahead property="patientTypeAhead" label=(t 'labels.patient')content=patientList selection=selectedPatient class="required patient-input"}}
     {{else}}
       {{patient-summary patient=model.patient returnTo='imaging.edit' returnToContext=model.id disablePatientLink=model.isNew }}
     {{/if}}
     {{#if model.isNew}}
       <div class="row">
-        {{em-select class="col-xs-3 required" label="Visit"
+        {{em-select class="col-xs-3 required" label=(t 'labels.visit')
           property="visit" content=patientVisitsForSelect
           optionValuePath="selectObject" optionLabelPath="selectObject.visitDescription"
-          prompt="--Add New Visit--"
+          prompt=(t 'imaging.labels.add_new_visit')
           selected=model.visit
         }}
       </div>
       {{checkbox-or-typeahead property="imagingTypeName"
-        label="Imaging Type" list=objectTypeList
+        label=(t 'labels.imaging_type') list=objectTypeList
         selection=selectedImagingType
         optionLabelPath='name'
         typeAheadType='pricing'
@@ -27,7 +27,7 @@
     {{else}}
       <div class="row">
         <div class="form-group col-xs-3">
-          <label>Visit</label>
+          <label>{{t 'labels.visit'}}</label>
           <p class="form-control-static">{{model.visit.visitDate}}</p>
         </div>
         <div class="form-group col-xs-9">
@@ -38,12 +38,12 @@
     {{/if}}
     {{#if canComplete}}
       {{select-or-typeahead property="radiologist"
-        label="Radiologist" list=radiologistList
+        label=(t 'imaging.labels.radiologist') list=radiologistList
         prompt=" "
         class="radiologist-input"
       }}
-      {{em-input property="result" label="Result" class="result-input"}}
+      {{em-input property="result" label=(t 'labels.result') class="result-input"}}
     {{/if}}
-    {{em-text property="notes" label="Notes" rows=3 }}
+    {{em-text property="notes" label=(t 'labels.notes') rows=3 }}
   {{/em-form}}
 {{/edit-panel}}

--- a/app/imaging/index/route.js
+++ b/app/imaging/index/route.js
@@ -1,7 +1,8 @@
+import { translationMacro as t } from 'ember-i18n';
 import AbstractIndexRoute from 'hospitalrun/routes/abstract-index-route';
 export default AbstractIndexRoute.extend({
   modelName: 'imaging',
-  pageTitle: 'Imaging Requests',
+  pageTitle: t('imaging.page_title'),
   searchStatus: 'Requested',
 
   _getStartKeyFromItem: function(item) {
@@ -11,7 +12,6 @@ export default AbstractIndexRoute.extend({
       searchStatus = this.get('searchStatus');
     return [searchStatus, requestedDateAsTime, imagingDateAsTime, id];
   },
-
   _modelQueryParams: function() {
     var maxId = this._getMaxPouchId(),
       maxValue = this.get('maxValue'),

--- a/app/imaging/index/template.hbs
+++ b/app/imaging/index/template.hbs
@@ -28,7 +28,7 @@
     </table>
   {{else}}
     <div class="alert alert-info">
-      <p>No items found. {{#if canAdd}} <a href="#" {{action 'newItem'}}>Create a new record?</a>{{/if}}</p>
+      <p>{{t 'messages.no_items_found'}} {{#if canAdd}} <a href="#" {{action 'newItem'}}>{{t 'messages.create_new_record'}}</a>{{/if}}</p>
     </div>
   {{/if}}
 {{/item-listing}}

--- a/app/imaging/route.js
+++ b/app/imaging/route.js
@@ -1,3 +1,4 @@
+import { translationMacro as t } from 'ember-i18n';
 import AbstractModuleRoute from 'hospitalrun/routes/abstract-module-route';
 export default AbstractModuleRoute.extend({
   addCapability: 'add_imaging',
@@ -10,14 +11,19 @@ export default AbstractModuleRoute.extend({
   }],
   allowSearch: false,
   moduleName: 'imaging',
-  newButtonText: '+ new imaging',
-  sectionTitle: 'Imaging',
-  subActions: [{
-    text: 'Requests',
-    linkTo: 'imaging.index'
-  }, {
-    text: 'Completed',
-    linkTo: 'imaging.completed'
-  }]
+  newButtonText: t('imaging.buttons.new_button'),
+  sectionTitle: t('imaging.section_title'),
+  subActions: function() {
+    let i18n = this.get('i18n');
+
+    return [{
+      text: i18n.t('labels.requests'),
+      linkTo: 'imaging.index'
+    }, {
+      text: i18n.t('labels.completed'),
+      linkTo: 'imaging.completed'
+    }];
+
+  }.property()
 
 });

--- a/app/initializers/i18n.js
+++ b/app/initializers/i18n.js
@@ -1,0 +1,11 @@
+export default {
+  name: 'i18n',
+
+  after: 'ember-i18n',
+
+  initialize: function(app) {
+    app.inject('route', 'i18n', 'service:i18n');
+    app.inject('controller', 'i18n', 'service:i18n');
+    app.inject('mixin', 'i18n', 'service:i18n');
+  }
+};

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -8,13 +8,34 @@ export default {
     quantity: 'Quantity',
     requested_on: 'Requested On',
     date_requested: 'Date Requested',
+    date_completed: 'Date Completed',
     requested_by: 'Requested By',
     fulfill: 'Fulfill',
     actions: 'Actions',
     action: 'Action',
     notes: 'Notes',
     edit: 'Edit',
-    imaging_type: 'Imaging Type'
+    imaging_type: 'Imaging Type',
+    result: 'Result',
+    results: 'Results',
+    visit: 'Visit',
+    requests: 'Requests',
+    completed: 'Completed',
+    id: 'Id',
+    gender: 'Gender',
+    age: 'Age'
+  },
+  messages: {
+    no_items_found: 'No items found.',
+    create_new_record: 'Create a new record?'
+  },
+  buttons: {
+    complete: 'Complete',
+    cancel: 'Cancel',
+    return_button: 'Return',
+    add: 'Add',
+    update: 'Update',
+    ok: 'Ok'
   },
   login: {
     messages: {
@@ -30,6 +51,31 @@ export default {
     messages: {
       no_requests: 'No requests found.',
       create_request: 'Create a new request?'
+    }
+  },
+  imaging: {
+    page_title: 'Imaging Requests',
+    section_title: 'Imaging',
+    buttons: {
+      new_button: '+ new imaging'
+    },
+    labels: {
+      radiologist: 'Radiologist',
+      add_new_visit: '--Add New Visit--'
+    },
+    messages: {
+      no_completed: 'No completed items found.'
+    },
+    titles: {
+      completed_imaging: 'Completed Imaging',
+      edit_title: 'Edit Imaging Request',
+      new_title: 'New Imaging Request'
+    },
+    alerts: {
+      completed_title: 'Imaging Request Completed',
+      completed_message: 'The imaging request has been completed.',
+      saved_title: 'Imaging Request Saved',
+      saved_message: 'The imaging request has been saved.'
     }
   }
 };

--- a/app/mixins/modal-helper.js
+++ b/app/mixins/modal-helper.js
@@ -6,13 +6,16 @@ export default Ember.Mixin.create({
    * @param message string containing the message to display.
    */
   displayAlert: function(title, message, okAction) {
-    this.send('openModal', 'dialog', Ember.Object.create({
+    let i18n = this.get('i18n');
+    let modalOptions = Ember.Object.extend({
+      updateButtonText: i18n.t('buttons.ok')
+    });
+    this.send('openModal', 'dialog', modalOptions.create({
       title: title,
       message: message,
       okAction: okAction,
       hideCancelButton: true,
-      updateButtonAction: 'ok',
-      updateButtonText: 'Ok'
+      updateButtonAction: 'ok'
     }));
   },
 

--- a/app/templates/components/patient-summary.hbs
+++ b/app/templates/components/patient-summary.hbs
@@ -2,16 +2,16 @@
     <div class="panel-body">
         <div class="row test-patient-summary">
             <div class="form-group col-sm-3">
-                <label class="control-label">Id</label> {{patient.displayPatientId}}
+                <label class="control-label">{{t 'labels.id'}}</label> {{patient.displayPatientId}}
             </div>
             <div class="form-group col-sm-4">
                 <label class="control-label">{{t 'labels.name'}}</label> {{patient.displayName}}
             </div>
             <div class="form-group col-sm-2">
-                <label class="control-label">Gender</label> {{patient.gender}}
+                <label class="control-label">{{t 'labels.gender'}}</label> {{patient.gender}}
             </div>
             <div class="form-group col-sm-3">
-                <label class="control-label">Age</label> {{patient.age}}
+                <label class="control-label">{{t 'labels.age'}}</label> {{patient.age}}
             </div>
         </div>
         {{#if havePrimaryDiagnoses}}


### PR DESCRIPTION
-Added an initializer to inject the I18N service into all controllers, routes, and mixins
-Did not write any i18n-specific tests - don't have a lot of experience in how to automated test i18n, in this case knowing that the current tests didn't break when run with the 'en' locale is probably good enough? Would gladly write some if you have any suggestions.
-The Ember localization syntax can get kind of awkward sometimes, it doesn't feel very DRY. Take for example the subActions changes in app/imaging/route.js - you can't access the translation helper in the array because this isn't bound to the route , so you have to change it to a function. Not sure if there's a way around this, that method was recommended here: http://stackoverflow.com/a/33380796/265714

A couple of things I considered out of scope:
-I didn't localize the nav
-I made no effort to audit display of numbers / dates / etc in the proper locale - seems like we're just focused on translating strings for now.