### PR TITLE
Keyboard ctrl-S or cmd-S is same as clicking Update button

### DIFF
--- a/app/admin/lookup/controller.js
+++ b/app/admin/lookup/controller.js
@@ -6,8 +6,10 @@ import ImagingPricingTypes from 'hospitalrun/mixins/imaging-pricing-types';
 import InventoryTypeList from 'hospitalrun/mixins/inventory-type-list';
 import UnitTypes from 'hospitalrun/mixins/unit-types';
 import VisitTypes from 'hospitalrun/mixins/visit-types';
-export default Ember.Controller.extend(BillingCategories, LabPricingTypes,
-  ModalHelper, ImagingPricingTypes, InventoryTypeList,  UnitTypes, VisitTypes, {
+import { EKMixin, keyDown } from 'ember-keyboard';
+export default Ember.Controller.extend(BillingCategories, EKMixin,
+  ImagingPricingTypes, InventoryTypeList, LabPricingTypes, ModalHelper,
+  UnitTypes, VisitTypes, {
     fileSystem: Ember.inject.service('filesystem'),
     lookupTypes:  Ember.computed(function() {
       return [{
@@ -310,6 +312,15 @@ export default Ember.Controller.extend(BillingCategories, LabPricingTypes,
     _sortValues: function(a, b) {
       return Ember.compare(a.toLowerCase(), b.toLowerCase());
     },
+
+    activateKeyboard: Ember.on('init', function() {
+      this.set('keyboardActivated', true);
+    }),
+
+    updateListKeyboard: Ember.on(keyDown('ctrl+KeyS'), keyDown('cmd+KeyS'), function(event) {
+      this.send('updateList');
+      event.preventDefault();
+    }),
 
     actions: {
       addValue: function() {

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "ember-data": "~2.6.2",
     "ember-export-application-global": "^1.0.5",
     "ember-i18n": "4.3.2",
+    "ember-keyboard": "2.1.3",
     "ember-load-initializers": "^0.5.1",
     "ember-pouch": "4.0.1",
     "ember-radio-buttons": "^4.0.1",


### PR DESCRIPTION
Fixes part of https://github.com/HospitalRun/hospitalrun-frontend/issues/540.

- Keyboard ctrl-S or cmd-S is same as clicking Update button, see gif
- Overrides Chrome cmd-S keyboard shortcut
- TODO: Next step would be to implement on all Update and Save buttons

![keyboard gif](https://cloud.githubusercontent.com/assets/1372946/18804193/98b805b6-81ac-11e6-9626-d5fd2670162f.gif)

cc @HospitalRun/core-maintainers

Pair: @alychloe