### PR TITLE
Fix 'calss' typo in appointment search template

### DIFF
--- a/app/appointments/search/template.hbs
+++ b/app/appointments/search/template.hbs
@@ -8,7 +8,7 @@
               label=(t "labels.status") content=appointmentStatusesWithEmpty
           }}
         </div>
-        <div calss="row">
+        <div class="row">
           {{em-select class="col-sm-3" label=(t "labels.type")
               property="selectedAppointmentType" content=visitTypesWithEmpty
           }}


### PR DESCRIPTION
Fixes untracked self-reported issue.

**Changes proposed in this pull request:**
Fixed a small typo I stumbled upon while working on the calendar feature, with visible effects on the end-product.

## Before:
![pic before](http://i.imgur.com/ZwBqaAW.png)

## After:
![pic after](http://i.imgur.com/vq7G9vv.png)

cc @HospitalRun/core-maintainers

