### PR TITLE
Remove downloadImageFromServer from photo model

### DIFF
--- a/app/models/photo.js
+++ b/app/models/photo.js
@@ -1,6 +1,5 @@
 import AbstractModel from 'hospitalrun/models/abstract';
 import DS from 'ember-data';
-import Ember from 'ember';
 
 export default AbstractModel.extend({
   _attachments: DS.attr(), // Temporarily store file as attachment until it gets uploaded to the server
@@ -11,22 +10,5 @@ export default AbstractModel.extend({
     async: false
   }),
   caption: DS.attr('string'),
-  url: DS.attr('string'),
-
-  downloadImageFromServer(imageRecord) {
-    let me = this;
-    let url = imageRecord.get('url');
-    let xhr = new XMLHttpRequest();
-    if (!Ember.isEmpty(url)) {
-      // Make sure directory exists or is created before downloading.
-      this.getPatientDirectory(imageRecord.get('patientId'));
-      xhr.open('GET', url, true);
-      xhr.responseType = 'blob';
-      xhr.onload = function() {
-        let file = new Blob([xhr.response]);
-        me.addImageToFileStore(file, null, imageRecord);
-      };
-      xhr.send();
-    }
-  }
+  url: DS.attr('string')
 });


### PR DESCRIPTION
Closes #881

**Changes proposed in this pull request:**
- Remove `downloadImageFromServer` from photo model

Function will throw an error if used and is not currently used in code
base

cc @HospitalRun/core-maintainers