### PR TITLE
Add `Requested By` to Imaging

### DIFF
--- a/app/imaging/completed/completed-list-item/component.js
+++ b/app/imaging/completed/completed-list-item/component.js
@@ -1,0 +1,5 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  tagName: 'tr'
+});

--- a/app/imaging/completed/completed-list-item/template.hbs
+++ b/app/imaging/completed/completed-list-item/template.hbs
@@ -1,0 +1,7 @@
+<td>{{date-format imaging.requestedDate}}</td>
+<td>{{date-format imaging.imagingDate}}</td>
+<td>{{imaging.requestedBy}}</td>
+<td>{{imaging.patient.displayName}}</td>
+<td>{{imaging.imagingType.name}}</td>
+<td>{{imaging.results}}</td>
+<td>{{imaging.notes}}</td>

--- a/app/imaging/completed/completed-list-item/template.hbs
+++ b/app/imaging/completed/completed-list-item/template.hbs
@@ -1,7 +1,7 @@
-<td>{{date-format imaging.requestedDate}}</td>
-<td>{{date-format imaging.imagingDate}}</td>
-<td>{{imaging.requestedBy}}</td>
-<td>{{imaging.patient.displayName}}</td>
-<td>{{imaging.imagingType.name}}</td>
-<td>{{imaging.results}}</td>
-<td>{{imaging.notes}}</td>
+<td class="requested-date">{{date-format imaging.requestedDate}}</td>
+<td class="imaging-date">{{date-format imaging.imagingDate}}</td>
+<td class="requested-by">{{imaging.requestedBy}}</td>
+<td class="display-name">{{imaging.patient.displayName}}</td>
+<td class="type">{{imaging.imagingType.name}}</td>
+<td class="results">{{imaging.result}}</td>
+<td class="notes">{{imaging.notes}}</td>

