### PR TITLE
Clarify in README whether installation instructions whether to clone or fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,7 @@ HospitalRun frontend
 
 _Ember frontend for HospitalRun_
 
-[![Build Status](https://travis-ci.org/HospitalRun/hospitalrun-frontend.svg?branch=master)](https://travis-ci.org/HospitalRun/hospitalrun-frontend)
-
-[![CouchDB](https://img.shields.io/badge/couchdb-2.0-green.svg)](http://couchdb.apache.org/)
+[![Build Status](https://travis-ci.org/HospitalRun/hospitalrun-frontend.svg?branch=master)](https://travis-ci.org/HospitalRun/hospitalrun-frontend) [![CouchDB](https://img.shields.io/badge/couchdb-2.0-green.svg)](http://couchdb.apache.org/)
 
 To run the development environment for this frontend you will need to have [Git](https://git-scm.com/), [Node.js](https://nodejs.org), [Ember CLI](http://ember-cli.com/), [Bower](http://bower.io/), and [CouchDB](http://couchdb.apache.org/) installed.
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ To run the development environment for this frontend you will need to have [Git]
 
 - [Contributing](#contributing)
 - [Installation](#installation)
-- [Running the appplication](#running-the-application)
+- [Running the application](#running-the-application)
 - [Running with Docker](#running-with-docker)
 - [Accessing HospitalRun with Docker Toolbox](#accessing-hospitalRun-with-docker-toolbox)
 - [Accessing HospitalRun with Docker](#accessing-hospitalRun-with-docker)
@@ -61,7 +61,7 @@ To install the frontend please do the following:
      2. Or start the application from your applications folder.
 
 
-## Running the appplication
+## Running the application
 To start the frontend please do the following:
 
 - Start the server by running `npm start` in the repo folder.  If `npm start` doesn't work for you, try `ember serve` as an alternative.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ To install the frontend please do the following:
 3. Install [ember-cli latest](https://www.npmjs.org/package/ember-cli): `npm install -g ember-cli@latest`.
    Depending on your [npm permissions](https://docs.npmjs.com/getting-started/fixing-npm-permissions) you might need root access to install ember-cli.
 4. Install [bower](https://www.npmjs.org/package/bower): `npm install -g bower`
-5. Clone this repo with `git clone https://github.com/HospitalRun/hospitalrun-frontend`, go to the cloned folder and run `script/bootstrap`. (*Note: Depending on your [npm permissions](https://docs.npmjs.com/getting-started/fixing-npm-permissions) you might need root access to install PhantomJS2; also, Windows users must run with [Cygwin](http://cygwin.org/)*).
+5. Clone this repo with `git clone https://github.com/HospitalRun/hospitalrun-frontend`, go to the cloned folder and run `script/bootstrap`. (*Note: Depending on your [npm permissions](https://docs.npmjs.com/getting-started/fixing-npm-permissions) you might need root access to install PhantomJS2; also, Windows users must run with [Cygwin](http://cygwin.org/)*). **Note:** *if you just want to use the project, cloning is the best option. However, if you wish to contribute to the project, you will need to fork the project first, and then clone your `hospitalrun-frontend` fork and make your contributions via a branch on your fork.*
 6. Install and configure [CouchDB](http://couchdb.apache.org/)
     1. Download and install CouchDB from http://couchdb.apache.org/#download
     2. Start CouchDB

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ _Ember frontend for HospitalRun_
 
 To run the development environment for this frontend you will need to have [Git](https://git-scm.com/), [Node.js](https://nodejs.org), [Ember CLI](http://ember-cli.com/), [Bower](http://bower.io/), and [CouchDB](http://couchdb.apache.org/) installed.
 
+## Table of contents
+
 - [Contributing](#contributing)
 - [Installation](#installation)
 - [Running the application](#running-the-application)

--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ To install the frontend please do the following:
 3. Install [ember-cli latest](https://www.npmjs.org/package/ember-cli): `npm install -g ember-cli@latest`.
    Depending on your [npm permissions](https://docs.npmjs.com/getting-started/fixing-npm-permissions) you might need root access to install ember-cli.
 4. Install [bower](https://www.npmjs.org/package/bower): `npm install -g bower`
-5. Clone this repo with `git clone https://github.com/HospitalRun/hospitalrun-frontend`, go to the cloned folder and run `script/bootstrap`. (*Note: Depending on your [npm permissions](https://docs.npmjs.com/getting-started/fixing-npm-permissions) you might need root access to install PhantomJS2; also, Windows users must run with [Cygwin](http://cygwin.org/)*). **Note:** *if you just want to use the project, cloning is the best option. However, if you wish to contribute to the project, you will need to fork the project first, and then clone your `hospitalrun-frontend` fork and make your contributions via a branch on your fork.*
+5. Clone this repo with `git clone https://github.com/HospitalRun/hospitalrun-frontend`, go to the cloned folder and run `script/bootstrap`.
+  - **Note:** Depending on your [npm permissions](https://docs.npmjs.com/getting-started/fixing-npm-permissions) you might need root access to install PhantomJS2; also, Windows users must run with [Cygwin](http://cygwin.org/)). 
+  - **Note:** If you just want to use the project, cloning is the best option. However, if you wish to contribute to the project, you will need to fork the project first, and then clone your `hospitalrun-frontend` fork and make your contributions via a branch on your fork.
 6. Install and configure [CouchDB](http://couchdb.apache.org/)
     1. Download and install CouchDB from http://couchdb.apache.org/#download
     2. Start CouchDB

--- a/README.md
+++ b/README.md
@@ -9,11 +9,25 @@ _Ember frontend for HospitalRun_
 
 To run the development environment for this frontend you will need to have [Git](https://git-scm.com/), [Node.js](https://nodejs.org), [Ember CLI](http://ember-cli.com/), [Bower](http://bower.io/), and [CouchDB](http://couchdb.apache.org/) installed.
 
+- [Contributing](#contributing)
+- [Installation](#installation)
+- [Running the appplication](#running-the-application)
+- [Running with Docker](#running-with-docker)
+- [Accessing HospitalRun with Docker Toolbox](#accessing-hospitalRun-with-docker-toolbox)
+- [Accessing HospitalRun with Docker](#accessing-hospitalRun-with-docker)
+- [Troubleshooting your local environment](#troubleshooting-your-local-environment)
+- [Loading sample data](#loading-sample-data)
+- [Testing](#testing)
+- [Contributing](#contributing-1)
+- [Start coding](#start-coding)
+- [Further Reading / Useful Links](#further-reading--useful-links)
+- [Experimental](#experimental)
+
 ## Contributing
 
 Contributions are welcome via pull requests and issues.  Please see our [contributing guide](https://github.com/hospitalrun/hospitalrun-frontend/blob/master/.github/CONTRIBUTING.md) for more details, including a link to join our project Slack.
 
-## Install
+## Installation
 To install the frontend please do the following:
 
 1. Make sure you have installed [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
@@ -47,7 +61,7 @@ To install the frontend please do the following:
      2. Or start the application from your applications folder.
 
 
-## Start
+## Running the appplication
 To start the frontend please do the following:
 
 - Start the server by running `npm start` in the repo folder.  If `npm start` doesn't work for you, try `ember serve` as an alternative.

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ To install the frontend please do the following:
    Depending on your [npm permissions](https://docs.npmjs.com/getting-started/fixing-npm-permissions) you might need root access to install ember-cli.
 4. Install [bower](https://www.npmjs.org/package/bower): `npm install -g bower`
 5. Clone this repo with `git clone https://github.com/HospitalRun/hospitalrun-frontend`, go to the cloned folder and run `script/bootstrap`.
-  - **Note:** Depending on your [npm permissions](https://docs.npmjs.com/getting-started/fixing-npm-permissions) you might need root access to install PhantomJS2; also, Windows users must run with [Cygwin](http://cygwin.org/)). 
-  - **Note:** If you just want to use the project, cloning is the best option. However, if you wish to contribute to the project, you will need to fork the project first, and then clone your `hospitalrun-frontend` fork and make your contributions via a branch on your fork.
+  - **Note:** *Depending on your [npm permissions](https://docs.npmjs.com/getting-started/fixing-npm-permissions) you might need root access to install PhantomJS2; also, Windows users must run with [Cygwin](http://cygwin.org/)).*
+  - **Note:** *If you just want to use the project, cloning is the best option. However, if you wish to contribute to the project, you will need to fork the project first, and then clone your `hospitalrun-frontend` fork and make your contributions via a branch on your fork.*
 6. Install and configure [CouchDB](http://couchdb.apache.org/)
     1. Download and install CouchDB from http://couchdb.apache.org/#download
     2. Start CouchDB


### PR DESCRIPTION
A contributor in our Slack channel noticed that the installation instructions are confusing for contributors, because we specify that you should clone this repo, when in fact if you are a contributor without write access to this repo (basically any new contributor) you will need to fork first, and then clone your fork.

This PR adds some copy to clarify that. Also adds a table of context because this README is getting super long (and should probably be refactored into better docs).

cc @HospitalRun/core-maintainers 