### PR TITLE
Fix sortByKey not clearing all properties

### DIFF
--- a/app/controllers/abstract-paged-controller.js
+++ b/app/controllers/abstract-paged-controller.js
@@ -77,9 +77,11 @@ export default Ember.Controller.extend(PaginationProps, ProgressDialog, UserSess
       this.setProperties({
         previousStartKey: null,
         previousStartKeys: [],
+        nextStartKey: null,
         sortDesc,
         sortKey,
-        startKey: null
+        startKey: null,
+        firstKey: null
       });
       this.showProgressModal();
     }

--- a/tests/unit/controllers/abstract-paged-controller-test.js
+++ b/tests/unit/controllers/abstract-paged-controller-test.js
@@ -123,10 +123,6 @@ sinonTest('actions.previousPage', function(assert) {
   assert.ok(showProgressModal.calledOnce, 'Should show progress modal');
 });
 
-/**
- * @todo verify that not clearing `nextStartKey` and `firstKey`
- * is the intended behavior
- */
 sinonTest('actions.sortByKey', function(assert) {
   let controller = this.subject({
     nextStartKey: 'next',
@@ -139,10 +135,8 @@ sinonTest('actions.sortByKey', function(assert) {
 
   controller.send('sortByKey', 'sort', 'desc');
 
-  // These two assertions preserve current implementation
-  assert.strictEqual(controller.get('nextStartKey'), 'next', 'Should not change nextStartKey');
-  assert.strictEqual(controller.get('firstKey'), 'first', 'Should not change firstKey');
-
+  assert.strictEqual(controller.get('nextStartKey'), null, 'Should clear nextStartKey');
+  assert.strictEqual(controller.get('firstKey'), null, 'Should clear firstKey');
   assert.strictEqual(controller.get('startKey'), null, 'Should clear startKey');
   assert.deepEqual(controller.get('previousStartKeys'), [], 'Should clear previousStartKeys');
   assert.strictEqual(controller.get('previousStartKey'), null, 'Should clear previousStartKey');


### PR DESCRIPTION
**Changes proposed in this pull request:**
- Fix `sortByKey` not clearing all properties in
  abstract-paged-controller
- Add `firstKey` and `nextStartKey` to be set to `null`

Based upon discussion from #900 

cc @HospitalRun/core-maintainers