### PR TITLE
Define Incorrect Behavior of haveInvoiceItems

### DIFF
--- a/app/models/inventory-batch.js
+++ b/app/models/inventory-batch.js
@@ -7,7 +7,7 @@ import Ember from 'ember';
 export default AbstractModel.extend({
   haveInvoiceItems() {
     let invoiceItems = this.get('invoiceItems');
-    return (Ember.isEmpty(invoiceItems));
+    return !Ember.isEmpty(invoiceItems);
   },
 
   validations: {

--- a/app/models/inventory-batch.js
+++ b/app/models/inventory-batch.js
@@ -16,7 +16,7 @@ export default AbstractModel.extend({
     },
     inventoryItemTypeAhead: {
       presence: {
-        if(object) {
+        unless(object) {
           return object.haveInvoiceItems();
         }
       }
@@ -27,7 +27,7 @@ export default AbstractModel.extend({
         messages: {
           greaterThan: 'must be greater than 0'
         },
-        if(object) {
+        unless(object) {
           return object.haveInvoiceItems();
         }
       }
@@ -38,7 +38,7 @@ export default AbstractModel.extend({
         messages: {
           greaterThan: 'must be greater than 0'
         },
-        if(object) {
+        unless(object) {
           return object.haveInvoiceItems();
         }
       }

--- a/tests/unit/models/inventory-batch-test.js
+++ b/tests/unit/models/inventory-batch-test.js
@@ -1,0 +1,22 @@
+import { moduleForModel, test } from 'ember-qunit';
+
+moduleForModel('inventory-batch', 'Unit | Model | inventory-batch', {
+  needs: [
+    'ember-validations@validator:local/presence',
+    'ember-validations@validator:local/numericality'
+  ]
+});
+
+test('haveInvoiceItems', function(assert) {
+  let inventoryBatch = this.subject({
+    invoiceItems: ['test']
+  });
+
+  assert.strictEqual(inventoryBatch.haveInvoiceItems(), false);
+});
+
+test('haveInvoiceItems false', function(assert) {
+  let inventoryBatch = this.subject();
+
+  assert.strictEqual(inventoryBatch.haveInvoiceItems(), true);
+});

--- a/tests/unit/models/inventory-batch-test.js
+++ b/tests/unit/models/inventory-batch-test.js
@@ -1,4 +1,8 @@
 import { moduleForModel, test } from 'ember-qunit';
+import {
+  testValidPropertyValues,
+  testInvalidPropertyValues
+} from '../../helpers/validate-properties';
 
 moduleForModel('inventory-batch', 'Unit | Model | inventory-batch', {
   needs: [
@@ -9,7 +13,7 @@ moduleForModel('inventory-batch', 'Unit | Model | inventory-batch', {
 
 test('haveInvoiceItems', function(assert) {
   let inventoryBatch = this.subject({
-    invoiceItems: ['test']
+    invoiceItems: ['test have']
   });
 
   assert.strictEqual(inventoryBatch.haveInvoiceItems(), true);
@@ -20,3 +24,30 @@ test('haveInvoiceItems false', function(assert) {
 
   assert.strictEqual(inventoryBatch.haveInvoiceItems(), false);
 });
+
+testValidPropertyValues('dateReceived', ['test dr']);
+testInvalidPropertyValues('dateReceived', [undefined]);
+
+testValidPropertyValues('inventoryItemTypeAhead', ['test']);
+testInvalidPropertyValues('inventoryItemTypeAhead', [undefined]);
+// Test skip validation
+testValidPropertyValues('inventoryItemTypeAhead', [undefined], function(subject) {
+  subject.set('invoiceItems', ['item']);
+});
+
+testValidPropertyValues('quantity', [0.001, 1, '123']);
+testInvalidPropertyValues('quantity', [-1, 0, '-1']);
+// Test skip validation
+testValidPropertyValues('quantity', [-1], function(subject) {
+  subject.set('invoiceItems', ['item']);
+});
+
+testValidPropertyValues('purchaseCost', [0.001, 1, '123']);
+testInvalidPropertyValues('purchaseCost', [-1, 0, '-1']);
+// Test skip validation
+testValidPropertyValues('purchaseCost', [-1], function(subject) {
+  subject.set('invoiceItems', ['item']);
+});
+
+testValidPropertyValues('vendor', ['test']);
+testInvalidPropertyValues('vendor', [undefined]);

--- a/tests/unit/models/inventory-batch-test.js
+++ b/tests/unit/models/inventory-batch-test.js
@@ -12,11 +12,11 @@ test('haveInvoiceItems', function(assert) {
     invoiceItems: ['test']
   });
 
-  assert.strictEqual(inventoryBatch.haveInvoiceItems(), false);
+  assert.strictEqual(inventoryBatch.haveInvoiceItems(), true);
 });
 
 test('haveInvoiceItems false', function(assert) {
   let inventoryBatch = this.subject();
 
-  assert.strictEqual(inventoryBatch.haveInvoiceItems(), true);
+  assert.strictEqual(inventoryBatch.haveInvoiceItems(), false);
 });


### PR DESCRIPTION
**Changes proposed in this pull request:**
- Define incorrect behavior of `InventoryBatch.haveInvoiceItems()` in
  model unit test
    
`haveInvoiceItems` returns `true` if `invoiceItems` is empty. This
should likely be reversed or method name should change.

cc @HospitalRun/core-maintainers