### PR TITLE
Addresses part of #483 - loading database now shows File Name in File To Load

### DIFF
--- a/app/admin/loaddb/controller.js
+++ b/app/admin/loaddb/controller.js
@@ -8,6 +8,7 @@ export default Ember.Controller.extend(ModalHelper, ProgressDialog, {
     progressMessage: t('admin.loaddb.progressMessage'),
     progressTitle: t('admin.loaddb.progressTitle'),
     syncResults: null,
+    fileImportedName: null,
 
     actions: {
       loadFile: function() {
@@ -21,8 +22,11 @@ export default Ember.Controller.extend(ModalHelper, ProgressDialog, {
         } else {
           this.showProgressModal();
           this.set('syncResults');
+          this.set('fileImportedName');
           fileSystem.fileToString(fileToImport).then((fileAsString) => {
             var database = this.get('database');
+            var fileName = this.get('importFile.name');
+	    this.set('fileImportedName', fileName);
             this.set('importFile');
             this.set('model.importFileName');
             database.loadDBFromDump(fileAsString).then((results) => {

--- a/app/admin/loaddb/template.hbs
+++ b/app/admin/loaddb/template.hbs
@@ -6,23 +6,23 @@
     {{/em-form}}
     {{#if syncResults}}
       <h4>{{t 'labels.fileLoadSuccessful'}}</h4>
-      <div class="form-group col-xs-3">
+      <div class="form-group col-xs-4">
         <label>{{t 'labels.fileName'}}</label>
         <p class="form-control-static">{{fileImportedName}}</p>
       </div>
-      <div class="form-group col-xs-3">
+      <div class="form-group col-xs-2">
         <label>{{t 'labels.startTime'}}</label>
         <p class="form-control-static">{{date-format syncResults.start_time format="l h:mm A"}}</p>
       </div>
-      <div class="form-group col-xs-3">
+      <div class="form-group col-xs-2">
         <label>{{t 'labels.endTime'}}</label>
         <p class="form-control-static">{{date-format syncResults.end_time format="l h:mm A"}}</p>
       </div>
-      <div class="form-group col-xs-3">
+      <div class="form-group col-xs-2">
         <label>{{t 'labels.docRead'}}</label>
         <p class="form-control-static">{{syncResults.docs_read}}</p>
       </div>
-        <div class="form-group col-xs-3">
+      <div class="form-group col-xs-2">
         <label>{{t 'labels.docWritten'}}</label>
         <p class="form-control-static">{{syncResults.docs_written}}</p>
       </div>

--- a/app/admin/loaddb/template.hbs
+++ b/app/admin/loaddb/template.hbs
@@ -7,6 +7,10 @@
     {{#if syncResults}}
       <h4>{{t 'labels.fileLoadSuccessful'}}</h4>
       <div class="form-group col-xs-3">
+        <label>{{t 'labels.fileName'}}</label>
+        <p class="form-control-static">{{fileImportedName}}</p>
+      </div>
+      <div class="form-group col-xs-3">
         <label>{{t 'labels.startTime'}}</label>
         <p class="form-control-static">{{date-format syncResults.start_time format="l h:mm A"}}</p>
       </div>

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -313,6 +313,7 @@ export default {
     importFile: 'Import File',
     fileLoadSuccessful: 'File To Load Successful',
     fileToLoad: 'File Load',
+    fileName: 'File Name',
     startTime: 'Start Time',
     startDate: 'Start Date',
     endTime: 'End Time',

--- a/app/styles/_bootstrap.scss
+++ b/app/styles/_bootstrap.scss
@@ -829,7 +829,7 @@ pre {
 }
 
 .col-xs-3 {
-    width: 20%;
+    width: 25%;
 }
 
 .col-xs-2 {
@@ -6721,3 +6721,4 @@ button.close {
     }
 }
 /* stylelint-enable */
+

--- a/app/styles/_bootstrap.scss
+++ b/app/styles/_bootstrap.scss
@@ -829,7 +829,7 @@ pre {
 }
 
 .col-xs-3 {
-    width: 25%;
+    width: 20%;
 }
 
 .col-xs-2 {


### PR DESCRIPTION
Partially addresses #483 .

**Changes proposed in this pull request:**
- [x] Added `File Name` to 'File to Load Successful'.

I have added 'File Name' to be shown in 'File to Load Successful'\LoadDB gui.
Loaded file successful persist is not added in this pull request. I will try to work on it, but for now I can't promise I will be able to add it. Anyways, I managed to make 'File Name' to be shown in table.
How does it looks:
![LoadDB - file name confirmation](http://i.imgur.com/aBwRUvr.png)

cc @HospitalRun/core-maintainers