### PR TITLE
Adding ember-cli-content-security-policy with defaults for dev

### DIFF
--- a/app/controllers/navigation.js
+++ b/app/controllers/navigation.js
@@ -5,6 +5,7 @@ import ProgressDialog from 'hospitalrun/mixins/progress-dialog';
 import UserSession from 'hospitalrun/mixins/user-session';
 import Navigation from 'hospitalrun/mixins/navigation';
 export default Ember.Controller.extend(HospitalRunVersion, ModalHelper, ProgressDialog, UserSession, Navigation, {
+  ajax: Ember.inject.service(),
   application: Ember.inject.controller(),
   allowSearch: false,
   config: Ember.inject.service(),
@@ -18,9 +19,8 @@ export default Ember.Controller.extend(HospitalRunVersion, ModalHelper, Progress
 
   actions: {
     about: function() {
-      let config = this.get('config'),
-          version = this.get('version');
-      config.getConfigValue('site_information', '').then((siteInfo) => {
+      let version = this.get('version');
+      this.get('ajax').request('/serverinfo').then((siteInfo) => {
         let message = `Version: ${version}`;
         if (!Ember.isEmpty(siteInfo)) {
           message += ` Site Info: ${siteInfo}`;

--- a/app/serializers/application.js
+++ b/app/serializers/application.js
@@ -1,0 +1,3 @@
+import { Serializer } from 'ember-pouch';
+
+export default Serializer.extend();

--- a/config/environment.js
+++ b/config/environment.js
@@ -19,6 +19,14 @@ module.exports = function(environment) {
     }
   };
 
+  ENV.contentSecurityPolicy = {
+    'script-src': "'self' 'unsafe-inline' 'unsafe-eval'",
+    'connect-src': "'self'",
+    'frame-src': "'self'",
+    'style-src': "'self' 'unsafe-inline'",
+    'img-src': "'self'",
+  };
+
   if (environment === 'test') {
     // Testem prefers this...
     ENV.baseURL = '/';

--- a/config/environment.js
+++ b/config/environment.js
@@ -24,7 +24,7 @@ module.exports = function(environment) {
     'connect-src': "'self'",
     'frame-src': "'self'",
     'style-src': "'self' 'unsafe-inline'",
-    'img-src': "'self'",
+    'img-src': "'self' data:"
   };
 
   if (environment === 'test') {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "express": "^4.8.5",
     "glob": "^7.0.0",
     "hospitalrun-dblisteners": "0.9.1",
-    "hospitalrun-server-routes": "0.9.1",
+    "hospitalrun-server-routes": "0.9.2",
     "loader.js": "^4.0.0",
     "nano": "6.2.0",
     "request": "2.69.0"

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "ember-cli-active-link-wrapper": "0.0.4",
     "ember-cli-app-version": "^1.0.0",
     "ember-cli-babel": "^5.1.5",
+    "ember-cli-content-security-policy": "0.5.0",
     "ember-cli-dependency-checker": "^1.2.0",
     "ember-cli-deprecation-workflow": "0.2.0",
     "ember-cli-fake-server": "0.3.0",


### PR DESCRIPTION
PR for #285

This adds the CSP without errors while working locally.