### PR TITLE
Define issues with MedicationDetails and tests

### DIFF
--- a/app/mixins/medication-details.js
+++ b/app/mixins/medication-details.js
@@ -2,6 +2,13 @@ import Ember from 'ember';
 import DS from 'ember-data';
 export default Ember.Mixin.create({
   // Denormalized medication details so that inventory records do not need to be retrieved
+
+  /**
+   * Does not return name on first call if medicationName is
+   * not set and name is obtained via inventoryAttribute
+   * Additional calls will return the name as medicationName
+   * will then be set
+   */
   getMedicationName(inventoryAttribute) {
     let medicationTitle = this.get('medicationTitle');
     if (!Ember.isEmpty(medicationTitle)) {
@@ -9,7 +16,7 @@ export default Ember.Mixin.create({
     } else {
       let inventoryObject = this.get(inventoryAttribute);
       if (inventoryObject.then) {
-        this.get(inventoryAttribute).then((inventoryItem) => {
+        inventoryObject.then((inventoryItem) => {
           this.set('medicationTitle', inventoryItem.get('name'));
         });
       } else {
@@ -18,14 +25,25 @@ export default Ember.Mixin.create({
     }
   },
 
+  /**
+   * Does not return name on first call if medicationName is
+   * not set and price is obtained via inventoryAttribute
+   * Additional calls will return the price as medicationName
+   * will then be set
+   */
   getMedicationPrice(inventoryAttribute) {
     let priceOfMedication = this.get('priceOfMedication');
     if (!Ember.isEmpty(priceOfMedication)) {
       return priceOfMedication;
     } else {
-      this.get(inventoryAttribute).then((inventoryItem) => {
-        this.set('priceOfMedication', inventoryItem.get('price'));
-      });
+      let inventoryObject = this.get(inventoryAttribute);
+      if (inventoryObject.then) {
+        inventoryObject.then((inventoryItem) => {
+          this.set('priceOfMedication', inventoryItem.get('price'));
+        });
+      } else {
+        this.set('priceOfMedication', inventoryObject.get('price'));
+      }
     }
   },
 
@@ -41,7 +59,7 @@ export default Ember.Mixin.create({
       } else {
         let objectInventoryItem = this.get(inventoryAttribute);
         if (objectInventoryItem.then) {
-          this.get(inventoryAttribute).then((inventoryItem) => {
+          objectInventoryItem.then((inventoryItem) => {
             resolve({
               name: inventoryItem.get('name'),
               price: inventoryItem.get('price')

--- a/app/mixins/medication-details.js
+++ b/app/mixins/medication-details.js
@@ -26,9 +26,9 @@ export default Ember.Mixin.create({
   },
 
   /**
-   * Does not return name on first call if medicationName is
+   * Does not return name on first call if priceOfMedication is
    * not set and price is obtained via inventoryAttribute
-   * Additional calls will return the price as medicationName
+   * Additional calls will return the price as priceOfMedication
    * will then be set
    */
   getMedicationPrice(inventoryAttribute) {

--- a/tests/unit/mixins/medication-details-test.js
+++ b/tests/unit/mixins/medication-details-test.js
@@ -104,7 +104,6 @@ test('getMedicationPrice attribute', function(assert) {
 
   let medicationDetails = this.subject({ inventoryItem });
 
-  let medicationPrice;
   /**
    * We run this twice because if this gets the value from
    * the attribute it does not actually return the value

--- a/tests/unit/mixins/medication-details-test.js
+++ b/tests/unit/mixins/medication-details-test.js
@@ -1,0 +1,133 @@
+import MedicationDetails from 'hospitalrun/mixins/medication-details';
+import { moduleFor, test } from 'ember-qunit';
+import Ember from 'ember';
+import DS from 'ember-data';
+
+moduleFor('mixin:medication-details', 'Unit | Mixin | medication-details', {
+  needs: [
+    'ember-validations@validator:local/numericality',
+    'ember-validations@validator:local/presence',
+    'model:inventory',
+    'model:inv-purchase',
+    'model:inv-location'
+  ],
+  subject(attrs) {
+    let subject;
+    Ember.run(() => {
+      let Test = DS.Model.extend(MedicationDetails);
+      this.register('model:test', Test);
+      subject = this.store().createRecord('test', attrs);
+    });
+
+    return subject;
+  },
+  store() {
+    return this.container.lookup('service:store');
+  }
+});
+
+test('getMedicationName', function(assert) {
+  let medicationDetails = this.subject({
+    medicationTitle: 'Medication Title'
+  });
+
+  assert.strictEqual(medicationDetails.getMedicationName(), 'Medication Title');
+});
+
+test('getMedicationName prefer medicationTitle', function(assert) {
+  let inventoryItem;
+  Ember.run(() => {
+    inventoryItem = this.store().createRecord('inventory', {
+      name: 'Test Item'
+    });
+  });
+
+  let medicationDetails = this.subject({
+    medicationTitle: 'Medication Title',
+    inventoryItem
+  });
+
+  assert.strictEqual(medicationDetails.getMedicationName('inventoryItem'), 'Medication Title');
+});
+
+test('getMedicationName attribute', function(assert) {
+  let inventoryItem;
+  Ember.run(() => {
+    inventoryItem = this.store().createRecord('inventory', {
+      name: 'Test Item'
+    });
+  });
+
+  let medicationDetails = this.subject({ inventoryItem });
+  /**
+   * We run this twice because if this gets the value from
+   * the attribute it does not actually return the value
+   */
+  Ember.run(() => medicationDetails.getMedicationName('inventoryItem'));
+
+  assert.strictEqual(medicationDetails.getMedicationName('inventoryItem'), 'Test Item');
+});
+
+test('getMedicationPrice', function(assert) {
+  let medicationDetails = this.subject({
+    priceOfMedication: 15.50
+  });
+
+  assert.strictEqual(medicationDetails.getMedicationPrice(), 15.50);
+});
+
+test('getMedicationPrice prefer priceOfMedication', function(assert) {
+  let inventoryItem;
+  Ember.run(() => {
+    inventoryItem = this.store().createRecord('inventory', {
+      name: 'Test Item',
+      price: 12.15
+    });
+  });
+
+  let medicationDetails = this.subject({
+    priceOfMedication: 15.5,
+    inventoryItem
+  });
+
+  assert.strictEqual(medicationDetails.getMedicationPrice('inventoryItem'), 15.5);
+});
+
+test('getMedicationPrice attribute', function(assert) {
+  let inventoryItem;
+  Ember.run(() => {
+    inventoryItem = this.store().createRecord('inventory', {
+      name: 'Test Item',
+      price: 22.33
+    });
+  });
+
+  let medicationDetails = this.subject({ inventoryItem });
+
+  let medicationPrice;
+  /**
+   * We run this twice because if this gets the value from
+   * the attribute it does not actually return the value
+   */
+  Ember.run(() => medicationDetails.getMedicationPrice('inventoryItem'));
+
+  assert.strictEqual(medicationDetails.getMedicationPrice('inventoryItem'), 22.33);
+});
+
+test('getMedicationDetails', function(assert) {
+  let done = assert.async();
+
+  let medicationDetails = this.subject({
+    medicationTitle: 'Medication Title',
+    priceOfMedication: 65.77
+  });
+
+  medicationDetails.getMedicationDetails().then((result) => {
+    assert.deepEqual(result, {
+      name: 'Medication Title',
+      price: 65.77
+    });
+
+    done();
+  });
+});


### PR DESCRIPTION
Fixes Issue with promise not being detected and defines issues with return values

**Changes proposed in this pull request:**
- Add mixin unit test for `MedicationDetails`
- Define issue where `getMedicationPrice` and `getMedicationName` do
  not return a value on first retrieval
- Add documentation explaining issue with return values
- Fix error on `getMedicationPrice` if attribute is not a promise
- Remove duplicate calls to `get` when a promise is detected

Not changing methods to use `Ember.RSVP.Promise` as anything that uses
those methods would currently not be setup to handle a returned
promise. This may want to be adjusted in the future.

cc @HospitalRun/core-maintainers