### PR TITLE
Enabled patient search by phone number

### DIFF
--- a/app/patients/search/route.js
+++ b/app/patients/search/route.js
@@ -6,7 +6,8 @@ export default AbstractSearchRoute.extend({
     'friendlyId',
     'externalPatientId',
     'firstName',
-    'lastName'
+    'lastName',
+    'phone'
   ],
   searchIndex: PatientSearch,
   searchModel: 'patient'


### PR DESCRIPTION
Fixes # .

**Changes proposed in this pull request:**

- Enabled patient search through their phone number.

Currently patient can only be searched with their id, firstname and lastname

cc @HospitalRun/core-maintainers

