### PR TITLE
remove <strong> from delete message

### DIFF
--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -735,7 +735,7 @@ export default {
   billing: {
     alerts: {
       no_invoice_found: 'No invoices found',
-      delete_item: 'Are you sure you wish to delete <strong>{{item}}</strong>?',
+      delete_item: 'Are you sure you wish to delete {{item}}?',
       no_pricing_items: 'No pricing items found.',
       no_pricing_profiles: 'No pricing profiles found.'
     },

--- a/tests/acceptance/invoices-test.js
+++ b/tests/acceptance/invoices-test.js
@@ -61,7 +61,7 @@ test('delete invoice', function(assert) {
       waitToAppear('.modal-dialog');
     });
     andThen(() => {
-      assert.equal(find('.alert').text().trim(), 'Are you sure you wish to delete <strong>inv00001</strong>?', 'Invoice deletion confirm displays');
+      assert.equal(find('.alert').text().trim(), 'Are you sure you wish to delete inv00001?', 'Invoice deletion confirm displays');
     });
     click('button:contains(Delete):last');
     waitToDisappear('.invoice-number:contains(inv00001)');

--- a/tests/acceptance/pricing-test.js
+++ b/tests/acceptance/pricing-test.js
@@ -136,7 +136,7 @@ test('delete price', function(assert) {
     });
     waitToAppear('.modal-dialog');
     andThen(() => {
-      assert.equal(find('.alert').text().trim(), 'Are you sure you wish to delete <strong>Blood test</strong>?', 'Pricing item is displayed for deletion');
+      assert.equal(find('.alert').text().trim(), 'Are you sure you wish to delete Blood test?', 'Pricing item is displayed for deletion');
     });
     click('button:contains(Delete):last');
     waitToDisappear('.price-name:contains(Blood test)');


### PR DESCRIPTION
I previously let `<strong>` tag in delete message through to master. after reading all delete strings this does not seem to be the standard so i removed the tags. 

cc @HospitalRun/core-maintainers

