### PR TITLE
Add availableQuantity translation

### DIFF
--- a/app/components/inventory-typeahead.js
+++ b/app/components/inventory-typeahead.js
@@ -4,10 +4,15 @@ export default TypeAhead.extend({
   classNameBindings: ['haveInventoryItems'],
   displayKey: 'name',
   showQuantity: true,
+  i18n: Ember.inject.service(),
+
   _mapInventoryItems(item) {
     let returnObj = {};
     if (this.get('showQuantity') && item.quantity) {
-      returnObj.name = `${item.name} - ${item.friendlyId} (${item.quantity} available)`;
+      returnObj.name = `${item.name} - ${item.friendlyId} (${this.get('i18n').t(
+        'inventory.labels.availableQuantity',
+        { quantity: item.quantity }
+      )})`;
     } else {
       returnObj.name = `${item.name} - ${item.friendlyId}`;
     }

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -465,6 +465,7 @@ export default {
       aisle: 'Aisle',
       aisleLocation: 'Aisle Location',
       allInventory: 'All Inventory',
+      availableQuantity: '{{quantity}} available',
       billTo: 'Bill To',
       consumePurchases: 'Consume Purchases',
       consumptionRate: 'Consumption Rate',

--- a/app/models/inv-location.js
+++ b/app/models/inv-location.js
@@ -12,11 +12,15 @@ let InventoryLocation = AbstractModel.extend(LocationName, {
   quantity: DS.attr('number'),
   location: DS.attr('string'),
   aisleLocation: DS.attr('string'),
+  i18n: Ember.inject.service(),
 
   locationNameWithQuantity: function() {
     let quantity = this.get('quantity');
     let locationName = this.get('locationName');
-    return `${locationName} (${quantity} available)`;
+    return `${locationName} (${this.get('i18n').t(
+      'inventory.labels.availableQuantity',
+      { quantity }
+    )})`;
   }.property('locationName', 'quantity'),
 
   validations: {

--- a/tests/unit/models/inv-location-test.js
+++ b/tests/unit/models/inv-location-test.js
@@ -1,0 +1,34 @@
+import { moduleForModel, test } from 'ember-qunit';
+import tHelper from 'ember-i18n/helper';
+import localeConfig from 'ember-i18n/config/en';
+
+moduleForModel('inv-location', 'Unit | Model | inv-location', {
+  needs: [
+    'ember-validations@validator:local/numericality',
+    'ember-validations@validator:local/acceptance',
+    'ember-validations@validator:local/presence',
+    'service:i18n',
+    'locale:en/translations',
+    'locale:en/config',
+    'util:i18n/missing-message',
+    'util:i18n/compile-template',
+    'config:environment'
+  ],
+  beforeEach() {
+    // set the locale and the config
+    this.container.lookup('service:i18n').set('locale', 'en');
+    this.registry.register('locale:en/config', localeConfig);
+
+    // register t helper
+    this.registry.register('helper:t', tHelper);
+  }
+});
+
+test('locationNameWithQuantity', function(assert) {
+  let invLocation = this.subject({
+    quantity: 3,
+    locationName: 'Test Location'
+  });
+
+  assert.equal(invLocation.get('locationNameWithQuantity'), 'Test Location (3 available)');
+});


### PR DESCRIPTION
**Changes proposed in this pull request:**
- Add `locationNameWithQuantity` translation for InventoryLocation model
- Add translation for items in inventory-typeahead component select list
- Add en translation for `inventory.labels.availableQuantity`
- Add model unit test for inv-location

cc @HospitalRun/core-maintainers
