### PR TITLE
Report export name

### DIFF
--- a/app/inventory/reports/template.hbs
+++ b/app/inventory/reports/template.hbs
@@ -100,7 +100,7 @@
       </table>
     </div>
     <div class="panel-footer">
-      <a href={{csvExport}} target="_blank" download="report.csv" class="btn btn-default">{{t 'inventory.reports.export'}}</a>
+      <a href={{csvExport}} target="_blank" download="{{reportTitle}}.csv" class="btn btn-default">{{t 'inventory.reports.export'}}</a>
 
     </div>
   </div>

--- a/app/patients/reports/template.hbs
+++ b/app/patients/reports/template.hbs
@@ -109,7 +109,7 @@
       </table>
     </div>
     <div class="panel-footer">
-      <a href={{csvExport}} target="_blank" download="report.csv" class="btn btn-default">{{t 'inventory.reports.export'}}</a>
+      <a href={{csvExport}} target="_blank" download="{{reportTitle}}.csv" class="btn btn-default">{{t 'inventory.reports.export'}}</a>
 
     </div>
   </div>

--- a/tests/acceptance/inventory-test.js
+++ b/tests/acceptance/inventory-test.js
@@ -269,7 +269,8 @@ function testSimpleReportForm(reportName) {
       andThen(() => {
         let reportTitle = `${reportName} Report ${startDate.format('l')} - ${endDate.format('l')}`;
         assert.equal(find('.panel-title').text().trim(), reportTitle, `${reportName} Report generated`);
-        findWithAssert('a:contains(Export Report)');
+        let exportLink = findWithAssert('a:contains(Export Report)');
+        assert.equal($(exportLink).attr('download'), `${reportTitle}.csv`);
       });
     });
   });
@@ -288,8 +289,10 @@ function testSingleDateReportForm(reportName) {
       waitToAppear('.panel-title');
 
       andThen(() => {
-        assert.equal(find('.panel-title').text().trim(), `${reportName} Report ${moment().format('l')}`, `${reportName} Report generated`);
-        findWithAssert('a:contains(Export Report)');
+        let reportTitle = `${reportName} Report ${moment().format('l')}`;
+        assert.equal(find('.panel-title').text().trim(), reportTitle, `${reportName} Report generated`);
+        let exportLink = findWithAssert('a:contains(Export Report)');
+        assert.equal($(exportLink).attr('download'), `${reportTitle}.csv`);
       });
     });
   });

--- a/tests/acceptance/patients-test.js
+++ b/tests/acceptance/patients-test.js
@@ -46,11 +46,18 @@ test('View reports tab', function(assert) {
   });
 });
 
-testSimpleReportForm('Admissions Summary');
-testSimpleReportForm('Diagnostic Testing');
-testSimpleReportForm('Discharges Detail');
-testSimpleReportForm('Discharges Summary');
-testSimpleReportForm('Procedures Detail');
+let reportNames = [
+  'Admissions Summary',
+  'Diagnostic Testing',
+  'Discharges Detail',
+  'Discharges Summary',
+  'Procedures Detail'
+];
+
+reportNames.forEach((reportName) => {
+  testSimpleReportForm(reportName);
+  testExportReportName(reportName);
+});
 
 test('View reports tab | Patient Status', function(assert) {
   runWithPouchDump('default', function() {
@@ -112,6 +119,31 @@ function testSimpleReportForm(reportName) {
         assert.equal(reportEndDate.length, 1, 'Report end date select is visible');
         let reportType = find('[data-test-selector="select-report-type"] select');
         assert.equal(reportType.find(':selected').text().trim(), reportName, `${reportName} option selected`);
+      });
+    });
+  });
+}
+
+function testExportReportName(reportName) {
+  test(`View reports tab | Export reports name for ${reportName} shows report name, start and end dates`, (assert) => {
+    runWithPouchDump('default', () => {
+      authenticateUser();
+      visit('/patients/reports');
+      select('[data-test-selector="select-report-type"] select', reportName);
+
+      andThen(() => {
+        assert.equal(currentURL(), '/patients/reports');
+      });
+
+      fillIn('[data-test-selector="select-report-start-date"] input', '12/11/2016');
+      fillIn('[data-test-selector="select-report-end-date"] input', '12/31/2016');
+
+      click('button:contains(Generate Report)');
+      waitToAppear('.panel-title');
+
+      andThen(() => {
+        let exportReportButton = findWithAssert('a:contains(Export Report)');
+        assert.equal($(exportReportButton).attr('download'), `${reportName} Report 12/11/2016 - 12/31/2016.csv`);
       });
     });
   });


### PR DESCRIPTION
Fixes #851 

**Changes proposed in this pull request:**
- Patients -> Reports and Inventory -> Reports export gives a file name with report name and date by using exactly the report title.


cc @HospitalRun/core-maintainers
