### PR TITLE
making the cancel update button always visible

### DIFF
--- a/app/styles/components/_panel.scss
+++ b/app/styles/components/_panel.scss
@@ -1,6 +1,13 @@
 // panel styles
 .panel-heading {
 
+   position:fixed;
+   width:100%;
+   z-index:9999;
+}
+.panel-heading {
+
+  
   .view-sub-bar { padding: 0 15px; }
 
   .view-sub-nav { margin: 0; }
@@ -59,4 +66,15 @@
 .panel-footer {
   background-color: $white;
   text-align: right;
+  position:relative;
+  float:left;
+  margin-top:-65px;
+  margin-left:200px;
+  z-index:99999;
+}
+
+
+.panel-primary{
+  margin-top:50px;
+  
 }

--- a/app/templates/components/edit-panel.hbs
+++ b/app/templates/components/edit-panel.hbs
@@ -1,7 +1,5 @@
 <div class="panel panel-primary">
-  <div class="panel-body">
-    {{yield}}
-  </div>
+  
   <div class="panel-footer">
     {{#unless editPanelProps.hideCancelButton}}
       {{#if editPanelProps.cancelButtonText}}
@@ -27,5 +25,8 @@
         {{button.buttonText}}
       </button>
     {{/each}}
+  </div>
+  <div class="panel-body">
+    {{yield}}
   </div>
 </div>


### PR DESCRIPTION
Fixes #569 make the save update button always visible.

**Changes proposed in this pull request:**
- make the footer-panel on /app/templates/components/edit-panel.hbs on the top.
- make its style as position:fixed.


cc @HospitalRun/core-maintainers @mnorbeck @tangollama @jglovier 
********************************************************************************************
<div class="panel panel-primary">
  
  <div class="panel-footer" style="position:fixed;">
    {{#unless editPanelProps.hideCancelButton}}
      {{#if editPanelProps.cancelButtonText}}
        <button class="btn btn-default warning" {{action 'cancel'}}>{{editPanelProps.cancelButtonText}}</button>
      {{else}}
        <button class="btn btn-default warning" {{action 'cancel'}}>{{t 'buttons.cancel'}}</button>
      {{/if}}
    {{/unless}}
    {{#if editPanelProps.showUpdateButton}}
      {{#if editPanelProps.disabledAction}}
        <button class="btn btn-primary on-white disabled-btn" {{action 'disabledAction'}}>{{editPanelProps.updateButtonText}}</button>
      {{else}}
        <button class="btn btn-primary on-white" {{action 'updateButtonAction'}} disabled={{editPanelProps.isUpdateDisabled}}>
          {{editPanelProps.updateButtonText}}
        </button>
      {{/if}}
    {{/if}}
    {{#each editPanelProps.additionalButtons as |button|}}
      <button class="{{button.class}}" {{action 'fireButtonAction' button.buttonAction}}>
        {{#if button.buttonIcon}}
          <span class="{{button.buttonIcon}}"></span>
        {{/if}}
        {{button.buttonText}}
      </button>
    {{/each}}
  </div>
  <div class="panel-body">
    {{yield}}
  </div>
</div>








