### PR TITLE
Updating documentation about linters.

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -118,14 +118,14 @@ Ember, by default uses [JSON API](http://jsonapi.org) as a JSON convention. [Cou
 
 A linter is a small program that checks code for stylistic or programming errors. Linters are available for most syntaxes, from Python to HTML.
 
-Programming is hard. We are bound to make mistakes. The big advantage of using linter is that your code can be linted as you type (before saving your changes) and any errors are highlighted immediately, which is considerably easier than saving the file, switching to a terminal, running a linter, reading through a list of errors, then switching back to your editor to locate the errors!
+Programming is hard. We are bound to make mistakes. The big advantage of using a linter is that your code can be linted as you type (before saving your changes) and any errors are highlighted immediately, which is considerably easier than saving the file, switching to a terminal, running a linter, reading through a list of errors, then switching back to your editor to locate the errors!
 
 In addition, linters can help to enforce coding standards, find unused variables, find formatting discrepancies etc.
 
 **HospitalRun** uses the following linters:
 
-1. [ESLint](http://eslint.org/) for ECMAScript/JavaScript. You can find the ESLint User guide [here](http://eslint.org/docs/user-guide/). In addition to the default set of rules ESLint is setup to use eslint-plugin-ember-suave you can find more information about that [here](https://github.com/DockYard/eslint-plugin-ember-suave).
-2. [stylelint](http://stylelint.io/) for Stylesheets. You can find stylelint User guide [here](http://stylelint.io/user-guide/).
+1. [ESLint](http://eslint.org/) for ECMAScript/JavaScript. You can find the ESLint User guide [here](http://eslint.org/docs/user-guide/). It's important to note that this project adheres to Dockyard's [Ember.js Style Guide](https://github.com/DockYard/styleguides/blob/master/engineering/ember.md). Also ESLint is setup to use eslint-plugin-ember-suave, you can find more information about that [here](https://github.com/DockYard/eslint-plugin-ember-suave).
+2. [stylelint](http://stylelint.io/) for Stylesheets. You can find the stylelint User guide [here](http://stylelint.io/user-guide/).
 3. [ember-template-lint](https://github.com/rwjblue/ember-template-lint) for Ember templates.
 
 ### Using Local Cache

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to the Ember front end for HospitalRun
 
-Contributions are welcome via pull requests and issues. Before submitting a pull request, please make sure all tests pass by running ```ember test```. Running this command will also run the project's linters, for more information see the section on [linters](#linter) below.
+Contributions are welcome via pull requests and issues. Before submitting a pull request, please make sure all tests pass by running ```ember test```. This project uses the style guides from Dockyard for [Ember](https://github.com/dockyard/styleguides/blob/master/engineering/ember.md) and [JavaScript](https://github.com/dockyard/styleguides/blob/master/engineering/javascript.md). These style guides are enforced via ESLint, which is one of the linters described in the section on [linters](#linter) below.
 
 ## Slack / Communication
 
@@ -124,7 +124,7 @@ In addition, linters can help to enforce coding standards, find unused variables
 
 **HospitalRun** uses the following linters:
 
-1. [ESLint](http://eslint.org/) for ECMAScript/JavaScript. You can find the ESLint User guide [here](http://eslint.org/docs/user-guide/). It's important to note that this project adheres to Dockyard's [Ember.js Style Guide](https://github.com/DockYard/styleguides/blob/master/engineering/ember.md). Also ESLint is setup to use eslint-plugin-ember-suave, you can find more information about that [here](https://github.com/DockYard/eslint-plugin-ember-suave).
+1. [ESLint](http://eslint.org/) for ECMAScript/JavaScript. You can find the ESLint User guide [here](http://eslint.org/docs/user-guide/). ESLint is setup to use eslint-plugin-ember-suave, you can find more information about that [here](https://github.com/DockYard/eslint-plugin-ember-suave).
 2. [stylelint](http://stylelint.io/) for Stylesheets. You can find the stylelint User guide [here](http://stylelint.io/user-guide/).
 3. [ember-template-lint](https://github.com/rwjblue/ember-template-lint) for Ember templates.
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to the Ember front end for HospitalRun
 
-Contributions are welcome via pull requests and issues.  This project uses the style guides from Dockyard for [Ember](https://github.com/dockyard/styleguides/blob/master/engineering/ember.md) and [JavaScript](https://github.com/dockyard/styleguides/blob/master/engineering/javascript.md).  These style guides are enforced via [Ember Suave](https://github.com/dockyard/ember-suave).  Before submitting a pull request, please make sure all tests pass by running ```ember test```.
+Contributions are welcome via pull requests and issues. Before submitting a pull request, please make sure all tests pass by running ```ember test```. Running this command will also run the project's linters, for more information see the section on [linters](#linter) below.
 
 ## Slack / Communication
 
@@ -124,8 +124,9 @@ In addition, linters can help to enforce coding standards, find unused variables
 
 **HospitalRun** uses the following linters:
 
-1. [ESLint](http://eslint.org/) for ECMAScript/JavaScript. You can find the ESLint User guide [here](http://eslint.org/docs/user-guide/).
+1. [ESLint](http://eslint.org/) for ECMAScript/JavaScript. You can find the ESLint User guide [here](http://eslint.org/docs/user-guide/). In addition to the default set of rules ESLint is setup to use eslint-plugin-ember-suave you can find more information about that [here](https://github.com/DockYard/eslint-plugin-ember-suave).
 2. [stylelint](http://stylelint.io/) for Stylesheets. You can find stylelint User guide [here](http://stylelint.io/user-guide/).
+3. [ember-template-lint](https://github.com/rwjblue/ember-template-lint) for Ember templates.
 
 ### Using Local Cache
 

--- a/README.md
+++ b/README.md
@@ -122,12 +122,6 @@ To run the test suite locally while developing, just run `ember test` from the p
 
 Tests will also run automatically via Travis CI when you push a branch to the repository or a pull request. You can view output by going to the Travis test status from the Pull Request merge box.
 
-### The SCSS linter
-
-To keep our styling scalable and consistent, we are using an [scss linter](https://www.npmjs.com/package/ember-cli-scss-lint) that will throw an error in the build if you do not conform to it's syntax rules. The syntax rules are defined in the [`.scss-lint.yml`](https://github.com/HospitalRun/hospitalrun-frontend/blob/master/.scss-lint.yml) file, and documentation for each linter is [available here](https://github.com/brigade/scss-lint/blob/master/lib/scss_lint/linter/README.md).
-
-The easiest way to work with styles in the project and abide by our linting rules is to install the [linter-scss-lint](https://atom.io/packages/linter-scss-lint) package for Atom. The package will then show you in real time where your styles are breaking the linter and how to correct them.
-
 ## Contributing
 
 Again, contributions are welcome via pull requests and issues.  Please see our [contributing guide](https://github.com/hospitalrun/hospitalrun-frontend/blob/master/.github/CONTRIBUTING.md) for more details.


### PR DESCRIPTION
Fixes: Consolidation and updating of documentation about linters used in the project.

**Changes proposed in this pull request:**
- Removed outdated linter information , about SCSS, from main README
- Removed outdated information about Ember Suave etc from top of CONTRIBUTING guide.
- Added to existing documentation in Linter section of CONTRIBUTING guide - including external links to documentation about eslint-plugin-ember-suave and ember-template-lint.

cc @HospitalRun/core-maintainers
