### PR TITLE
Add abstract controller unit tests and translations

### DIFF
--- a/app/controllers/abstract-report-controller.js
+++ b/app/controllers/abstract-report-controller.js
@@ -112,9 +112,9 @@ export default Ember.Controller.extend(DateFormat, ModalHelper, NumberFormat, Pa
   },
 
   _notifyReportError(errorMessage) {
-    let alertMessage = 'An error was encountered while generating the requested report.  Please let your system administrator know that you have encountered an error.';
+    let i18n = this.get('i18n');
     this.closeProgressModal();
-    this.displayAlert('Error Generating Report', alertMessage);
+    this.displayAlert(i18n.t('alerts.reportError'), i18n.t('messages.reportError'));
     throw new Error(errorMessage);
   },
 

--- a/app/controllers/abstract-report-controller.js
+++ b/app/controllers/abstract-report-controller.js
@@ -144,10 +144,23 @@ export default Ember.Controller.extend(DateFormat, ModalHelper, NumberFormat, Pa
 
     let reportDesc = reportTypes.findBy('value', reportType);
     if (Ember.isEmpty(startDate)) {
-      this.set('reportTitle', `${reportDesc.name} Report ${formattedEndDate}`);
+      this.set('reportTitle', this.get('i18n').t(
+        'inventory.reports.titleSingleDate',
+        {
+          name: reportDesc.name,
+          date: formattedEndDate
+        }
+      ));
     } else {
       formattedStartDate = moment(startDate).format('l');
-      this.set('reportTitle', `${reportDesc.name} Report ${formattedStartDate} - ${formattedEndDate}`);
+      this.set('reportTitle', this.get('i18n').t(
+        'inventory.reports.titleDateRange',
+        {
+          name: reportDesc.name,
+          startDate: formattedStartDate,
+          endDate: formattedEndDate
+        }
+      ));
     }
   },
 

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -370,12 +370,14 @@ export default {
     sorry: 'Sorry, something went wrong...',
     forAuthorizedPersons: 'This report is for authorized persons only.',
     requiredFieldsCorrectErrors: 'Please fill in required fields (marked with *) and correct the errors before saving.',
-    saveActionException: 'An error occurred while attempting to save: {{message}}'
+    saveActionException: 'An error occurred while attempting to save: {{message}}',
+    reportError: 'An error was encountered while generating the requested report.  Please let your system administrator know that you have encountered an error.'
   },
   alerts: {
     pleaseWait: 'Please Wait',
     warningExclamation: 'Warning!!!!',
-    errorExclamation: 'Error!!!!'
+    errorExclamation: 'Error!!!!',
+    reportError: 'Error Generating Report'
   },
   headings: {
     chargedItems: 'Charged Items'

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -604,7 +604,9 @@ export default {
       stockTransferDetail: 'Detailed Stock Transfer',
       stockTransferSum: 'Summary Stock Transfer',
       stockUsageDetail: 'Detailed Stock Usage',
-      stockUsageSum: 'Summary Stock Usage'
+      stockUsageSum: 'Summary Stock Usage',
+      titleSingleDate: '{{name}} Report {{date}}',
+      titleDateRange: '{{name}} Report {{startDate}} - {{endDate}}'
     },
     titles: {
       addPurchase: 'Add Purchase',

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "ember-resolver": "^2.0.3",
     "ember-select-list": "0.9.5",
     "ember-simple-auth": "^1.1.0",
+    "ember-sinon-qunit": "^1.4.0",
     "ember-truth-helpers": "1.2.0",
     "ember-validations": "2.0.0-alpha.5",
     "eslint-plugin-ember-suave": "^1.0.0",

--- a/tests/unit/controllers/abstract-delete-controller-test.js
+++ b/tests/unit/controllers/abstract-delete-controller-test.js
@@ -1,0 +1,61 @@
+import { moduleFor } from 'ember-qunit';
+import test from 'ember-sinon-qunit/test-support/test';
+import Ember from 'ember';
+import DS from 'ember-data';
+
+moduleFor('controller:abstract-delete-controller', 'Unit | Controller | abstract-delete-controller', {
+  unit: true,
+  testModel(attrs) {
+    return Ember.run(() => {
+      this.register('model:test', DS.Model);
+      return this.store().createRecord('test', attrs);
+    });
+  },
+  store() {
+    return this.container.lookup('service:store');
+  },
+  sendStub(controller) {
+    let once = false;
+    let originalSend = controller.send.bind(controller);
+    return (arg) => {
+      if (once) {
+        return;
+      }
+
+      once = true;
+      originalSend(arg);
+    };
+  }
+});
+
+test('actions.cancel', function(assert) {
+  let controller = this.subject();
+  let send = this.stub(controller, 'send', this.sendStub(controller));
+
+  controller.send('cancel');
+
+  assert.equal(send.getCall(0).args[0], 'cancel');
+  assert.equal(send.getCall(1).args[0], 'closeModal', 'Should close modal');
+});
+
+test('actions.delete', function(assert) {
+  let controller = this.subject({
+    model: this.testModel({
+      save: () => {},
+      unloadRecord: () => {}
+    })
+  });
+  let send = this.stub(controller, 'send', this.sendStub(controller));
+  let save = this.stub(controller.get('model'), 'save', () => {
+    return new Ember.RSVP.Promise((resolve) => resolve());
+  });
+  let unloadRecord = this.stub(controller.get('model'), 'unloadRecord');
+
+  Ember.run(() => controller.send('delete'));
+
+  assert.equal(send.getCall(0).args[0], 'delete');
+  assert.ok(save.calledOnce, 'Should save model');
+  assert.strictEqual(controller.get('model.archived'), true, 'Should archive model');
+  assert.ok(unloadRecord.calledOnce, 'Should unload record of model');
+  assert.equal(send.getCall(1).args[0], 'closeModal', 'Should close modal');
+});

--- a/tests/unit/controllers/abstract-paged-controller-test.js
+++ b/tests/unit/controllers/abstract-paged-controller-test.js
@@ -1,0 +1,154 @@
+import { moduleFor, test } from 'ember-qunit';
+import sinonTest from 'ember-sinon-qunit/test-support/test';
+import Ember from 'ember';
+import DS from 'ember-data';
+
+moduleFor('controller:abstract-paged-controller', 'Unit | Controller | abstract-paged-controller', {
+  unit: true,
+  testModel(attrs) {
+    return Ember.run(() => {
+      this.register('model:test', DS.Model);
+      return this.store().createRecord('test', attrs);
+    });
+  },
+  store() {
+    return this.container.lookup('service:store');
+  }
+});
+
+test('showActions', function(assert) {
+  let controller = this.subject({
+    canAdd: false,
+    canEdit: true,
+    canDelete: false
+  });
+
+  assert.strictEqual(controller.get('showActions'), true);
+});
+
+test('disablePreviousPage', function(assert) {
+  let controller = this.subject();
+
+  assert.strictEqual(controller.get('disablePreviousPage'), true);
+});
+
+test('disablePreviousPage false', function(assert) {
+  let controller = this.subject({
+    previousStartKey: 'test'
+  });
+
+  assert.strictEqual(controller.get('disablePreviousPage'), false);
+});
+
+test('disableNextPage', function(assert) {
+  let controller = this.subject();
+
+  assert.strictEqual(controller.get('disableNextPage'), true);
+});
+
+test('disableNextPage false', function(assert) {
+  let controller = this.subject({
+    nextStartKey: 'test'
+  });
+
+  assert.strictEqual(controller.get('disableNextPage'), false);
+});
+
+test('showPagination', function(assert) {
+  let controller = this.subject({
+    previousStartKey: 'test'
+  });
+
+  assert.strictEqual(controller.get('showPagination'), true);
+});
+
+test('showPagination false', function(assert) {
+  let controller = this.subject();
+
+  assert.strictEqual(controller.get('showPagination'), false);
+});
+
+test('hasRecords', function(assert) {
+  let controller = this.subject({
+    model: this.testModel({
+      length: 1
+    })
+  });
+
+  assert.strictEqual(controller.get('hasRecords'), true);
+});
+
+test('hasRecords false', function(assert) {
+  let controller = this.subject({
+    model: this.testModel({
+      length: 0
+    })
+  });
+
+  assert.strictEqual(controller.get('hasRecords'), false);
+});
+
+test('hasRecords false empty', function(assert) {
+  assert.strictEqual(this.subject().get('hasRecords'), false);
+});
+
+sinonTest('actions.nextPage', function(assert) {
+  let controller = this.subject({
+    nextStartKey: 'next',
+    previousStartKeys: ['prev1', 'prev2'],
+    firstKey: 'first'
+  });
+  let showProgressModal = this.stub(controller, 'showProgressModal');
+
+  controller.send('nextPage');
+
+  assert.strictEqual(controller.get('previousStartKey'), 'first', 'Should set previousStartKey');
+  assert.deepEqual(controller.get('previousStartKeys'), ['prev1', 'prev2', 'first'], 'Should set previousStartKeys');
+  assert.strictEqual(controller.get('startKey'), 'next', 'Should set startKey');
+  assert.ok(showProgressModal.calledOnce, 'Should show progress modal');
+});
+
+sinonTest('actions.previousPage', function(assert) {
+  let controller = this.subject({
+    previousStartKey: 'prev',
+    previousStartKeys: ['prev1', 'prev2', 'prev3']
+  });
+  let showProgressModal = this.stub(controller, 'showProgressModal');
+
+  controller.send('previousPage');
+
+  assert.strictEqual(controller.get('startKey'), 'prev', 'Should set startKey');
+  assert.strictEqual(controller.get('previousStartKey'), 'prev2', 'Should set previousStartKey');
+  assert.deepEqual(controller.get('previousStartKeys'), ['prev1'], 'Should set previousStartKey');
+  assert.ok(showProgressModal.calledOnce, 'Should show progress modal');
+});
+
+/**
+ * @todo verify that not clearing `nextStartKey` and `firstKey`
+ * is the intended behavior
+ */
+sinonTest('actions.sortByKey', function(assert) {
+  let controller = this.subject({
+    nextStartKey: 'next',
+    previousStartKey: 'prev',
+    previousStartKeys: ['prev1', 'prev2'],
+    firstKey: 'first',
+    startKey: 'start'
+  });
+  let showProgressModal = this.stub(controller, 'showProgressModal');
+
+  controller.send('sortByKey', 'sort', 'desc');
+
+  // These two assertions preserve current implementation
+  assert.strictEqual(controller.get('nextStartKey'), 'next', 'Should not change nextStartKey');
+  assert.strictEqual(controller.get('firstKey'), 'first', 'Should not change firstKey');
+
+  assert.strictEqual(controller.get('startKey'), null, 'Should clear startKey');
+  assert.deepEqual(controller.get('previousStartKeys'), [], 'Should clear previousStartKeys');
+  assert.strictEqual(controller.get('previousStartKey'), null, 'Should clear previousStartKey');
+
+  assert.strictEqual(controller.get('sortDesc'), 'desc', 'Should set sortDesc');
+  assert.strictEqual(controller.get('sortKey'), 'sort', 'Should set sortKey');
+
+  assert.ok(showProgressModal.calledOnce, 'Should show progress modal');
+});

--- a/tests/unit/controllers/abstract-report-controller-test.js
+++ b/tests/unit/controllers/abstract-report-controller-test.js
@@ -1,0 +1,113 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('controller:abstract-report-controller', 'Unit | Controller | abstract-report-controller', {
+  unit: true
+});
+
+test('actions.firstPage', function(assert) {
+  let controller = this.subject();
+
+  controller.send('firstPage');
+
+  assert.strictEqual(controller.get('offset'), 0);
+});
+
+test('actions.nextPage', function(assert) {
+  let controller = this.subject({
+    offset: 8,
+    limit: 4
+  });
+
+  controller.send('nextPage');
+
+  assert.strictEqual(controller.get('offset'), 12);
+});
+
+test('actions.previousPage', function(assert) {
+  let controller = this.subject({
+    offset: 8,
+    limit: 2
+  });
+
+  controller.send('previousPage');
+
+  assert.strictEqual(controller.get('offset'), 6);
+});
+
+test('actions.lastPage', function(assert) {
+  let controller = this.subject({
+    limit: 1,
+    offset: 0,
+    reportRows: ['one', 'two', 'three']
+  });
+
+  controller.send('lastPage');
+
+  assert.strictEqual(controller.get('offset'), 3);
+});
+
+test('currentReportRows', function(assert) {
+  let controller = this.subject({
+    limit: 2,
+    offset: 1,
+    reportRows: ['one', 'two', 'three', 'four']
+  });
+
+  assert.deepEqual(controller.get('currentReportRows'), ['two', 'three']);
+});
+
+test('disablePreviousPage', function(assert) {
+  let controller = this.subject({
+    offset: 0
+  });
+
+  assert.strictEqual(controller.get('disablePreviousPage'), true);
+});
+
+test('disablePreviousPage false', function(assert) {
+  let controller = this.subject({
+    offset: 2
+  });
+
+  assert.strictEqual(controller.get('disablePreviousPage'), false);
+});
+
+test('disableNextPage', function(assert) {
+  let controller = this.subject({
+    limit: 1,
+    offset: 2,
+    reportRows: ['one', 'two', 'three']
+  });
+
+  assert.strictEqual(controller.get('disableNextPage'), true);
+});
+
+test('disableNextPage false', function(assert) {
+  let controller = this.subject({
+    limit: 1,
+    offset: 1,
+    reportRows: ['one', 'two', 'three']
+  });
+
+  assert.strictEqual(controller.get('disableNextPage'), false);
+});
+
+test('showPagination', function(assert) {
+  let controller = this.subject({
+    limit: 1,
+    offset: 0,
+    reportRows: ['one', 'two', 'three']
+  });
+
+  assert.strictEqual(controller.get('showPagination'), true);
+});
+
+test('showPagination false', function(assert) {
+  let controller = this.subject({
+    limit: 3,
+    offset: 0,
+    reportRows: ['one', 'two', 'three']
+  });
+
+  assert.strictEqual(controller.get('showPagination'), false);
+});

--- a/tests/unit/controllers/abstract-report-controller-test.js
+++ b/tests/unit/controllers/abstract-report-controller-test.js
@@ -49,6 +49,77 @@ sinonTest('_notifyReportError', function(assert) {
   assert.ok(closeProgressModal.calledOnce, 'Should close progress modal');
 });
 
+sinonTest('_setReportTitle', function(assert) {
+  let controller = this.subject({
+    endDate: new Date(1482269979422),
+    startDate: new Date(1472269979422),
+    reportTypes: [
+      Ember.Object.create({
+        value: 'one',
+        name: 'Number One'
+      }),
+      Ember.Object.create({
+        value: 'two',
+        name: 'Number Two'
+      })
+    ],
+    reportType: 'two'
+  });
+
+  this.stub(window, 'moment', (function() {
+    let count = 0;
+    return () => {
+      if (count < 1) {
+        count += 1;
+        return {
+          format() {
+            return 'April 1st, 1996';
+          }
+        };
+      }
+
+      return {
+        format() {
+          return 'January 3rd, 1995';
+        }
+      };
+    };
+  }()));
+
+  controller._setReportTitle();
+
+  assert.equal(controller.get('reportTitle'), 'Number Two Report January 3rd, 1995 - April 1st, 1996');
+});
+
+sinonTest('_setReportTitle single date', function(assert) {
+  let controller = this.subject({
+    endDate: new Date(1472269979422),
+    reportTypes: [
+      Ember.Object.create({
+        value: 'one',
+        name: 'Number One'
+      }),
+      Ember.Object.create({
+        value: 'two',
+        name: 'Number Two'
+      })
+    ],
+    reportType: 'one'
+  });
+
+  this.stub(window, 'moment', () => {
+    return {
+      format() {
+        return 'April 3rd, 2015';
+      }
+    };
+  });
+
+  controller._setReportTitle();
+
+  assert.equal(controller.get('reportTitle'), 'Number One Report April 3rd, 2015');
+});
+
 test('actions.firstPage', function(assert) {
   let controller = this.subject();
 


### PR DESCRIPTION
**Changes proposed in this pull request:**
- Add unit tests for controller abstract-delete-controller
- Add dependency(devDependency) for ember-sinon-qunit for use in
  stubbing methods for proper test coverage
- Update documentation with `@todo` about possible unintended behavior
  of the `sortByKey` action
  The tests in this commit preserve the behavior as implemented. It is
  possible that `sortByKey` should also set `nextStartKey` and `startKey`
  to `null` as well.
- Add translations for `_notifyReportError` in
  abstract-report-controller
- Add unit test for `_notifyReportError`
- Add translations for `_setReportTitle` in abstract-report-controller
- Add unit tests for `_setReportTitle` with translations
- Add unit tests for abstract-report-controller
- Add unit tests from abstract-paged-controller

Finally needed the sinon devDependency here. I'll circle back after this is merged and pull the timekeeper stuff out.

Not 100% sure of where I should be putting the translations in the locale file. Just making a best guess so definitely let me know if I should move them to a better spot.

This is all in one big PR because of later tests needing sinon as well. I tried to keep the commits clean, so when reviewing it is probably easiest for you to step through the commit diffs if you are looking to get a closer look at the changes.

cc @HospitalRun/core-maintainers