### PR TITLE
Bug fix for add user cancel error

### DIFF
--- a/app/components/edit-panel.js
+++ b/app/components/edit-panel.js
@@ -1,10 +1,11 @@
 import Ember from 'ember';
 export default Ember.Component.extend({
   editPanelProps: null,
+  cancelAction: 'cancel',
 
   actions: {
     cancel: function() {
-      this.sendAction('editPanelProps.cancelAction');
+      this.sendAction('cancelAction');
     },
     disabledAction: function() {
       this.sendAction('editPanelProps.disabledAction');

--- a/app/mixins/edit-panel-props.js
+++ b/app/mixins/edit-panel-props.js
@@ -2,7 +2,6 @@ import Ember from 'ember';
 export default Ember.Mixin.create({
 
   additionalButtons: null,
-  cancelAction: null,
   cancelButtonText: null,
   disabledAction: null,
   hideCancelButton: null,
@@ -14,7 +13,6 @@ export default Ember.Mixin.create({
   editPanelProps: function() {
     return this.getProperties([
       'additionalButtons',
-      'cancelAction',
       'cancelButtonText',
       'disabledAction',
       'hideCancelButton',
@@ -24,7 +22,6 @@ export default Ember.Mixin.create({
       'updateButtonText'
     ]);
   }.property('additionalButtons',
-             'cancelAction',
              'cancelButtonText',
              'disabledAction',
              'hideCancelButton',


### PR DESCRIPTION
Fixes #719 .

Changes proposed in this pull request:
- Added action 'cancelAction' in component edit-panel.js 
- Removed all instances of cancelAction from mixin edit-panel-prop.js
- While adding a new user in the user listing, if a person fills in the details and clicks Cancel, that particular user won't be visible in the user listing on the index page of Users.

cc @HospitalRun/core-maintainers