### PR TITLE
Dockerizing hospitalrun-frontend

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM node:argon
+
+RUN npm install -g ember-cli
+RUN npm install -g bower
+RUN npm install -g phantomjs
+
+RUN git clone https://github.com/facebook/watchman.git && cd watchman && git checkout v3.5.0 && ./autogen.sh && ./configure && make && make install
+
+WORKDIR /hospitalrun-frontend
+
+COPY package.json /hospitalrun-frontend
+RUN npm install
+COPY bower.json /hospitalrun-frontend
+RUN echo '{ "allow_root": true }' > /root/.bowerrc
+RUN bower install
+
+ADD . /hospitalrun-frontend
+
+RUN cp server/config-example.js server/config.js
+
+CMD ./script/initcouch.sh && ember serve

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '2'
+services:
+  web:
+    build: .
+    ports:
+     - 4200:4200
+    links:
+      - couchdb
+    depends_on:
+     - couchdb
+    command: ./script/initcouch.sh && ember serve
+  couchdb:
+    image: klaemo/couchdb:latest
+    ports:
+      - 5984:5984


### PR DESCRIPTION
Dockerizing hospitalrun-frontend


**Changes proposed in this pull request:**
- Added a Dockerfile file
- Added a docker-compose.yml file
- [etc]

*Note: Currently, this works when we build the image from the Dockerfile and used separately with the klaemo/couchdb docker image. But when using the docker-compose, the linking of the two containers does not work. We get this error: Empty error from server. 
Will keep on working on it. Hoping that someone else can also have a look
.

cc @HospitalRun/core-maintainers

