### PR TITLE
Two translated labels fixed

### DIFF
--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -57,7 +57,7 @@ export default {
       reports: 'Reports',
       patientListing: 'Patient Listing',
       newPatient: 'New Patient',
-      appointmentsThisWeek: 'Appointment This Week',
+      appointmentsThisWeek: 'Appointments This Week',
       "today'sAppointments": 'Today\'s Appointments',
       appointmentSearch: 'Appointment Search',
       addAppointment: 'Add Appointment',
@@ -1441,7 +1441,7 @@ export default {
   models: {
     appointment: {
       labels: {
-        status: 'First Name',
+        status: 'Status',
         appointmentType: 'Type',
         provider: 'With',
         location: 'Location',


### PR DESCRIPTION
Fixes self-reported issue.

**Changes proposed in this pull request:**
- a minor fix for two labels that displayed incorrect text.

cc @HospitalRun/core-maintainers