### PR TITLE
Use `number-input` for more numeric fields

### DIFF
--- a/app/medication/return/template.hbs
+++ b/app/medication/return/template.hbs
@@ -18,7 +18,7 @@
       }}
     </div>
     <div class="row">
-      {{em-input property="quantity" label=(t 'medication.labels.quantityToReturn') class="col-xs-3 required test-medication-quantity"}}
+      {{number-input property="quantity" label=(t 'medication.labels.quantityToReturn') class="col-xs-3 required test-medication-quantity"}}
       {{select-or-typeahead property="deliveryLocation" label=(t 'medication.labels.returnLocation') list=warehouseList selection=model.location className="col-xs-4"}}
       {{select-or-typeahead property="deliveryAisle" label=(t 'medication.labels.returnAisle') list=aisleLocationList selection=model.aisleLocation className="col-xs-4"}}
     </div>

--- a/app/procedures/medication/template.hbs
+++ b/app/procedures/medication/template.hbs
@@ -6,6 +6,6 @@
     updateButtonText=updateButtonText }}
   {{#em-form model=model submitButton=false }}
     {{inventory-typeahead property="itemName" label=(t 'procedures.labels.medicationUsed') content=medicationList selection=selectedInventoryItem class="medication-used"}}
-    {{em-input label=(t 'labels.quantity') property="quantity" class="required medication-quantity"}}
+    {{number-input label=(t 'labels.quantity') property="quantity" class="required medication-quantity"}}
   {{/em-form}}
 {{/modal-dialog}}

--- a/app/templates/inventory-basic.hbs
+++ b/app/templates/inventory-basic.hbs
@@ -26,7 +26,7 @@
 </div>
 <div class="row">
   {{em-input property="reorderPoint" label=(t 'inventory.labels.reorderPoint') class="col-sm-3 test-inv-reorder"}}
-  {{em-input property="price" label=(t 'inventory.labels.salePricePerUnit') class="col-sm-3 test-inv-price"}}
+  {{number-input property="price" label=(t 'inventory.labels.salePricePerUnit') class="col-sm-3 test-inv-price"}}
   {{em-select label=(t 'inventory.labels.distributionUnit') class="col-sm-3 required test-inv-dist-unit"
     property="distributionUnit"
     content=unitListForSelect


### PR DESCRIPTION
As an addition to PR #668, I converted the `em-input` helper to `number-input` for some more numeric form fields.

cc @HospitalRun/core-maintainers

