### PR TITLE
Show Failing function in photo model (Test Intentionally Fails)

### DIFF
--- a/tests/unit/models/photo-test.js
+++ b/tests/unit/models/photo-test.js
@@ -1,0 +1,23 @@
+import { moduleForModel, test } from 'ember-qunit';
+import Ember from 'ember';
+
+moduleForModel('photo', 'Unit | Model | photo', {
+  needs: [
+    'model:patient'
+  ]
+});
+
+test('downloadImageFromServer', function(assert) {
+  let photo = this.subject();
+
+  let imageRecord = Ember.Object.create({
+    url: 'http://example.com',
+    patientId: '123'
+  });
+
+  /**
+   * Fails with
+   * `this.getPatientDirectory is not a function`
+   */
+  assert.ok(photo.downloadImageFromServer(imageRecord), 'This will fail with an error');
+});


### PR DESCRIPTION
**Changes proposed in this pull request:**
- Add test that will fail with
  `this.getPatientDirectory is not a function`

`getPatientDirectory` does not appear to be defined anywhere and I do
not believe `downloadImageFromServer` is used anywhere as well.

Recommend removing the method or at minimum adding documentation that it
throws an error if used

cc @HospitalRun/core-maintainers