### PR TITLE
Pagination button tweaks

### DIFF
--- a/app/components/nav-paging.js
+++ b/app/components/nav-paging.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 import PagingActions from 'hospitalrun/mixins/paging-actions';
 export default Ember.Component.extend(PagingActions, {
-  classNames: ['btn-group', 'pull-right'],
+  classNames: ['paging-buttons'],
   paginationProps: null
 });

--- a/app/styles/_layout.scss
+++ b/app/styles/_layout.scss
@@ -5,6 +5,19 @@
 
 .view-current-title { @include view_main_heading; }
 
+// panel styles
+
+.panel-primary {
+  position: relative;
+  border: 0;
+  background-color: $white;
+  color: $navy_mid2;
+
+  input,
+  textarea,
+  select { background: rgba($blue_light,.2); }
+}
+
 // ? unsure what below are for...
 
 .detail-section-content {

--- a/app/styles/_temp_misc.scss
+++ b/app/styles/_temp_misc.scss
@@ -60,16 +60,6 @@
   label { font-weight: 300; }
 }
 
-.panel-primary {
-  border: 0;
-  background-color: $white;
-  color: $navy_mid2;
-
-  input,
-  textarea,
-  select { background: rgba($blue_light,.2); }
-}
-
 .modal-dialog { color: $navy; }
 
 .not-editable {

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -16,6 +16,7 @@
 @import 'components/form_styles';
 @import 'components/tab_nav';
 @import 'components/tab_content';
+@import 'components/pagination';
 @import 'components/patient_summary';
 @import 'components/patient_history';
 @import 'components/imaging';

--- a/app/styles/components/_pagination.scss
+++ b/app/styles/components/_pagination.scss
@@ -1,0 +1,9 @@
+// styles for pagination
+//
+// visible on patient listing and any other
+// view with pagination
+.paging-buttons {
+  position: absolute;
+  top: 3px;
+  right: 3px;
+}


### PR DESCRIPTION
**Changes proposed in this pull request:**
- created a component stylesheet for pagination
- fixed the positioning of the pagination buttons

**Before:**

<img width="1001" alt="screenshot 2016-06-01 07 44 59" src="https://cloud.githubusercontent.com/assets/1319791/15708499/c7b9d2d4-27cc-11e6-9c1c-bb45de616083.png">

**After:**

<img width="999" alt="screenshot 2016-06-01 07 41 48" src="https://cloud.githubusercontent.com/assets/1319791/15708394/5b0dedbe-27cc-11e6-852a-d7ed94103879.png">

Note: pagination button styles and markup still need improved, but going to address in another PR because it involves refactoring, and more thought around button strategy in general (related to #359).

Also, addresses #134.
