### PR TITLE
Fixes #278: Localization for Medication module

### DIFF
--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -99,10 +99,13 @@ export default {
     patient: 'Patient',
     quantity: 'Quantity',
     requested_on: 'Requested On',
+    date: 'Date',
     date_requested: 'Date Requested',
     date_completed: 'Date Completed',
     requested_by: 'Requested By',
     fulfill: 'Fulfill',
+    fulfill_request: 'Fulfill Request',
+    fulfill_request_now: 'Fulfill Request Now',
     actions: 'Actions',
     action: 'Action',
     notes: 'Notes',
@@ -134,7 +137,16 @@ export default {
     password: 'Password',
     edit_user: 'Edit User',
     new_user: 'New User',
-    delete_user: 'Delete User'
+    delete_user: 'Delete User',
+    medication: 'Medication',
+    status: 'Status',
+    add_new_outpatient_visit: '--Add New Outpatient Visit--',
+    prescription: 'Prescription',
+    prescription_date: 'Prescription Date',
+    bill_to: 'Bill To',
+    pull_from: 'Pull From',
+    fulfilled: 'Fulfilled',
+    delete_request: 'Delete Request'
   },
   messages: {
     no_items_found: 'No items found.',
@@ -143,7 +155,11 @@ export default {
     no_users_found: 'No users found.',
     are_you_sure_delete: 'Are you sure you wish to delete the user ',
     user_has_been_saved: 'The user has been saved.',
-    user_saved: 'User Saved'
+    user_saved: 'User Saved',
+    new_patient_has_to_be_created: 'A new patient needs to be created...Please wait..'
+  },
+  alerts: {
+    please_wait: 'Please Wait'
   },
   buttons: {
     complete: 'Complete',
@@ -156,7 +172,10 @@ export default {
     new_user: 'New User',
     add_value: 'Add Value',
     import: 'Import',
-    load_file: 'Load File'
+    load_file: 'Load File',
+    new_request: 'New Request',
+    all_requests: 'All Requests',
+    dispense: 'Dispense'
   },
   login: {
     messages: {
@@ -198,6 +217,44 @@ export default {
       completed_message: 'The imaging request has been completed.',
       saved_title: 'Imaging Request Saved',
       saved_message: 'The imaging request has been saved.'
+    }
+  },
+  medication: {
+    page_title: 'Medication Requests',
+    section_title: 'Medication',
+    return_medication: 'Return Medication',
+    buttons: {
+      dispense_medication: 'dispense medication',
+      new_button: '+ new request',
+      return_medication: 'return medication'
+    },
+    titles: {
+      completed_medication: 'Completed Medication',
+      edit_medication_request: 'Edit Medication Request',
+      new_medication_request: 'New Medication Request'
+    },
+    messages: {
+      create_new: 'Create a new medication request?',
+      confirm_deletion: 'Are you sure you wish to delete this medication request?'
+    },
+    labels: {
+      refills: 'Refills',
+      quantity_requested: 'Quantity Requested',
+      quantity_dispensed: 'Quantity Dispensed',
+      quantity_distributed: 'Quantity Distributed',
+      quantity_to_return: 'Quantity To Return',
+      return_location: 'Return Location',
+      return_aisle: 'Return Aisle',
+      return_reason: 'Return Reason/Notes',
+      adjustment_date: 'Adjustment Date',
+      credit_to_account: 'Credit To Account'
+    },
+    alerts: {
+      returned_title: 'Medication Returned',
+      returned_message:  'The medication has been marked as returned.',
+      saved_title: 'Medication Request Saved',
+      saved_message: 'The medication record has been saved.',
+      fulfilled_title: 'Medication Request Fulfilled'
     }
   }
 };

--- a/app/medication/completed/route.js
+++ b/app/medication/completed/route.js
@@ -1,6 +1,7 @@
+import { translationMacro as t } from 'ember-i18n';
 import MedicationIndexRoute from 'hospitalrun/medication/index/route';
 export default MedicationIndexRoute.extend({
   modelName: 'medication',
-  pageTitle: 'Completed Medication',
+  pageTitle: t('medication.titles.completed_medication'),
   searchStatus: 'Fulfilled'
 });

--- a/app/medication/delete/controller.js
+++ b/app/medication/delete/controller.js
@@ -1,7 +1,8 @@
+import { translationMacro as t } from 'ember-i18n';
 import AbstractDeleteController from 'hospitalrun/controllers/abstract-delete-controller';
 import PatientSubmodule from 'hospitalrun/mixins/patient-submodule';
 export default AbstractDeleteController.extend(PatientSubmodule, {
-  title: 'Delete Request',
+  title: t('labels.delete_request'),
 
   actions: {
     delete: function() {

--- a/app/medication/delete/template.hbs
+++ b/app/medication/delete/template.hbs
@@ -5,6 +5,6 @@
     updateButtonText=updateButtonText }}
   <div class="alert alert-danger">
     <span class="glyphicon glyphicon-warning-sign"></span>
-    Are you sure you wish to delete this medication request?
+    {{t 'medication.messages.confirm_deletion'}}
   </div>
 {{/modal-dialog}}

--- a/app/medication/edit/controller.js
+++ b/app/medication/edit/controller.js
@@ -54,13 +54,14 @@ export default AbstractEditController.extend(InventorySelection, FulfillRequest,
   }.property('isFulfilling', 'model.prescription'),
 
   quantityLabel: function() {
-    var returnLabel = 'Quantity Requested',
+    let i18n = this.get('i18n');
+    var returnLabel = i18n.t('medication.labels.quantity_requested'),
       isFulfilled = this.get('isFulfilled'),
       isFulfilling = this.get('isFulfilling');
     if (isFulfilling) {
-      returnLabel = 'Quantity Dispensed';
+      returnLabel = i18n.t('medication.labels.quantity_dispensed');
     } else if (isFulfilled) {
-      returnLabel = 'Quantity Distributed';
+      returnLabel = i18n.t('medication.labels.quantity_distributed');
     }
     return returnLabel;
   }.property('isFulfilled'),
@@ -69,22 +70,24 @@ export default AbstractEditController.extend(InventorySelection, FulfillRequest,
   updateCapability: 'add_medication',
 
   afterUpdate: function() {
-    var alertTitle = 'Medication Request Saved',
-      alertMessage = 'The medication record has been saved.',
+    let i18n = this.get('i18n');
+    var alertTitle,
+      alertMessage,
       isFulfilled = this.get('isFulfilled');
     if (isFulfilled) {
-      alertTitle = 'Medication Request Fulfilled';
+      alertTitle = i18n.t('medication.alerts.fulfilled_title');
       alertMessage = 'The medication request has been fulfilled.';
       this.set('model.selectPatient', false);
     } else {
-      alertTitle = 'Medication Request Saved';
-      alertMessage = 'The medication record has been saved.';
+      alertTitle = i18n.t('medication.alerts.saved_title');
+      alertMessage = i18n.t('medication.alerts.saved_message');
     }
     this.saveVisitIfNeeded(alertTitle, alertMessage);
   },
 
   _addNewPatient: function() {
-    this.displayAlert('Please Wait', 'A new patient needs to be created...Please wait..');
+    let i18n = this.get('i18n');
+    this.displayAlert(i18n.t('alerts.please_wait'), i18n.t('messages.new_patient_has_to_be_created'));
     this._getNewPatientId().then(function(friendlyId) {
       var patientTypeAhead = this.get('model.patientTypeAhead'),
         nameParts = patientTypeAhead.split(' '),
@@ -197,14 +200,15 @@ export default AbstractEditController.extend(InventorySelection, FulfillRequest,
   }.property('updateCapability', 'isFulfilled'),
 
   updateButtonText: function() {
+    let i18n = this.get('i18n');
     if (this.get('model.hideFulfillRequest')) {
-      return 'Dispense';
+      return i18n.t('buttons.dispense');
     } else if (this.get('isFulfilling')) {
-      return 'Fulfill';
+      return i18n.t('labels.fulfill');
     } else if (this.get('model.isNew')) {
-      return 'Add';
+      return i18n.t('buttons.add');
     } else {
-      return 'Update';
+      return i18n.t('buttons.update');
     }
   }.property('model.isNew', 'isFulfilling', 'model.hideFulfillRequest'),
 

--- a/app/medication/edit/route.js
+++ b/app/medication/edit/route.js
@@ -1,12 +1,13 @@
+import { translationMacro as t } from 'ember-i18n';
 import AbstractEditRoute from 'hospitalrun/routes/abstract-edit-route';
 import Ember from 'ember';
 import FulfillRequest from 'hospitalrun/mixins/fulfill-request';
 import InventoryLocations from 'hospitalrun/mixins/inventory-locations'; // inventory-locations mixin is needed for fulfill-request mixin!
 import PatientListRoute from 'hospitalrun/mixins/patient-list-route';
 export default AbstractEditRoute.extend(FulfillRequest, InventoryLocations, PatientListRoute, {
-  editTitle: 'Edit Medication Request',
+  editTitle: t('medication.titles.edit_medication_request'),
   modelName: 'medication',
-  newTitle: 'New Medication Request',
+  newTitle: t('medication.titles.new_medication_request'),
   database: Ember.inject.service(),
   getNewData: function(params) {
     var idParam = this.get('idParam'),

--- a/app/medication/edit/template.hbs
+++ b/app/medication/edit/template.hbs
@@ -5,61 +5,61 @@
     {{/unless}}
     <div class="row">
       {{#if model.selectPatient}}
-        {{patient-typeahead property="patientTypeAhead" label="Patient" content=patientList selection=selectedPatient class="col-xs-6 required test-patient-input"}}
+        {{patient-typeahead property="patientTypeAhead" label=(t 'labels.patient') content=patientList selection=selectedPatient class="col-xs-6 required test-patient-input"}}
       {{/if}}
       {{#if model.isNew}}
-        {{em-select class="col-xs-4 required test-add-visit" label="Visit"
+        {{em-select class="col-xs-4 required test-add-visit" label=(t 'labels.visit')
           property="visit" content=patientVisitsForSelect
           optionValuePath="selectObject" optionLabelPath="selectObject.visitDescription"
-          prompt="--Add New Outpatient Visit--"
+          prompt=(t 'labels.add_new_outpatient_visit')
           selected=model.visit
         }}
       {{else}}
         <div class="form-group col-xs-3">
-          <label>Visit</label>
+          <label>{{t 'labels.visit'}}</label>
           <p class="form-control-static">{{model.visit.visitDescription}}</p>
         </div>
       {{/if}}
     </div>
     {{#if isFulfilledOrRequested}}
       <div class="form-group">
-        <label class="control-label">Medication</label>
+        <label class="control-label">{{t 'labels.medication'}}</label>
         <p class="form-control-static">{{model.medicationName}}</p>
       </div>
     {{else}}
-      {{inventory-typeahead property="inventoryItemTypeAhead" label="Medication" content=medicationList selection=selectedInventoryItem class="required test-medication-input"}}
+      {{inventory-typeahead property="inventoryItemTypeAhead" label=(t 'labels.medication') content=medicationList selection=selectedInventoryItem class="required test-medication-input"}}
     {{/if}}
     {{#if isFulfilled}}
-      {{static-text label="Prescription" value=model.prescription }}
+      {{static-text label=(t 'labels.prescription') value=model.prescription }}
       <div class="row">
-        {{#static-text label="Prescription Date" class="col-xs-4"}}
+        {{#static-text label=(t 'labels.prescription_date') class="col-xs-4"}}
           {{date-format model.prescriptionDate}}
         {{/static-text}}
         {{static-text label=quantityLabel class="col-xs-3" value=model.quantity }}
-        {{static-text label="Refills" class="col-xs-3" value=model.refills }}
+        {{static-text label=(t 'medication.labels.refills') class="col-xs-3" value=model.refills }}
       </div>
     {{else}}
-      {{em-text property="prescription" label="Prescription" rows="3" class=prescriptionClass }}
+      {{em-text property="prescription" label=(t 'labels.prescription')rows="3" class=prescriptionClass }}
       <div class="row">
-        {{date-picker property="prescriptionDate" label="Prescription Date" class="col-sm-4"}}
+        {{date-picker property="prescriptionDate" label=(t 'labels.prescription_date') class="col-sm-4"}}
       </div>
       <div class="row">
         {{em-input property="quantity" label=quantityLabel class=quantityClass }}
-        {{em-input property="refills" label="Refills" class="col-xs-3"}}
+        {{em-input property="refills" label=(t 'medication.labels.refills') class="col-xs-3"}}
       </div>
       {{#unless model.hideFulfillRequest}}
         {{#if model.isNew}}
           {{#if canFulfill}}
             <div class="form-group">
-              <label class="control-label">Fulfill Request</label>
+              <label class="control-label">{{t 'labels.fulfill_request'}}</label>
             </div>
-            {{em-checkbox label="Fulfill Request Now" property="shouldFulfillRequest"}}
+            {{em-checkbox label=(t 'labels.fulfill_request_now') property="shouldFulfillRequest"}}
           {{/if}}
         {{/if}}
       {{/unless}}
       {{#if isFulfilling}}
-        {{select-or-typeahead property="expenseAccount" label="Bill To" list=expenseAccountList selection=model.expenseAccount }}
-        {{inventory-location-picker label="Pull From" quantityRequested=model.quantity
+        {{select-or-typeahead property="expenseAccount" label=(t 'labels.bill_to') list=expenseAccountList selection=model.expenseAccount }}
+        {{inventory-location-picker label=(t 'labels.pull_from') quantityRequested=model.quantity
           locationList= model.inventoryItem.availableLocations
           selectedLocations=model.inventoryLocations
         }}

--- a/app/medication/index/route.js
+++ b/app/medication/index/route.js
@@ -1,7 +1,8 @@
+import { translationMacro as t } from 'ember-i18n';
 import AbstractIndexRoute from 'hospitalrun/routes/abstract-index-route';
 export default AbstractIndexRoute.extend({
   modelName: 'medication',
-  pageTitle: 'Medication Requests',
+  pageTitle: t('medication.page_title'),
   searchStatus: 'Requested',
 
   _getStartKeyFromItem: function(item) {

--- a/app/medication/index/template.hbs
+++ b/app/medication/index/template.hbs
@@ -2,11 +2,11 @@
   {{#if model}}
     <table class="table">
       <tr class="table-header">
-        <th>Date</th>
+        <th>{{t 'labels.date'}}</th>
         <th>{{t 'labels.patient'}}</th>
-        <th>Medication</th>
+        <th>{{t 'labels.medication'}}</th>
         <th>{{t 'labels.quantity'}}</th>
-        <th>Status</th>
+        <th>{{t 'labels.status'}}</th>
         {{#if showActions}}
           <th>{{t 'labels.actions'}}</th>
         {{/if}}
@@ -28,7 +28,7 @@
     </table>
   {{else}}
     <div class="alert alert-info">
-      <p>No items found. {{#if canAdd}}<a href="#" {{action 'newItem'}}>Create a new medication request?</a>{{/if}}</p>
+      <p>{{t 'messages.no_items_found'}} {{#if canAdd}}<a href="#" {{action 'newItem'}}>{{t 'medication.messages.create_new'}}</a>{{/if}}</p>
     </div>
   {{/if}}
 {{/item-listing}}

--- a/app/medication/return/controller.js
+++ b/app/medication/return/controller.js
@@ -1,3 +1,4 @@
+import { translationMacro as t } from 'ember-i18n';
 import AbstractEditController from 'hospitalrun/controllers/abstract-edit-controller';
 import Ember from 'ember';
 import FulfillRequest from 'hospitalrun/mixins/fulfill-request';
@@ -94,8 +95,9 @@ export default AbstractEditController.extend(FulfillRequest, InventoryLocations,
 
   actions: {
     doneFulfillRequest: function() {
+      let i18n = this.get('i18n');
       this.updateLookupLists();
-      this.displayAlert('Medication Returned', 'The medication has been marked as returned.', 'allItems');
+      this.displayAlert(i18n.t('medication.alerts.returned_title'), i18n.t('medication.alerts.returned_message'), 'allItems');
     },
     update: function() {
       var medication = this.get('model.medication'),
@@ -114,5 +116,5 @@ export default AbstractEditController.extend(FulfillRequest, InventoryLocations,
     }
   },
 
-  updateButtonText: 'Return Medication'
+  updateButtonText: t('medication.return_medication')
 });

--- a/app/medication/return/route.js
+++ b/app/medication/return/route.js
@@ -1,10 +1,11 @@
+import { translationMacro as t } from 'ember-i18n';
 import MedicationEditRoute from '../edit/route';
 import Ember from 'ember';
 
 export default MedicationEditRoute.extend({
-  editTitle: 'Return Medication',
+  editTitle: t('medication.return_medication'),
   modelName: 'inv-request',
-  newTitle: 'Return Medication',
+  newTitle: t('medication.return_medication'),
   getNewData: function() {
     return Ember.RSVP.resolve({
       dateCompleted: new Date(),

--- a/app/medication/return/template.hbs
+++ b/app/medication/return/template.hbs
@@ -1,31 +1,31 @@
 {{#edit-panel editPanelProps=editPanelProps}}
   {{#em-form model=model submitButton=false }}
     {{#if showPatientMedicationList}}
-      {{em-select class="required" label="Medication"
+      {{em-select class="required" label=(t 'labels.medication')
         property="medication" content=patientMedication
         optionValuePath="selectObject" optionLabelPath="selectObject.inventoryItem.name"
         selected=model.medication
       }}
     {{else}}
-      {{inventory-typeahead property="inventoryItemTypeAhead" label="Medication" content=medicationList selection=selectedInventoryItem class="required test-medication-input" showQuantity=false }}
+      {{inventory-typeahead property="inventoryItemTypeAhead" label=(t 'labels.medication') content=medicationList selection=selectedInventoryItem class="required test-medication-input" showQuantity=false }}
     {{/if}}
     <div class="row">
-      {{patient-typeahead property="patientTypeAhead" label="Patient" content=patientList selection=selectedPatient class="col-xs-6"}}
-      {{em-select class="col-xs-6" label="Visit"
+      {{patient-typeahead property="patientTypeAhead" label=(t 'labels.patient') content=patientList selection=selectedPatient class="col-xs-6"}}
+      {{em-select class="col-xs-6" label=(t 'labels.visit')
         property="visit" content=patientVisitsForSelect
         optionValuePath="selectObject" optionLabelPath="selectObject.visitDescription"
         selected=model.visit
       }}
     </div>
     <div class="row">
-      {{em-input property="quantity" label="Quantity To Return" class="col-xs-3 required test-medication-quantity"}}
-      {{select-or-typeahead property="deliveryLocation" label="Return Location" list=warehouseList selection=model.location className="col-xs-4"}}
-      {{select-or-typeahead property="deliveryAisle" label="Return Aisle" list=aisleLocationList selection=model.aisleLocation className="col-xs-4"}}
+      {{em-input property="quantity" label=(t 'medication.labels.quantity_to_return') class="col-xs-3 required test-medication-quantity"}}
+      {{select-or-typeahead property="deliveryLocation" label=(t 'medication.labels.return_location') list=warehouseList selection=model.location className="col-xs-4"}}
+      {{select-or-typeahead property="deliveryAisle" label=(t 'medication.labels.return_aisle') list=aisleLocationList selection=model.aisleLocation className="col-xs-4"}}
     </div>
-    {{em-text property="reason" label="Return Reason/Notes" rows="3"}}
+    {{em-text property="reason" label=(t 'medication.labels.return_reason') rows="3"}}
     <div class="row">
-      {{date-picker property="dateCompleted" label="Adjustment Date" class="col-sm-4"}}
-      {{select-or-typeahead property="expenseAccount" label="Credit To Account" list=expenseAccountList selection=model.expenseAccount  className="col-sm-8"}}
+      {{date-picker property="dateCompleted" label=(t 'medication.labels.adjustment_date') class="col-sm-4"}}
+      {{select-or-typeahead property="expenseAccount" label=(t 'medication.labels.credit_to_account') list=expenseAccountList selection=model.expenseAccount  className="col-sm-8"}}
     </div>
   {{/em-form}}
 {{/edit-panel}}

--- a/app/medication/route.js
+++ b/app/medication/route.js
@@ -1,18 +1,20 @@
+import { translationMacro as t } from 'ember-i18n';
 import AbstractModuleRoute from 'hospitalrun/routes/abstract-module-route';
 import Ember from 'ember';
 export default AbstractModuleRoute.extend({
   addCapability: 'add_medication',
   moduleName: 'medication',
-  newButtonText: '+ new request',
-  sectionTitle: 'Medication',
+  newButtonText: t('medication.buttons.new_button'),
+  sectionTitle: t('medication.section_title'),
 
   additionalButtons: function() {
+    let i18n = this.get('i18n');
     var additionalButtons = [];
     if (this.currentUserCan('fulfill_medication')) {
       additionalButtons.push({
         buttonIcon: 'octicon octicon-checklist',
         buttonAction: 'dispenseMedication',
-        buttonText: 'dispense medication',
+        buttonText: i18n.t('medication.buttons.dispense_medication'),
         class: 'btn btn-primary'
       });
     }
@@ -20,7 +22,7 @@ export default AbstractModuleRoute.extend({
       additionalButtons.push({
         buttonIcon: 'octicon octicon-mail-reply',
         buttonAction: 'returnMedication',
-        buttonText: 'return medication',
+        buttonText: i18n.t('medication.buttons.return_medication'),
         class: 'btn btn-primary'
       });
     }
@@ -43,13 +45,16 @@ export default AbstractModuleRoute.extend({
     findArgs: ['lookup', 'warehouse_list']
   }],
 
-  subActions: [{
-    text: 'Requests',
-    linkTo: 'medication.index'
-  }, {
-    text: 'Completed',
-    linkTo: 'medication.completed'
-  }],
+  subActions: function() {
+    let i18n = this.get('i18n');
+    return [{
+      text: i18n.t('labels.requests'),
+      linkTo: 'medication.index'
+    }, {
+      text: i18n.t('labels.completed'),
+      linkTo: 'medication.completed'
+    }];
+  }.property(),
 
   actions: {
     dispenseMedication: function() {

--- a/app/medication/search/template.hbs
+++ b/app/medication/search/template.hbs
@@ -1,3 +1,3 @@
-{{#search-listing newButtonText="New Request" allButtonText="All Requests"}}
+{{#search-listing newButtonText=(t 'buttons.new_request') allButtonText=(t 'buttons.all_requests')}}
     {{partial 'medication/index'}}
 {{/search-listing}}


### PR DESCRIPTION
One thing I wanted to highlight is the 'searchStatus' parameter used in many of the index routes isn't easy to internationalize right now - because that same string is used for both display and is actually stored in the model - I think we'll have to switch to use category id: string mappings and translate those for the models?