### PR TITLE
Hid checkbox labels

### DIFF
--- a/app/inventory/batch/template.hbs
+++ b/app/inventory/batch/template.hbs
@@ -5,12 +5,14 @@
       {{select-or-typeahead property="vendor" label=(t 'inventory.labels.vendor') list=vendorList selection=model.vendor className="col-sm-4 required test-vendor"}}
       {{em-input property="invoiceNo" label=(t 'inventory.labels.invoiceNumber') class="col-sm-4 test-invoice-number"}}
     </div>
-    <div class="row">
+    <div class="form-group row">
       {{select-or-typeahead property="location" label=(t 'inventory.labels.location') list=warehouseList selection=model.location className="col-sm-5"}}
       {{select-or-typeahead property="aisleLocation" label=(t 'inventory.labels.aisleLocation') list=aisleLocationList selection=model.aisleLocation className="col-sm-5"}}
-      <div class="form-group col-sm-2">
-        <label class="control-label">{{t 'inventory.labels.gift'}}</label>
-        {{em-checkbox label=(t 'inventory.labels.gift') property="giftInKind"}}
+      <div class="col-sm-2 checkbox-label-space">
+        <div class="form-check">
+          <label class="control-label sr-only">{{t 'inventory.labels.gift'}}</label>
+          {{em-checkbox label=(t 'inventory.labels.gift') property="giftInKind"}}
+        </div>
       </div>
     </div>
     <div class="panel panel-primary">

--- a/app/inventory/request/template.hbs
+++ b/app/inventory/request/template.hbs
@@ -60,7 +60,7 @@
       {{/if}}
       {{#if canFulfill}}
         <div class="form-group">
-          <label class="control-label">{{t 'inventory.labels.fulfillRequest'}}</label>
+          <label class="control-label sr-only">{{t 'inventory.labels.fulfillRequest'}}</label>
         </div>
         {{em-checkbox label=(t 'inventory.labels.fulfillRequest') property="shouldFulfillRequest"}}
       {{/if}}
@@ -77,7 +77,7 @@
         selectedLocations=model.inventoryLocations
       }}
       <div class="form-group">
-        <label class="control-label">{{t 'inventory.labels.consumePurchases'}}</label>
+        <label class="control-label sr-only">{{t 'inventory.labels.consumePurchases'}}</label>
       </div>
       {{em-checkbox label=(t 'inventory.labels.markAsConsumed') property="markAsConsumed"}}
     {{/if}}

--- a/app/styles/components/_form_styles.scss
+++ b/app/styles/components/_form_styles.scss
@@ -6,3 +6,7 @@
 
   select { height: 44px; }
 }
+
+.checkbox-label-space {
+  top: 25px;
+}


### PR DESCRIPTION
Fixes #322.

-Hid redundant labels using “sr-only” class.
-The checkbox ended up where the label used to be so I added a class of
 “checkbox-label-space” that can be used where that comes into play.
gif:
http://recordit.co/qtt0q8Xwt7


cc @HospitalRun/core-maintainers