--- a/app/imaging/completed/template.hbs
+++ b/app/imaging/completed/template.hbs
@@ -1,4 +1,4 @@
-{{#item-listing paginationProps=paginationProps }}
+{{#item-listing paginationProps=paginationProps}}
   {{#if model}}
     <table class="table">
       <tr class="table-header">
@@ -11,20 +11,12 @@
           <th>{{t 'labels.notes'}}</th>
       </tr>
       {{#each model as |imaging|}}
-        <tr>
-          <td>{{date-format imaging.requestedDate}}</td>
-          <td>{{date-format imaging.imagingDate}}</td>
-          <td>{{imaging.requestedBy}}</td>
-          <td>{{imaging.patient.displayName}}</td>
-          <td>{{imaging.imagingType.name}}</td>
-          <td>{{imaging.result}}</td>
-          <td>{{imaging.notes}}</td>
-        </tr>
+        {{imaging/completed/completed-list-item imaging=imaging}}
       {{/each}}
     </table>
   {{else}}
-      <div class="alert alert-info">
-          <p>{{t 'imaging.messages.no_completed'}}</p>
-      </div>
+    <div class="alert alert-info">
+      <p>{{t 'imaging.messages.no_completed'}}</p>
+    </div>
   {{/if}}
 {{/item-listing}}

--- a/app/imaging/completed/template.hbs
+++ b/app/imaging/completed/template.hbs
@@ -4,6 +4,7 @@
       <tr class="table-header">
           <th>{{t 'labels.date_requested'}}</th>
           <th>{{t 'labels.date_completed'}}</th>
+          <th>{{t 'labels.requested_by'}}</th>
           <th>{{t 'labels.patient'}}</th>
           <th>{{t 'labels.imaging_type'}}</th>
           <th>{{t 'labels.results'}}</th>
@@ -13,6 +14,7 @@
         <tr>
           <td>{{date-format imaging.requestedDate}}</td>
           <td>{{date-format imaging.imagingDate}}</td>
+          <td>{{imaging.requestedBy}}</td>
           <td>{{imaging.patient.displayName}}</td>
           <td>{{imaging.imagingType.name}}</td>
           <td>{{imaging.result}}</td>

--- a/app/imaging/completed/template.hbs
+++ b/app/imaging/completed/template.hbs
@@ -1,6 +1,6 @@
 {{#item-listing paginationProps=paginationProps}}
   {{#if model}}
-    <table class="table">
+    <table class="table imaging-completed-table">
       <tr class="table-header">
           <th>{{t 'labels.date_requested'}}</th>
           <th>{{t 'labels.date_completed'}}</th>

--- a/app/imaging/edit/template.hbs
+++ b/app/imaging/edit/template.hbs
@@ -35,6 +35,12 @@
           <p class="form-control-static">{{model.imagingType.name}}</p>
         </div>
       </div>
+      <div class="row">
+        <div class="form-group col-xs-12">
+          <label>{{t 'labels.requested_by'}}</label>
+          <p class="form-control-static">{{model.requestedBy}}</p>
+        </div>
+      </div>
     {{/if}}
     {{#if canComplete}}
       {{select-or-typeahead property="radiologist"

--- a/app/imaging/index/imaging-edit-button/component.js
+++ b/app/imaging/index/imaging-edit-button/component.js
@@ -1,0 +1,6 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  tagName: 'button',
+  classNames: ['btn', 'btn-default', 'neutral']
+});

--- a/app/imaging/index/imaging-edit-button/template.hbs
+++ b/app/imaging/index/imaging-edit-button/template.hbs
@@ -1,0 +1,1 @@
+{{#link-to 'imaging.edit' imaging}}{{t 'labels.edit'}}{{/link-to}}

--- a/app/imaging/index/requested-list-item/component.js
+++ b/app/imaging/index/requested-list-item/component.js
@@ -1,0 +1,10 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  tagName: 'tr',
+  classNames: ['clickable'],
+
+  click() {
+    this.sendAction('action', this.imaging);
+  }
+});

--- a/app/imaging/index/requested-list-item/template.hbs
+++ b/app/imaging/index/requested-list-item/template.hbs
@@ -1,8 +1,8 @@
-<td>{{date-format imaging.requestedDate}}</td>
-<td>{{imaging.requestedBy}}</td>
-<td>{{imaging.patient.displayName}}</td>
-<td>{{imaging.imagingType.name}}</td>
-<td>{{imaging.notes}}</td>
+<td class="date">{{date-format imaging.requestedDate}}</td>
+<td class="requested-by">{{imaging.requestedBy}}</td>
+<td class="patient">{{imaging.patient.displayName}}</td>
+<td class="type">{{imaging.imagingType.name}}</td>
+<td class="notes">{{imaging.notes}}</td>
 
 {{#if showActions}}
   <td>

--- a/app/imaging/index/requested-list-item/template.hbs
+++ b/app/imaging/index/requested-list-item/template.hbs
@@ -1,0 +1,13 @@
+<td>{{date-format imaging.requestedDate}}</td>
+<td>{{imaging.requestedBy}}</td>
+<td>{{imaging.patient.displayName}}</td>
+<td>{{imaging.imagingType.name}}</td>
+<td>{{imaging.notes}}</td>
+
+{{#if showActions}}
+  <td>
+    {{#if canEdit}}
+      {{imaging/index/imaging-edit-button imaging=imaging}}
+    {{/if}}
+  </td>
+{{/if}}

--- a/app/imaging/index/template.hbs
+++ b/app/imaging/index/template.hbs
@@ -12,20 +12,11 @@
         {{/if}}
       </tr>
       {{#each model as |imaging|}}
-        <tr {{action 'editItem' imaging }} class="clickable">
-          <td>{{date-format imaging.requestedDate}}</td>
-          <td>{{imaging.requestedBy}}</td>
-          <td>{{imaging.patient.displayName}}</td>
-          <td>{{imaging.imagingType.name}}</td>
-          <td>{{imaging.notes}}</td>
-          {{#if showActions}}
-            <td>
-              {{#if canEdit}}
-                <button class="btn btn-default neutral" {{action 'editItem' imaging  bubbles=false }}>{{t 'labels.edit'}}</button>
-              {{/if}}
-            </td>
-          {{/if}}
-        </tr>
+        {{imaging/index/requested-list-item
+          imaging=imaging
+          action="editItem"
+          showActions=showActions
+          canEdit=canEdit}}
       {{/each}}
     </table>
   {{else}}

--- a/app/imaging/index/template.hbs
+++ b/app/imaging/index/template.hbs
@@ -3,6 +3,7 @@
     <table class="table">
       <tr class="table-header">
         <th>{{t 'labels.date_requested'}}</th>
+        <th>{{t 'labels.requested_by'}}</th>
         <th>{{t 'labels.patient'}}</th>
         <th>{{t 'labels.imaging_type'}}</th>
         <th>{{t 'labels.notes'}}</th>
@@ -13,6 +14,7 @@
       {{#each model as |imaging|}}
         <tr {{action 'editItem' imaging }} class="clickable">
           <td>{{date-format imaging.requestedDate}}</td>
+          <td>{{imaging.requestedBy}}</td>
           <td>{{imaging.patient.displayName}}</td>
           <td>{{imaging.imagingType.name}}</td>
           <td>{{imaging.notes}}</td>

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -18,6 +18,7 @@
 @import 'components/tab_content';
 @import 'components/patient_summary';
 @import 'components/patient_history';
+@import 'components/imaging';
 
 // NOTE: do not place styles in this file
 // If you have styles to add, put them in

--- a/app/styles/components/_imaging.scss
+++ b/app/styles/components/_imaging.scss
@@ -1,0 +1,1 @@
+.notes { max-width: 300px; }


### PR DESCRIPTION
Fixes #362.

**Changes proposed in this pull request:**
- Adds `Requested By` to Imaging **Requests** and **Completed** lists
- Refactors Imaging to use [components in blocks](https://github.com/DockYard/styleguides/blob/master/engineering/ember.md#use-components-in-each-blocks)
- Adds `Add Note` link to the **Requests** list items that don't have notes
- Adds `No Notes` and `No Results` to **Completed** list items that don't have either Notes or Results

---

`Add Notes` link:
![link](https://cloud.githubusercontent.com/assets/3615754/14840677/0b17e742-0bfc-11e6-9f9d-b70991b401b5.png)

`No Notes` and `No Results`
![light](https://cloud.githubusercontent.com/assets/3615754/14840777/fefd7a3e-0bfc-11e6-8378-ee9f921d8877.png)
cc @HospitalRun/core-maintainers
