### PR TITLE
#824 Update inventory quantity to not allow negative numbers, acceptance test added

### DIFF
--- a/app/components/quantity-conv.js
+++ b/app/components/quantity-conv.js
@@ -30,7 +30,7 @@ export default Ember.Component.extend({
     let quantity = this.get('quantity');
     let quantityClass = 'has-success';
     let targetUnit = this.get('targetUnit');
-    if (!Ember.isEmpty(targetUnit) && (Ember.isEmpty(quantity) || isNaN(quantity))) {
+    if (!Ember.isEmpty(targetUnit) && (Ember.isEmpty(quantity) || isNaN(quantity) || quantity < 0)) {
       this.set('quantityHelp', 'not a valid number');
       quantityClass = 'has-error';
     } else {

--- a/app/models/inv-purchase.js
+++ b/app/models/inv-purchase.js
@@ -38,7 +38,8 @@ let InventoryPurchaseItem = AbstractModel.extend(LocationName, {
       numericality: true
     },
     originalQuantity: {
-      numericality: true
+      numericality: true,
+      greaterThanOrEqualTo: 0
     },
     vendor: {
       presence: true

--- a/app/models/inventory.js
+++ b/app/models/inventory.js
@@ -74,7 +74,10 @@ export default AbstractModel.extend(LocationName, {
       presence: true
     },
     quantity: {
-      numericality: validateIfNewItem
+      numericality: {
+        validateIfNewItem,
+        greaterThanOrEqualTo: 0
+      }
     },
     price: {
       numericality: {

--- a/tests/acceptance/inventory-test.js
+++ b/tests/acceptance/inventory-test.js
@@ -69,6 +69,43 @@ test('Adding a new inventory item', (assert) => {
   });
 });
 
+test('Items with negative quantites should not be saved', (assert) => {
+  runWithPouchDump('default', function() {
+    authenticateUser();
+    visit('/inventory/edit/new');
+
+    andThen(() => {
+      assert.equal(currentURL(), '/inventory/edit/new');
+    });
+    fillIn('.test-inv-name input', 'Biogesic');
+    select('.test-inv-rank', 'B');
+    fillIn('textarea', 'Biogesic nga medisina');
+    select('.test-inv-type', 'Medication');
+    fillIn('.test-inv-cross input', '2600');
+    fillIn('.test-inv-reorder input', '100');
+    fillIn('.test-inv-price input', '5');
+    select('.test-inv-dist-unit', 'tablet');
+    fillIn('.test-inv-quantity input', '-1000');
+    fillIn('.test-inv-cost input', '4000');
+    select('.test-inv-unit', 'tablet');
+    typeAheadFillIn('.test-vendor', 'Alpha Pharmacy');
+    click('button:contains(Add)');
+    waitToAppear('.modal-dialog');
+
+    andThen(() => {
+      assert.equal(find('.modal-title').text(), 'Warning!!!!', 'Inventory Item with negative quantity should not be saved.');
+    });
+    click('button:contains(Ok)');
+
+    andThen(() => {
+      assert.equal(currentURL(), '/inventory/edit/new');
+      findWithAssert('button:contains(Add)');
+      findWithAssert('button:contains(Cancel)');
+      assert.equal(find('.test-inv-quantity .help-block').text(), 'not a valid number', 'Error message should be present for invalid quantities');
+    });
+  });
+});
+
 test('Visiting /inventory/barcode', (assert) => {
   runWithPouchDump('inventory', function() {
     authenticateUser();


### PR DESCRIPTION
Fixes #824.

**Changes proposed in this pull request:**
- Updated inventory model to not allow negative numbers.
- Updated inv-purchase model to not allow negative numbers.
- Updated quantity-conv.js to consider negative quantities as an invalid number.
- Added an acceptance test to make sure items with negative quantities cannot be added.
- UI notifies when quantity is negative

<img width="788" alt="screen shot 2016-12-08 at 11 22 01 pm" src="https://cloud.githubusercontent.com/assets/5996255/21039725/3d3689d8-bd9d-11e6-88f4-9b75f8f041a3.png">


cc @HospitalRun/core-maintainers
