### PR TITLE
Update Format of README Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,12 @@ To install the frontend please do the following:
         3. If you're stuck with the installation, check out the instructions published here: http://docs.couchdb.org/en/1.6.1/install/index.html
     3. Verify that CouchDB is running by successfully navigating to 127.0.0.1:5984/_utils. If that fails, check the installation guide for CouchDB http://docs.couchdb.org/en/1.6.1/install/index.html
     4. Create admin user:
-        If you are running CouchDB 1.x
-        1. If you have just installed CouchDB and have no admin user, please run `./script/initcouch.sh` in the folder you cloned the HospitalRun repo.  A user `hradmin` will be created with password: `test`.
-        2. If you already have a CouchDB admin user, please run `./script/initcouch.sh USER PASS` in the folder you cloned the HospitalRun repo.  `USER` and `PASS` are the CouchDB admin user credentials.
-        If you are running CouchDB 2.x
-        1. If you have just installed CouchDB and have no admin user, please run `./script/initcouch2.sh` in the folder you cloned the HospitalRun repo.  A user `hradmin` will be created with password: `test`.
-        2. If you already have a CouchDB admin user, please run `./script/initcouch2.sh USER PASS` in the folder you cloned the HospitalRun repo.  `USER` and `PASS` are the CouchDB admin user credentials.
+        1. If you are running CouchDB 1.x
+            1. If you have just installed CouchDB and have no admin user, please run `./script/initcouch.sh` in the folder you cloned the HospitalRun repo.  A user `hradmin` will be created with password: `test`.
+            2. If you already have a CouchDB admin user, please run `./script/initcouch.sh USER PASS` in the folder you cloned the HospitalRun repo.  `USER` and `PASS` are the CouchDB admin user credentials.
+        2. If you are running CouchDB 2.x
+            1. If you have just installed CouchDB and have no admin user, please run `./script/initcouch2.sh` in the folder you cloned the HospitalRun repo.  A user `hradmin` will be created with password: `test`.
+            2. If you already have a CouchDB admin user, please run `./script/initcouch2.sh USER PASS` in the folder you cloned the HospitalRun repo.  `USER` and `PASS` are the CouchDB admin user credentials.
 7. Copy the `server/config-example.js` to `server/config.js` in the folder you cloned the HospitalRun repo.  If you already had a CouchDB admin user that you passed into the couch script (`./script/initcouch.sh USER PASS`), then you will need to modify the `couchAdminUser` and `couchAdminPassword` values in `server/config.js` to reflect those credentials. (*Note: If on Mac, you need to make sure CouchDB can be run. See [How to open an app from a unidentified developer and exempt it from Gatekeeper](https://support.apple.com/en-us/HT202491).*)
 8. Verify that CouchDB is running by visiting: http://127.0.0.1:5984/_utils/#login
    and logging in with the with the credentials you just created from steps 6 and 7.


### PR DESCRIPTION
No previous issue about this pull request

I just started looking at this project and while I was going through the install section I was a little bit confused by the formatting of the Create Admin User section of the Install section in the README.

I am sorry that I didn't make an official issue prior to this, but it is a pretty minor change that I just wanted to add in to make the README a little bit clearer for new users.

**Proposed Changes**
Change format of part IV of step 6 from this:

![originalsection](https://cloud.githubusercontent.com/assets/8670469/18959514/72989260-8634-11e6-8da6-0a8e2da57659.PNG)

to this:

![newsection](https://cloud.githubusercontent.com/assets/8670469/18959516/786fc08c-8634-11e6-871e-636ad8418e54.PNG)


cc @HospitalRun/core-maintainers
Changed README.md at part IV in step 6 of the Install section. The README seemed like it was supposed to format this step into two different sections, one for users running CouchDB 1.x and one for 2.x. However, I think that no line break occurred that differentiated the part IV main line from the sub-instructions, and made the section a little bit confusing to read.