### PR TITLE
Typeahead now displays more options 

### DIFF
--- a/app/components/type-ahead.js
+++ b/app/components/type-ahead.js
@@ -45,6 +45,7 @@ export default InputComponent.extend({
   hint: true,
   highlight: true,
   lastHint: null,
+  limit:10,
   minlength: 1,
   selectedItem: false,
   inputElement: null,
@@ -56,7 +57,7 @@ export default InputComponent.extend({
     var typeAheadBloodhound = new Bloodhound({
       datumTokenizer: Bloodhound.tokenizers.obj.whitespace(this.get('displayKey')),
       queryTokenizer: Bloodhound.tokenizers.whitespace,
-      local: this.get('mappedContent')
+      local: this.get('mappedContent')      
     });
     typeAheadBloodhound.initialize();
     this.set('bloodhound', typeAheadBloodhound);
@@ -73,6 +74,7 @@ export default InputComponent.extend({
       minLength: this.get('minlength')
     }, {
       displayKey: this.get('displayKey'),
+      limit:this.get('limit'),
       source: this._getSource(),
       templates: this.get('templates')
     });

--- a/app/styles/_temp_misc.scss
+++ b/app/styles/_temp_misc.scss
@@ -21,6 +21,9 @@ $table-header-color: rgba($navy_drk2,.7);
   padding: 5px 0;
   width: 100%;
   min-width: 160px;
+  max-height: 100px;
+  overflow-y: scroll;
+  overflow-x: hidden; 
 
   .query-results { margin-bottom: 0; }
 }


### PR DESCRIPTION
Fixes #519

**Changes proposed in this pull request:**

- Typeahead now displays 10 options instead of 5 by adding a limit to typeahead.js
- The typeahead has a max height of 100px to avoid taking up to much space and has a vertical scrollbar

# Example
![typeahead](https://cloud.githubusercontent.com/assets/15896226/16880031/25e1c65e-4aab-11e6-8d49-e7012d244775.png)

cc @HospitalRun/core-maintainers

