### PR TITLE
Move modal alert to inline

### DIFF
--- a/app/patients/edit/controller.js
+++ b/app/patients/edit/controller.js
@@ -645,13 +645,9 @@ export default AbstractEditController.extend(BloodTypes, DiagnosisActions, Retur
 
   afterUpdate(record) {
     this._updateSequence(record).then(() => {
-      this.send('openModal', 'dialog', Ember.Object.create({
-        title: this.get('i18n').t('patients.titles.savedPatient'),
-        message: this.get('i18n').t('patients.messages.savedPatient', record),
-        updateButtonAction: 'returnToPatient',
-        updateButtonText: this.get('i18n').t('patients.buttons.backToPatients'),
-        cancelButtonText: this.get('i18n').t('buttons.close')
-      }));
+      $('.message').show();
+      $('.message').text(this.get('i18n').t('patients.messages.savedPatient', record));
+      $(".message").delay(3000).fadeOut(100);
     });
   }
 

--- a/app/patients/edit/template.hbs
+++ b/app/patients/edit/template.hbs
@@ -464,4 +464,5 @@
       {{/unless}}
     </div>
   {{/em-form}}
+  <div class="alert alert-success message" style="display:none;"></div>
 {{/edit-panel}}


### PR DESCRIPTION
Fixes #377 

**Changes proposed in this pull request:**
- Take out modal
- Show inline alert above button
- Hide inline alert after 3000ms

![image](https://cloud.githubusercontent.com/assets/7412026/23329502/fa2844ea-fb74-11e6-8f4e-a478c1417164.png)


@billybonks @jglovier 
