### PR TITLE
Nitrous.io Quickstart button

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,15 @@ To install the frontend please do the following:
         2. If you already have a CouchDB admin user, please run `./script/initcouch.sh USER PASS` in the folder you cloned the HospitalRun repo.  `USER` and `PASS` are the CouchDB admin user credentials.
 8. Copy the `server/config-example.js` to `server/config.js` in the folder you cloned the HospitalRun repo.
 
+### Nitrous Quickstart
+Create a free development environment for this HospitalRun project in the cloud on [Nitrous.io](https://www.nitrous.io) by clicking the button below.
+
+<a href="https://www.nitrous.io/quickstart">
+  <img src="https://nitrous-image-icons.s3.amazonaws.com/quickstart.png" alt="Nitrous Quickstart" width=142 height=34>
+</a>
+
+In the IDE, start HospitalRun via `Run > Start HospitalRun` and access your site via `Preview > 4200`.
+
 ### Experimental
 If you are willing to try using `make`, ensure you have installed git, node and couchdb (steps 1, 2 and 6 above), you may skip the rest.  This requires couchdb in the path to work correctly.
 * Run `make serve`, it will start couchdb, install npm dependencies and start the server.

--- a/README.nitrous.md
+++ b/README.nitrous.md
@@ -1,0 +1,13 @@
+# Setup
+
+Welcome to your HospitalRun project on Nitrous.
+
+## Running the HospitalRun server:
+
+In the [Nitrous IDE](https://community.nitrous.io/docs/ide-overview), start HospitalRun via "Run > Start HospitalRun"
+
+Now you've got a development server running and can see the output in the Nitrous terminal window. You can open up a new shell or utilize [tmux](https://community.nitrous.io/docs/tmux) to open new shells to run other commands.
+
+## Preview the app
+
+In the Nitrous IDE, open the "Preview" menu and click "Port 4200".

--- a/nitrous.json
+++ b/nitrous.json
@@ -1,0 +1,10 @@
+{
+  "template": "ruby",
+  "ports": [4200],
+  "name": "HospitalRun",
+  "description": "Ember front end for HospitalRun",
+  "scripts": {
+    "post-create": "sudo apt-get install -y couchdb && echo 'running npm install - this might take awhile...' && npm install -g ember-cli@latest && npm install -g bower && bower install && script/bootstrap && ./script/initcouch.sh && cp server/config-example.js server/config.js",
+    "Start HospitalRun": "cd ~/code/hospitalrun-frontend && npm start"
+  }
+}


### PR DESCRIPTION
**Changes proposed in this pull request:**
- Add Nitrous Quickstart button

Added Nitrous Quickstart files so anyone can quickly spin up a free, cloud dev environment to start using this repo. Clicking the Quickstart button will automatically clone this repo and will install and configure any required packages.

cc @HospitalRun/core-maintainers

