### PR TITLE
Add unit mixin tests for date-format and can-edit-requested

### DIFF
--- a/tests/unit/mixins/can-edit-requested-test.js
+++ b/tests/unit/mixins/can-edit-requested-test.js
@@ -1,0 +1,19 @@
+import CanEditRequested from 'hospitalrun/mixins/can-edit-requested';
+import { moduleFor, test } from 'ember-qunit';
+import Ember from 'ember';
+
+moduleFor('mixin:can-edit-requested', 'Unit | Mixin | can-edit-requested');
+
+test('canEdit', function(assert) {
+  let canEditRequested = Ember.Object.extend(CanEditRequested).create({
+    status: 'Requested'
+  });
+
+  assert.strictEqual(canEditRequested.get('canEdit'), true);
+});
+
+test('canEdit false', function(assert) {
+  let canEditRequested = Ember.Object.extend(CanEditRequested).create();
+
+  assert.strictEqual(canEditRequested.get('canEdit'), false);
+});

--- a/tests/unit/mixins/date-format-test.js
+++ b/tests/unit/mixins/date-format-test.js
@@ -1,0 +1,27 @@
+import DateFormat from 'hospitalrun/mixins/date-format';
+import { moduleFor, test } from 'ember-qunit';
+import Ember from 'ember';
+
+moduleFor('mixin:date-format', 'Unit | Mixin | date-format');
+
+test('dateToTime', function(assert) {
+  let dateFormat = Ember.Object.extend(DateFormat).create();
+
+  assert.strictEqual(
+    dateFormat.dateToTime(new Date(1481665085175)),
+    1481665085175,
+    'Should return correct time'
+  );
+
+  assert.strictEqual(
+    dateFormat.dateToTime(),
+    undefined,
+    'Should return undefined for no argument'
+  );
+
+  assert.strictEqual(
+    dateFormat.dateToTime(1481665085175),
+    undefined,
+    'Should return undefined for non Date object'
+  );
+});


### PR DESCRIPTION
**Changes proposed in this pull request:**
- Add unit mixin test for `date-format`
- Add unit mixin test for `can-edit-requested`

cc @HospitalRun/core-maintainers
