### PR TITLE
Make eslint object-curly-spacing rule enforced

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -27,6 +27,7 @@ module.exports = {
   },
 
   rules: {
-    'no-console': 0
+    'no-console': 0,
+    'object-curly-spacing': [ 2, 'always']
   }
 };


### PR DESCRIPTION
Fixes: part of https://github.com/HospitalRun/hospitalrun-frontend/issues/732

Relates to: https://github.com/HospitalRun/hospitalrun-frontend/pull/770 cc @btecu 

**Changes proposed in this pull request:**
- Since many of the rules outlined in https://github.com/HospitalRun/hospitalrun-frontend/issues/732 aren’t part of eslint recommended https://github.com/DockYard/eslint-plugin-ember-suave/blob/master/config/recommended.js, I suggest adding the rules to the `eslintrc.js`, so that they are enforced as they are fixed.
- Re: http://eslint.org/docs/rules/object-curly-spacing

Why? I just realized my fork was terribly out of date when I started looking at https://github.com/HospitalRun/hospitalrun-frontend/issues/732 recently. I have previously used ember-suave, am just getting started with eslint.

If this PR is ok:
- I’ll add the rest of the already completed rules from https://github.com/HospitalRun/hospitalrun-frontend/issues/732 to the `.eslintrc.js` in a follow-on PR.
- Go through the remaining rules from https://github.com/HospitalRun/hospitalrun-frontend/issues/732, and add the rule to the `.eslintrc.js` as the rules are fixed.

If I'm misunderstanding something please let me know!

cc @HospitalRun/core-maintainers

