### PR TITLE
Added scrollbar and more options in typeahead

### DIFF
--- a/app/components/type-ahead.js
+++ b/app/components/type-ahead.js
@@ -45,6 +45,7 @@ export default InputComponent.extend({
   hint: true,
   highlight: true,
   lastHint: null,
+  limit: 10,
   minlength: 1,
   selectedItem: false,
   inputElement: null,
@@ -73,6 +74,7 @@ export default InputComponent.extend({
       minLength: this.get('minlength')
     }, {
       displayKey: this.get('displayKey'),
+      limit: this.get('limit'),
       source: this._getSource(),
       templates: this.get('templates')
     });

--- a/app/components/type-ahead.js
+++ b/app/components/type-ahead.js
@@ -45,7 +45,7 @@ export default InputComponent.extend({
   hint: true,
   highlight: true,
   lastHint: null,
-  limit: 10,
+  limit: 500,
   minlength: 1,
   selectedItem: false,
   inputElement: null,

--- a/app/styles/_temp_misc.scss
+++ b/app/styles/_temp_misc.scss
@@ -21,6 +21,9 @@ $table-header-color: rgba($navy_drk2,.7);
   padding: 5px 0;
   width: 100%;
   min-width: 160px;
+  max-height: 110px;
+  overflow-y: scroll;
+  overflow-x: none;
 
   .query-results { margin-bottom: 0; }
 }


### PR DESCRIPTION
Fixes #519 Medication/inventory typeahead issues 

**Changes proposed in this pull request:**
- Typeahead now displays a maximum  of 10 options by adding limit in typeahead.js. Adding more than 10 appears to make the acceptance tests timeout
- Typeahead now has a maximum height of 110px and displays a vertical scrollbar 

# Example
![typeahead 2](https://cloud.githubusercontent.com/assets/15896226/16885120/f3bd0aca-4ac4-11e6-97d7-a1c03468c251.png)


cc @HospitalRun/core-maintainers

