### PR TITLE
Add model unit test billing-line-item appointments

### DIFF
--- a/tests/unit/models/appointment-test.js
+++ b/tests/unit/models/appointment-test.js
@@ -1,0 +1,20 @@
+import { moduleForModel } from 'ember-qunit';
+
+import { testValidPropertyValues, testInvalidPropertyValues } from '../../helpers/validate-properties';
+
+moduleForModel('appointment', 'Unit | Model | appointment', {
+  needs: [
+    'ember-validations@validator:local/presence',
+    'model:patient',
+    'model:visit',
+  ]
+});
+
+testValidPropertyValues('appointmentType', ['test']);
+testInvalidPropertyValues('appointmentType', [undefined]);
+
+testValidPropertyValues('location', ['test']);
+testInvalidPropertyValues('location', [undefined]);
+
+testValidPropertyValues('startDate', ['test']);
+testInvalidPropertyValues('startDate', [undefined]);

--- a/tests/unit/models/billing-line-item-test.js
+++ b/tests/unit/models/billing-line-item-test.js
@@ -1,0 +1,26 @@
+import { moduleForModel } from 'ember-qunit';
+
+import { testValidPropertyValues, testInvalidPropertyValues } from '../../helpers/validate-properties';
+
+moduleForModel('billing-line-item', 'Unit | Model | billing-line-item', {
+  needs: [
+    'ember-validations@validator:local/presence',
+    'ember-validations@validator:local/numericality',
+    'model:line-item-detail'
+  ]
+});
+
+testValidPropertyValues('category', ['test']);
+testInvalidPropertyValues('category', [undefined]);
+
+testValidPropertyValues('discount', [123, '123', 0.123, undefined]);
+testInvalidPropertyValues('discount', ['test']);
+
+testValidPropertyValues('nationalInsurance', [123, '123', 0.123, undefined]);
+testInvalidPropertyValues('nationalInsurance', ['test']);
+
+testValidPropertyValues('name', ['test']);
+testInvalidPropertyValues('name', [undefined]);
+
+testValidPropertyValues('privateInsurance', [123, '123', 0.123, undefined]);
+testInvalidPropertyValues('privateInsurance', ['test']);


### PR DESCRIPTION
**Changes proposed in this pull request:**
- Add basic validation model unit tests for billing-line-item
- Add basic validation model unit tests for appointment

cc @HospitalRun/core-maintainers