### PR TITLE
Adding 'missed appointments' tab

### DIFF
--- a/app/appointments/item/template.hbs
+++ b/app/appointments/item/template.hbs
@@ -6,7 +6,7 @@
     <td>{{appointment.appointmentType}}</td>
     <td>{{appointment.location}}</td>
     <td>{{appointment.provider}}</td>
-    <td>{{appointment.displayStatus}}</td>
+    <td class="appointment-status">{{appointment.displayStatus}}</td>
     <td>
         {{#if canAddVisit}}
             <button class="btn btn-default" {{action 'createVisit' appointment bubbles=false }}>{{t 'buttons.add_visit'}}</button>

--- a/app/appointments/missed/controller.js
+++ b/app/appointments/missed/controller.js
@@ -1,0 +1,4 @@
+import AppointmentIndexController from 'hospitalrun/appointments/index/controller';
+export default AppointmentIndexController.extend({
+  startKey: []
+});

--- a/app/appointments/missed/route.js
+++ b/app/appointments/missed/route.js
@@ -1,0 +1,17 @@
+import AppointmentIndexRoute from 'hospitalrun/appointments/index/route';
+import { translationMacro as t } from 'ember-i18n';
+
+export default AppointmentIndexRoute.extend({
+  editReturn: 'appointments.missed',
+  modelName: 'appointment',
+  pageTitle: t('appointments.missed'),
+
+  _modelQueryParams() {
+    let queryParams = this._super(...arguments);
+    queryParams.filterBy = [{
+      name: 'status',
+      value: 'Missed'
+    }];
+    return queryParams;
+  }
+});

--- a/app/appointments/missed/template.hbs
+++ b/app/appointments/missed/template.hbs
@@ -1,0 +1,1 @@
+{{partial 'appointments/index'}}

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -580,6 +580,7 @@ export default {
     new_title: 'New Appointment',
     section_title: 'Appointments',
     this_week: 'Appointments This Week',
+    missed: 'Missed Appointments',
     search_title: 'Search Appointments',
     today_title: 'Today\'s Appointments',
     messages: {

--- a/app/mixins/appointment-statuses.js
+++ b/app/mixins/appointment-statuses.js
@@ -3,7 +3,8 @@ import SelectValues from 'hospitalrun/utils/select-values';
 export default Ember.Mixin.create({
   appointmentStatusList: [
     'Scheduled',
-    'Canceled'
+    'Canceled',
+    'Missed'
   ],
   appointmentStatuses: Ember.computed.map('appointmentStatusList', SelectValues.selectValuesMap),
 

--- a/app/mixins/navigation.js
+++ b/app/mixins/navigation.js
@@ -89,6 +89,12 @@ export default Ember.Mixin.create({
           capability: 'appointments'
         },
         {
+          title: 'Missed',
+          iconClass: 'octicon-chevron-right',
+          route: 'appointments.missed',
+          capability: 'appointments'
+        },
+        {
           title: 'Search',
           iconClass: 'octicon-search',
           route: 'appointments.search',

--- a/app/models/appointment.js
+++ b/app/models/appointment.js
@@ -8,6 +8,7 @@ export default AbstractModel.extend({
   patient: DS.belongsTo('patient', {
     async: false
   }),
+  visits: DS.hasMany('visit'),
   provider: DS.attr('string'),
   location: DS.attr('string'),
   appointmentType: DS.attr('string'),

--- a/app/router.js
+++ b/app/router.js
@@ -27,6 +27,7 @@ Router.map(function() {
     this.route('edit', { path: '/edit/:appointment_id' });
     this.route('search');
     this.route('today');
+    this.route('missed');
   });
 
   this.route('finishgauth', { path: '/finishgauth/:s1/:s2/:k/:t/:i/:p' });

--- a/tests/acceptance/appointments-test.js
+++ b/tests/acceptance/appointments-test.js
@@ -24,6 +24,23 @@ test('visiting /appointments', function(assert) {
   });
 });
 
+test('visiting /appointments/missed', function(assert) {
+  runWithPouchDump('appointments', function() {
+    authenticateUser();
+    let url = '/appointments';
+    // create an apointmet scheduled in the past
+    let today = moment();
+    let tomorrow = moment().add(1, 'days');
+    let status = 'Missed';
+    createAppointment(today, tomorrow, status);
+    visit(url);
+    andThen(function() {
+      assert.equal(currentURL(), url);
+      findWithAssert(`.appointment-status:contains(${status})`);
+    });
+  });
+});
+
 test('Creating a new appointment', function(assert) {
   runWithPouchDump('appointments', function() {
     authenticateUser();
@@ -35,20 +52,7 @@ test('Creating a new appointment', function(assert) {
       findWithAssert('button:contains(Add)');
     });
 
-    fillIn('.test-patient-input .tt-input', 'Lennex Zinyando - P00017');
-    triggerEvent('.test-patient-input .tt-input', 'input');
-    triggerEvent('.test-patient-input .tt-input', 'blur');
-    select('.test-appointment-type', 'Followup');
-    waitToAppear('.test-appointment-date input');
-    andThen(function() {
-      selectDate('.test-appointment-date input', new Date());
-    });
-    fillIn('.test-appointment-location .tt-input', 'Harare');
-    triggerEvent('.test-appointment-location .tt-input', 'input');
-    triggerEvent('.test-appointment-location .tt-input', 'blur');
-    fillIn('.test-appointment-with', 'Dr Test');
-    click('button:contains(Add)');
-    waitToAppear('.table-header');
+    createAppointment();
 
     andThen(() => {
       assert.equal(currentURL(), '/appointments');
@@ -133,18 +137,19 @@ test('Delete an appointment', function(assert) {
   });
 });
 
-function createAppointment() {
+function createAppointment(startDate=(new Date()), endDate=(moment().add(1, 'day').toDate()), status='Scheduled') {
   visit('/appointments/edit/new');
   fillIn('.test-patient-input .tt-input', 'Lennex Zinyando - P00017');
   triggerEvent('.test-patient-input .tt-input', 'input');
   triggerEvent('.test-patient-input .tt-input', 'blur');
   select('.test-appointment-type', 'Admission');
+  select('.test-appointment-status', status);
   waitToAppear('.test-appointment-start input');
   andThen(function() {
-    selectDate('.test-appointment-start input', new Date());
+    selectDate('.test-appointment-start input', startDate);
   });
   andThen(function() {
-    selectDate('.test-appointment-end input', moment().add(1, 'day').toDate());
+    selectDate('.test-appointment-end input', endDate);
   });
   fillIn('.test-appointment-location .tt-input', 'Harare');
   triggerEvent('.test-appointment-location .tt-input', 'input');

--- a/tests/unit/appointments/missed/route-test.js
+++ b/tests/unit/appointments/missed/route-test.js
@@ -1,0 +1,11 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('route:appointments/missed', 'Unit | Route | appointments/missed', {
+  // Specify the other units that are required for this test.
+  // needs: ['controller:foo']
+});
+
+test('it exists', function(assert) {
+  let route = this.subject();
+  assert.ok(route);
+});


### PR DESCRIPTION
Fixes #351 .

I didn't realize the other appointment routes already filter to the latest, so 'missed' doesn't require any filters.

I added a test, and modified the `createAppointment` helper function to accept params.



-

cc @HospitalRun/core-maintainers

