### PR TITLE
Issue 661: Use 'Sex Not Entered' for patients with missing gender on …

### DIFF
--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -878,7 +878,8 @@ export default {
       referredDate: 'Referred Date',
       religion: 'Religion',
       parent: 'Parent/Guardian',
-      contacts: 'Contacts'
+      contacts: 'Contacts',
+      sexNotEntered: 'Sex Not Entered'
     },
     notes: {
       newNote: 'New Note for',

--- a/app/patients/reports/controller.js
+++ b/app/patients/reports/controller.js
@@ -545,7 +545,9 @@ export default AbstractReportController.extend(PatientDiagnosis, PatientVisits, 
   _generateAdmissionOrDischargeReport: function(visits, reportType) {
     var detailedReport = false,
       reportColumns,
-      patientBySex = {};
+      patientBySex = {},
+      sexNotEnteredLabel = this.get('i18n').t('patients.labels.sexNotEntered');
+
     if (reportType.indexOf('detailed') > -1) {
       detailedReport = true;
       reportColumns = this.get('admissionDetailReportColumns');
@@ -570,7 +572,7 @@ export default AbstractReportController.extend(PatientDiagnosis, PatientVisits, 
         };
         var sex = visit.get('patient.sex');
         if (!sex) {
-          sex = 'Sex Not Entered';
+          sex = sexNotEnteredLabel;
         }
         var sexGrouping = patientBySex[sex];
         if (!sexGrouping) {

--- a/app/patients/reports/controller.js
+++ b/app/patients/reports/controller.js
@@ -568,13 +568,17 @@ export default AbstractReportController.extend(PatientDiagnosis, PatientVisits, 
           admissionDate: visit.get('startDate'),
           dischargeDate: visit.get('endDate')
         };
-        var sexGrouping = patientBySex[visit.get('patient.sex')];
+        var sex = visit.get('patient.sex');
+        if (!sex) {
+          sex = 'Sex Not Entered';
+        }
+        var sexGrouping = patientBySex[sex];
         if (!sexGrouping) {
           sexGrouping = {
             count: 0,
             rows: []
           };
-          patientBySex[visit.get('patient.sex')] = sexGrouping;
+          patientBySex[sex] = sexGrouping;
         }
         sexGrouping.count++;
         sexGrouping.rows.push(reportRow);


### PR DESCRIPTION
Fixes #661 .

**Changes proposed in this pull request:**
- Use 'Sex Not Entered' for patients without gender entered for reports.

cc @HospitalRun/core-maintainers
