### PR TITLE
Add abstract-edit-controller tests and Add Translations

### DIFF
--- a/app/controllers/abstract-edit-controller.js
+++ b/app/controllers/abstract-edit-controller.js
@@ -99,7 +99,11 @@ export default Ember.Controller.extend(EditPanelProps, IsUpdateDisabled, ModalHe
     },
 
     showDisabledDialog() {
-      this.displayAlert('Warning!!!!', 'Please fill in required fields (marked with *) and correct the errors before saving.');
+      let i18n = this.get('i18n');
+      this.displayAlert(
+        i18n.t('alerts.warningExclamation'),
+        i18n.t('messages.requiredFieldsCorrectErrors')
+      );
     },
 
     /**
@@ -113,11 +117,19 @@ export default Ember.Controller.extend(EditPanelProps, IsUpdateDisabled, ModalHe
           this.saveModel(skipAfterUpdate);
         }).catch((err) => {
           if (!err.ignore) {
-            this.displayAlert('Error!!!!', `An error occurred while attempting to save: ${JSON.stringify(err)}`);
+            let i18n = this.get('i18n');
+            this.displayAlert(
+              i18n.t('alerts.errorExclamation'),
+              i18n.t('messages.saveActionException', { message: JSON.stringify(err) })
+            );
           }
         });
       } catch(ex) {
-        this.displayAlert('Error!!!!', `An error occurred while attempting to save: ${ex}`);
+        let i18n = this.get('i18n');
+        this.displayAlert(
+          i18n.t('alerts.errorExclamation'),
+          i18n.t('messages.saveActionException', { message: JSON.stringify(ex) })
+        );
       }
     }
   },

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -368,10 +368,14 @@ export default {
     newPatientHasToBeCreated: 'A new patient needs to be created...Please wait..',
     noNotesAvailable: 'No additional clinical notes are available for this visit.',
     sorry: 'Sorry, something went wrong...',
-    forAuthorizedPersons: 'This report is for authorized persons only.'
+    forAuthorizedPersons: 'This report is for authorized persons only.',
+    requiredFieldsCorrectErrors: 'Please fill in required fields (marked with *) and correct the errors before saving.',
+    saveActionException: 'An error occurred while attempting to save: {{message}}'
   },
   alerts: {
-    pleaseWait: 'Please Wait'
+    pleaseWait: 'Please Wait',
+    warningExclamation: 'Warning!!!!',
+    errorExclamation: 'Error!!!!'
   },
   headings: {
     chargedItems: 'Charged Items'

--- a/tests/unit/controllers/abstract-edit-controller-test.js
+++ b/tests/unit/controllers/abstract-edit-controller-test.js
@@ -1,0 +1,128 @@
+import { moduleFor, test } from 'ember-qunit';
+import Ember from 'ember';
+import tHelper from 'ember-i18n/helper';
+import localeConfig from 'ember-i18n/config/en';
+
+moduleFor('controller:abstract-edit-controller', 'Unit | Controller | abstract-edit-controller', {
+  needs: [
+    'service:i18n',
+    'locale:en/translations',
+    'locale:en/config',
+    'util:i18n/missing-message',
+    'util:i18n/compile-template',
+    'config:environment'
+  ],
+  beforeEach() {
+    // set the locale and the config
+    this.container.lookup('service:i18n').set('locale', 'en');
+    this.registry.register('locale:en/config', localeConfig);
+
+    // manually inject the i18n service as initialzer does not run
+    // in unit test
+    Ember.getOwner(this).inject('controller', 'i18n', 'service:i18n');
+
+    // register t helper
+    this.registry.register('helper:t', tHelper);
+  }
+});
+
+test('cancelButtonText', function(assert) {
+  assert.equal(this.subject().get('cancelButtonText'), 'Return');
+});
+
+test('cancelButtonText hasDirtyAttributes', function(assert) {
+  let controller = this.subject({
+    model: {
+      hasDirtyAttributes: true
+    }
+  });
+
+  assert.equal(controller.get('cancelButtonText'), 'Cancel');
+});
+
+test('disabledAction', function(assert) {
+  assert.equal(this.subject().get('disabledAction'), 'showDisabledDialog');
+});
+
+test('disabledAction invalid', function(assert) {
+  let controller = this.subject({
+    model: {
+      isValid: true
+    }
+  });
+
+  assert.strictEqual(controller.get('disabledAction'), undefined);
+});
+
+test('isNewOrDeleted', function(assert) {
+  assert.strictEqual(this.subject().get('isNewOrDeleted'), undefined);
+});
+
+test('isNewOrDeleted new', function(assert) {
+  let controller = this.subject({
+    model: {
+      isNew: true,
+      isDeleted: false
+    }
+  });
+
+  assert.strictEqual(controller.get('isNewOrDeleted'), true);
+});
+
+test('isNewOrDeleted deleted', function(assert) {
+  let controller = this.subject({
+    model: {
+      isNew: false,
+      isDeleted: true
+    }
+  });
+
+  assert.strictEqual(controller.get('isNewOrDeleted'), true);
+});
+
+test('updateButtonText', function(assert) {
+  assert.equal(this.subject().get('updateButtonText'), 'Update');
+});
+
+test('updateButtonText isNew', function(assert) {
+  let controller = this.subject({
+    model: {
+      isNew: true
+    }
+  });
+
+  assert.equal(controller.get('updateButtonText'), 'Add');
+});
+
+test('actions.showDisabledDialog message', function(assert) {
+  let alertMessage, alertTitle;
+  let controller = this.subject();
+
+  controller.displayAlert = function stub(title, message) {
+    alertTitle = title;
+    alertMessage = message;
+  };
+
+  controller.send('showDisabledDialog');
+
+  assert.equal(alertTitle, 'Warning!!!!');
+  assert.equal(alertMessage, 'Please fill in required fields (marked with *) and correct the errors before saving.');
+});
+
+test('actions.update exception message', function(assert) {
+  let alertMessage, alertTitle;
+  let controller = this.subject();
+
+  controller.beforeUpdate = function() {
+    throw 'Test';
+  };
+  controller.displayAlert = function stub(title, message) {
+    alertTitle = title;
+    alertMessage = message;
+  };
+
+  controller.send('update');
+
+  assert.equal(alertTitle, 'Error!!!!');
+  assert.equal(alertMessage, 'An error occurred while attempting to save: &quot;Test&quot;');
+});


### PR DESCRIPTION
**Changes proposed in this pull request:**
- Add abstract-edit-controller unit tests
- Add translations for `showDisplayDialog` action
- Add translations for `update` action on exceptions and failed promise

cc @HospitalRun/core-maintainers