### PR TITLE
Trigger database syncing with Background Sync

### DIFF
--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -9,6 +9,60 @@ const {
   }
 } = Ember;
 
+const { localMainDB, remoteDB } = window;
+
+function foregroundSync() {
+  console.log('foreground syncing');
+  return localMainDB.sync(remoteDB).on('error', function(err) {
+    console.log('foreground sync error:', err);
+  });
+}
+
+function backgroundSync() {
+  console.log('registering background sync');
+  return navigator.serviceWorker.ready
+    .then(function(reg) {
+      return reg.sync.register('sync');
+    })
+    .then(function() {
+      console.log('background sync registration succeeded');
+    })
+    .catch(function() {
+      console.log('background sync registration failed');
+    });
+}
+
+function watchLocalDB() {
+  console.log('watching local DB');
+  return localMainDB.changes({
+    since: 'now',
+    live: true
+  }).on('change', function(change) {
+    console.log('local change: ', change);
+    return backgroundSync();
+  }).on('error', function(err) {
+    console.error('local err: ', err);
+  });
+}
+
+function watchRemoteDB() {
+  console.log('watching remote DB');
+  return remoteDB.changes({
+    since: 'now',
+    live: true
+  }).on('change', function(change) {
+    console.log('remote change: ', change);
+    return backgroundSync();
+  }).on('error', function(err) {
+    console.error('remote err: ', err);
+  });
+}
+
+foregroundSync().then(function() {
+  watchLocalDB();
+  watchRemoteDB();
+});
+
 export default Adapter.extend(PouchAdapterUtils, {
   database: Ember.inject.service(),
   db: Ember.computed.reads('database.mainDB'),

--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -58,10 +58,12 @@ function watchRemoteDB() {
   });
 }
 
-foregroundSync().then(function() {
-  watchLocalDB();
-  watchRemoteDB();
-});
+if (localMainDB && remoteDB) {
+  foregroundSync().then(function() {
+    watchLocalDB();
+    watchRemoteDB();
+  });
+}
 
 export default Adapter.extend(PouchAdapterUtils, {
   database: Ember.inject.service(),

--- a/app/services/database.js
+++ b/app/services/database.js
@@ -44,12 +44,15 @@ export default Ember.Service.extend(PouchAdapterUtils, {
       }
       let url = `${document.location.protocol}//${document.location.host}/db/main`;
 
-      this._createRemoteDB(url, pouchOptions)
+      let localMainDB = this._createLocalDB('localMainDB', pouchOptions);
+      let remoteDB = this._createRemoteDB(url, pouchOptions);
+
+      remoteDB
       .catch((err) => {
         if ((err.status && err.status === 401) || configs.config_disable_offline_sync === true) {
           reject(err);
         } else {
-          return this._createLocalDB('localMainDB', pouchOptions);
+          return localMainDB;
         }
       }).then((db) => resolve(db))
       .catch((err) => reject(err));
@@ -162,6 +165,7 @@ export default Ember.Service.extend(PouchAdapterUtils, {
   _createRemoteDB(remoteUrl, pouchOptions) {
     return new Ember.RSVP.Promise(function(resolve, reject) {
       let remoteDB = new PouchDB(remoteUrl, pouchOptions);
+      window.remoteDB = remoteDB;
       // remote db lazy created, check if db created correctly
       remoteDB.info().then(()=> {
         createPouchViews(remoteDB);
@@ -176,6 +180,7 @@ export default Ember.Service.extend(PouchAdapterUtils, {
   _createLocalDB(localDBName, pouchOptions) {
     return new Ember.RSVP.Promise(function(resolve, reject) {
       let localDB = new PouchDB(localDBName, pouchOptions);
+      window.localMainDB = localDB;
       localDB.info().then(() => {
         createPouchViews(localDB);
         resolve(localDB);

--- a/app/serviceworkers/pouchdb-sync.js
+++ b/app/serviceworkers/pouchdb-sync.js
@@ -58,7 +58,7 @@ function syncDatabases() {
   }
   let remoteURL = `${self.location.protocol}//${self.location.host}/db/main`;
   let remoteDB = new PouchDB(remoteURL, pouchOptions);
-  localMainDB.sync(remoteDB)
+  return localMainDB.sync(remoteDB)
   .on('change', function(info) {
     logDebug('local sync change', info);
   }).on('paused', function() {


### PR DESCRIPTION
Fixes #731.

Do initial sync in the main thread. Subsequent syncing is triggered with a Background Sync event and only happens in the Service Worker.

cc @HospitalRun/core-maintainers

