### PR TITLE
Removes unnecessary `resetNamespace`s

### DIFF
--- a/app/router.js
+++ b/app/router.js
@@ -11,7 +11,9 @@ Router.map(function() {
     this.route('address');
     this.route('loaddb');
     this.route('lookup', { path: '/' });
-    this.route('users', function() {
+    this.route('users', {
+      resetNamespace: true 
+    }, function() {
       this.route('edit', { path: '/edit/:user_id' });
     });
     this.route('roles');

--- a/app/router.js
+++ b/app/router.js
@@ -12,7 +12,7 @@ Router.map(function() {
     this.route('loaddb');
     this.route('lookup', { path: '/' });
     this.route('users', {
-      resetNamespace: true 
+      resetNamespace: true
     }, function() {
       this.route('edit', { path: '/edit/:user_id' });
     });

--- a/app/router.js
+++ b/app/router.js
@@ -7,15 +7,11 @@ const Router = Ember.Router.extend({
 });
 
 Router.map(function() {
-  this.route('admin', {
-    resetNamespace: true
-  }, function() {
+  this.route('admin', function() {
     this.route('address');
     this.route('loaddb');
     this.route('lookup', { path: '/' });
-    this.route('users', {
-      resetNamespace: true
-    }, function() {
+    this.route('users', function() {
       this.route('edit', { path: '/edit/:user_id' });
     });
     this.route('roles');
@@ -23,9 +19,7 @@ Router.map(function() {
     this.route('workflow');
   });
 
-  this.route('appointments', {
-    resetNamespace: true
-  }, function() {
+  this.route('appointments', function() {
     this.route('edit', { path: '/edit/:appointment_id' });
     this.route('search');
     this.route('today');
@@ -36,16 +30,12 @@ Router.map(function() {
 
   this.route('index', { path: '/' });
 
-  this.route('imaging', {
-    resetNamespace: true
-  }, function() {
+  this.route('imaging', function() {
     this.route('completed');
     this.route('edit', { path: '/edit/:imaging_id' });
   });
 
-  this.route('inventory', {
-    resetNamespace: true
-  }, function() {
+  this.route('inventory', function() {
     this.route('barcode', { path: '/barcode/:inventory_id' });
     this.route('edit', { path: '/edit/:inventory_id' });
     this.route('batch', { path: '/batch/:inventory-batch_id' });
@@ -55,43 +45,33 @@ Router.map(function() {
     this.route('search', { path: '/search/:search_text' });
   });
 
-  this.route('invoices', {
-    resetNamespace: true
-  }, function() {
+  this.route('invoices', function() {
     this.route('edit', { path: '/edit/:invoice_id' });
     this.route('search', { path: '/search/:search_text' });
   });
 
-  this.route('labs', {
-    resetNamespace: true
-  }, function() {
+  this.route('labs', function() {
     this.route('completed');
     this.route('edit', { path: '/edit/:lab_id' });
   });
 
   this.route('login');
 
-  this.route('medication', {
-    resetNamespace: true
-  }, function() {
+  this.route('medication', function() {
     this.route('completed');
     this.route('edit', { path: '/edit/:medication_id' });
     this.route('return', { path: '/return/:inv-request_id' });
     this.route('search', { path: '/search/:search_text' });
   });
 
-  this.route('patients', {
-    resetNamespace: true
-  }, function() {
+  this.route('patients', function() {
     this.route('edit', { path: '/edit/:patient_id' });
     this.route('reports');
     this.route('admitted');
     this.route('search', { path: '/search/:search_text' });
   });
 
-  this.route('pricing', {
-    resetNamespace: true
-  }, function() {
+  this.route('pricing', function() {
     this.route('imaging');
     this.route('lab');
     this.route('procedure');
@@ -101,15 +81,11 @@ Router.map(function() {
     this.route('profiles');
   });
 
-  this.route('print', {
-    resetNamespace: true
-  }, function() {
+  this.route('print', function() {
     this.route('invoice', { path: '/invoice/:invoice_id' });
   });
 
-  this.route('visits', {
-    resetNamespace: true
-  }, function() {
+  this.route('visits', function() {
     this.route('edit', { path: '/edit/:visit_id' });
     this.route('procedures', {
       resetNamespace: true


### PR DESCRIPTION
This is a code style improvement with no issue associated.

**Changes proposed in this pull request:**
- Remove unnecessary `{ resetNamespace: true }` for top-level routes.

cc @HospitalRun/core-maintainers

The routes declared directly beneath `Router.map` are already top-level, so the reset is unnecessary.
This has the added benefit of removing some visual cruft, because the few `resetNamespace`s left are actually meaningful, making visual parsing easier, as well as grepping.