### PR TITLE
Switch labels in user admin page

### DIFF
--- a/app/users/index/template.hbs
+++ b/app/users/index/template.hbs
@@ -13,8 +13,8 @@
       {{#each model as |user|}}
         {{#unless user.deleted}}
           <tr {{action 'editItem' user}} class="clickable">
-            <td class="user-display-name">{{user.displayName}}</td>
             <td class="user-name">{{user.name}}</td>
+            <td class="user-display-name">{{user.displayName}}</td>
             <td class="user-email">{{user.email}}</td>
             <td class="user-role">{{user.displayRole}}</td>
             {{#if showActions}}


### PR DESCRIPTION
Fixes #415 .

**Changes proposed in this pull request:**
- Switch table data displayName and name from Users in User's admin page

Old:

![image](https://cloud.githubusercontent.com/assets/2495160/14620193/15b18da6-0581-11e6-9e12-b72c8c98a1e4.png)

New:

![screenshot from 2016-04-18 16-21-29](https://cloud.githubusercontent.com/assets/2495160/14620329/a0cec5ca-0581-11e6-9ff7-95f558515f35.png)

cc @HospitalRun/core-maintainers
