### PR TITLE
Add missing space to script/bootstrap

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -14,7 +14,7 @@ if [ -f "package.json" ]; then
   npm install -g phantomjs-prebuilt
 fi
 
-if [ -f "bower.json"]; then
+if [ -f "bower.json" ]; then
   echo "==> Installing bower components…"
   bower install
 fi


### PR DESCRIPTION
**Changes proposed in this pull request:**
- Add space to bootstrap script to prevent bower setup from being skipped

cc @HospitalRun/core-maintainers

