### PR TITLE
Add unit mixin test mixins/appointment-statuses AppointmentStatuses

### DIFF
--- a/tests/unit/mixins/appointment-statuses-test.js
+++ b/tests/unit/mixins/appointment-statuses-test.js
@@ -1,0 +1,54 @@
+import AppointmentStatuses from 'hospitalrun/mixins/appointment-statuses';
+import { moduleFor, test } from 'ember-qunit';
+import Ember from 'ember';
+
+moduleFor('mixin:appointment-statuses', 'Unit | Mixin | appointment-statuses');
+
+test('appointmentStatusList', function(assert) {
+  let appointmentStatuses = Ember.Object.extend(AppointmentStatuses).create();
+  assert.deepEqual(appointmentStatuses.get('appointmentStatusList'), [
+    'Scheduled',
+    'Canceled',
+    'Missed'
+  ]);
+});
+
+test('appointmentStatuses', function(assert) {
+  let appointmentStatuses = Ember.Object.extend(AppointmentStatuses).create();
+  assert.deepEqual(appointmentStatuses.get('appointmentStatuses'), [
+    {
+      id: 'Scheduled',
+      value: 'Scheduled'
+    },
+    {
+      id: 'Canceled',
+      value: 'Canceled'
+    },
+    {
+      id: 'Missed',
+      value: 'Missed'
+    }
+  ]);
+});
+
+test('appointmentStatusesWithEmpty', function(assert) {
+  let appointmentStatuses = Ember.Object.extend(AppointmentStatuses).create();
+  assert.deepEqual(appointmentStatuses.get('appointmentStatusesWithEmpty'), [
+    {
+      id: '',
+      value: ''
+    },
+    {
+      id: 'Scheduled',
+      value: 'Scheduled'
+    },
+    {
+      id: 'Canceled',
+      value: 'Canceled'
+    },
+    {
+      id: 'Missed',
+      value: 'Missed'
+    }
+  ]);
+});


### PR DESCRIPTION
**Changes proposed in this pull request:**
- Add unit mixin test appointment-status AppointmentStatuses
    
New creation of mixin unit test section. Following format of util with
the exception of leaving "Unit | Mixin" singular. All others appear to
be in the singular format except "Unit | Utils

cc @HospitalRun/core-maintainers