### PR TITLE
#526: Use add_procedure for procedure edit updateCapability

### DIFF
--- a/app/procedures/edit/controller.js
+++ b/app/procedures/edit/controller.js
@@ -63,7 +63,7 @@ export default AbstractEditController.extend(ChargeActions, PatientSubmodule, {
     return this.get('i18n').t('procedures.titles.edit');
   }.property('model.isNew'),
 
-  updateCapability: 'add_charge',
+  updateCapability: 'add_procedure',
 
   actions: {
     showAddMedication: function() {


### PR DESCRIPTION
Fixes #526 .

**Changes proposed in this pull request:**
- The add button was hidden on this screen because the updateCapability was 'add_charge" in the procedures edit controller. I changed it to 'add_procedure' - this matches other controllers that appear in the visit (add_medication is used for the medications edit controller, for example).

cc @HospitalRun/core-maintainers

