### PR TITLE
Issue 627: Fix visit types list not refreshing.

### DIFF
--- a/app/appointments/edit/controller.js
+++ b/app/appointments/edit/controller.js
@@ -57,7 +57,7 @@ export default AbstractEditController.extend(AppointmentStatuses, PatientSubmodu
         isAdmissionAppointment = this.get('isAdmissionAppointment');
     return (!allDay && isAdmissionAppointment);
   }.property('model.allDay', 'isAdmissionAppointment'),
-  visitTypesList: Ember.computed.alias('appointmentsController.visitTypeList'),
+  visitTypesList: Ember.computed.alias('appointmentsController.visitTypesList'),
 
   cancelAction: function() {
     var returnTo = this.get('model.returnTo');

--- a/app/appointments/search/controller.js
+++ b/app/appointments/search/controller.js
@@ -19,7 +19,7 @@ export default AppointmentIndexController.extend(AppointmentStatuses, VisitTypes
   startDate: null,
   startKey: [],
   status: null,
-  visitTypesList: Ember.computed.alias('appointmentsController.visitTypeList'),
+  visitTypesList: Ember.computed.alias('appointmentsController.visitTypesList'),
 
   actions: {
     search: function() {

--- a/app/mixins/visit-types.js
+++ b/app/mixins/visit-types.js
@@ -25,9 +25,9 @@ export default Ember.Mixin.create({
 
   visitTypes: function() {
     return this._getVisitTypes();
-  }.property('visitTypesList', 'defaultVisitTypes'),
+  }.property('visitTypesList', 'defaultVisitTypes').volatile(),
 
   visitTypesWithEmpty: function() {
     return this._getVisitTypes(true);
-  }.property('visitTypesList', 'defaultVisitTypes')
+  }.property('visitTypesList', 'defaultVisitTypes').volatile()
 });

--- a/app/patients/reports/controller.js
+++ b/app/patients/reports/controller.js
@@ -13,7 +13,7 @@ export default AbstractReportController.extend(PatientDiagnosis, PatientVisits, 
   physicianList: Ember.computed.map('patientsController.physicianList.value', SelectValues.selectValuesMap),
   locationList: Ember.computed.map('patientsController.locationList.value', SelectValues.selectValuesMap),
   statusList: Ember.computed.map('patientsController.statusList.value', SelectValues.selectValuesMap),
-  visitTypesList: Ember.computed.alias('patientsController.visitTypeList'),
+  visitTypesList: Ember.computed.alias('patientsController.visitTypesList'),
   reportType: 'detailedAdmissions',
   patientDetails: {},
 

--- a/app/visits/edit/controller.js
+++ b/app/visits/edit/controller.js
@@ -101,7 +101,7 @@ export default AbstractEditController.extend(ChargeActions, PatientSubmodule, Pa
   pricingTypes: Ember.computed.alias('visitsController.wardPricingTypes'),
   physicianList: Ember.computed.alias('visitsController.physicianList'),
   locationList: Ember.computed.alias('visitsController.locationList'),
-  visitTypesList: Ember.computed.alias('visitsController.visitTypeList'),
+  visitTypesList: Ember.computed.alias('visitsController.visitTypesList'),
   lookupListsToUpdate: [{
     name: 'diagnosisList',
     property: 'model.primaryBillingDiagnosis',


### PR DESCRIPTION
Fixes #627 

**Changes proposed in this pull request:**
- Fixes the typo that was causing the visitTypesList to not be computed properly.
- Add volatile to the dependent property of visitTypesList (see app/mixins/visit-types.js).  It looks like being dependent on a computer property doesn't quite work as any subsequent updates to the underlying data is not firing the observers (i.e. the mixin functions).  

cc @HospitalRun/core-maintainers

