### PR TITLE
Tighten up app nav spacing

### DIFF
--- a/app/styles/components/_sidebar_nav.scss
+++ b/app/styles/components/_sidebar_nav.scss
@@ -187,7 +187,6 @@
   .category-sub-items {
     border-bottom: 1px solid $navy_drkest;
     background: #3a4d63;
-    padding: 5px 0;
   }
 
   .category-sub-item {

--- a/app/styles/components/_sidebar_nav.scss
+++ b/app/styles/components/_sidebar_nav.scss
@@ -163,8 +163,8 @@
     border-bottom: 1px solid $navy_drkest;
     background: $navy_mid2;
     padding: 0 15px;
-    height: 55px;
-    line-height: 55px;
+    height: 48px;
+    line-height: 48px;
     color: $white;
     font-size: 18px;
 
@@ -172,8 +172,8 @@
       @include transition_all;
       float: left;
       margin-right: 12px;
-      line-height: 55px;
       width: 16px;
+      line-height: 48px;
     }
 
     &:hover,

--- a/app/styles/components/_sidebar_nav.scss
+++ b/app/styles/components/_sidebar_nav.scss
@@ -17,7 +17,7 @@
   .mega-octicon {
     text-align: center;
     color: $sidebar_icon;
-    font-size: 24px;
+    font-size: 16px;
   }
 }
 
@@ -172,8 +172,8 @@
       @include transition_all;
       float: left;
       margin-right: 12px;
-      width: 24px;
       line-height: 55px;
+      width: 16px;
     }
 
     &:hover,
@@ -216,7 +216,7 @@
       float: left;
       margin-right: 6px;
       margin-left: 6px;
-      width: 24px;
+      width: 16px;
       line-height: 36px;
     }
   }


### PR DESCRIPTION
The nav spacing is a little big for all the things that we have in the nav, and adding more items will only compound this problem. This PR tightens up the nav a little so less scrolling is required (especially on smaller screens).

**Changes proposed in this pull request:**
- Reduce vertical nav spacing
- Reduce size of icons

**Screenshots:**

| Before | After |
|---|---|
| <img width="1275" alt="screenshot 2016-10-22 18 46 33" src="https://cloud.githubusercontent.com/assets/1319791/19623026/e350a596-9887-11e6-82be-26f6fcf59d90.png"> | <img width="1276" alt="screenshot 2016-10-22 18 45 24" src="https://cloud.githubusercontent.com/assets/1319791/19623023/bc54a0c8-9887-11e6-9b98-3ce6c2b66969.png"> |

cc @HospitalRun/core-maintainers
