### PR TITLE
Test for missing translations

### DIFF
--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -35,6 +35,8 @@ export default {
       load_db: 'Load DB',
       users: 'Users',
       new_user: 'New User',
+      admitted_patients: 'Admitted Patients',
+      missed: 'Missed',
       user_roles: 'User Roles'
     },
     actions: {

--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -8,6 +8,19 @@ import './select';
 import './select-date';
 import './wait-to-appear';
 
+function createTranslationWrapper(original, context) {
+  function t(str, data) {
+    let result = original.call(context, str, data);
+    if (result.indexOf && result.indexOf('Missing translation') > -1) {
+      throw new Error(result);
+    }
+
+    return result.string || result;
+  }
+
+  return t;
+}
+
 export default function startApp(attrs) {
   let application;
 
@@ -19,6 +32,9 @@ export default function startApp(attrs) {
     application.setupForTesting();
     application.injectTestHelpers();
   });
+
+  let translationService = application.__container__.lookup('service:i18n');
+  application.__container__.lookup('service:i18n').t = createTranslationWrapper(translationService.t, translationService);
 
   return application;
 }


### PR DESCRIPTION
Stubs the translation function that do the translation and
throw an error if it is missing

uses deprecated api, happy to change but atleast it is only one
instance

All Feature tests must run startApp in the before each hook

cc @HospitalRun/core-maintainers