### PR TITLE
Fixes Issue 467

### DIFF
--- a/app/invoices/payment/controller.js
+++ b/app/invoices/payment/controller.js
@@ -3,10 +3,22 @@ import Ember from 'ember';
 import PatientSubmodule from 'hospitalrun/mixins/patient-submodule';
 
 export default AbstractEditController.extend(PatientSubmodule, {
+  closeModalAction: 'cleanup',
   cancelAction: 'closeModal',
   findPatientVisits: false,
   invoiceController: Ember.inject.controller('invoices'),
   newPayment: false,
+
+  actions: {
+    cleanup: function() {
+      var model = this.model;
+      this.model.validate().then(function() {
+        model.save();
+      }).catch(function() {
+        model.destroyRecord();
+      });
+    }
+  },
 
   expenseAccountList: Ember.computed.alias('invoiceController.expenseAccountList'),
   patientList: Ember.computed.alias('invoiceController.patientList'),

--- a/app/invoices/payment/template.hbs
+++ b/app/invoices/payment/template.hbs
@@ -1,4 +1,5 @@
 {{#modal-dialog
+    closeModalAction=closeModalAction
     isUpdateDisabled=isUpdateDisabled
     title=title
     updateButtonAction=updateButtonAction


### PR DESCRIPTION
Fixes #467 

**Problem Summary**
- A `payment` model is created when hitting the `Add Payment` button on invoices. 
- This model is invalid, but it's creation sets the `paidTotal` to 0. 
- This set's `status` to 'Paid' for invoices requiring 0 payment.

**Fix Summary**
- request adds additional logic to where the `status` field is set
  - keeps track of last unpaid status if it needs to return to it
    (e.g. return to either Bill or Draft)
- fixes missing checks for invalid payments when calculating remaining
  balance
- implements cleanup function to destroy payment model placeholder
  upon modal exit with invalid model state.
