### PR TITLE
Move dependencies to dev dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,14 +72,12 @@
     "request": "2.72.0",
     "ember-cli-stylelint": "^0.1.5",
     "stylelint": "^6.6.0",
+    "ember-radio-buttons": "^4.0.1",
+    "ember-inflector": "^1.9.4",
     "stylelint-config-concentric": "^1.0.2",
     "stylelint-declaration-use-variable": "^1.3.0",
     "stylelint-scss": "^1.2.0",
     "stylelint-value-border-zero": "^1.0.2"
-  },
-  "dependencies": {
-    "ember-inflector": "^1.9.4",
-    "ember-radio-buttons": "^4.0.1"
   },
   "ember-addon": {
     "paths": [

--- a/package.json
+++ b/package.json
@@ -70,16 +70,16 @@
     "loader.js": "4.0.10",
     "nano": "6.2.0",
     "request": "2.72.0",
+    "ember-cli-stylelint": "^0.1.5",
+    "stylelint": "^6.6.0",
     "stylelint-config-concentric": "^1.0.2",
     "stylelint-declaration-use-variable": "^1.3.0",
     "stylelint-scss": "^1.2.0",
     "stylelint-value-border-zero": "^1.0.2"
   },
   "dependencies": {
-    "ember-cli-stylelint": "^0.1.5",
     "ember-inflector": "^1.9.4",
-    "ember-radio-buttons": "^4.0.1",
-    "stylelint": "^6.6.0"
+    "ember-radio-buttons": "^4.0.1"
   },
   "ember-addon": {
     "paths": [


### PR DESCRIPTION
no need for this to be a production dependency.

@jkleinsc unless you moved them on purpose so that we know about the regex dos

cc @HospitalRun/core-maintainers

