### PR TITLE
Address issue #390, Adjustment types for inventory need to be localized

### DIFF
--- a/app/inventory/adjust/controller.js
+++ b/app/inventory/adjust/controller.js
@@ -16,7 +16,9 @@ export default AbstractEditController.extend(AdjustmentTypes, {
   }.observes('transactionType'),
 
   updateButtonText: function() {
-    return this.get('model.transactionType');
+    let transactionType = this.get('model.transactionType');
+    let adjustmentType = this.get('adjustmentTypes').findBy('type', transactionType);
+    return adjustmentType.name;
   }.property('model.transactionType'),
 
   updateButtonAction: 'adjust',

--- a/app/inventory/reports/controller.js
+++ b/app/inventory/reports/controller.js
@@ -642,7 +642,7 @@ export default AbstractReportController.extend(LocationName, ModalHelper, Number
           let consumed = {};
           let gikConsumed = {};
           let adjustments = {};
-          this.adjustmentTypes.forEach(function(adjustmentType) {
+          this.get('adjustmentTypes').forEach(function(adjustmentType) {
             adjustments[adjustmentType.type] = [];
           });
           Object.keys(inventoryMap).forEach(function(key) {

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -567,6 +567,13 @@ export default {
     }
   },
   inventory: {
+    adjustmentTypes: {
+      add: 'Add',
+      remove: 'Remove',
+      returnToVendor: 'Return To Vendor',
+      return: 'Return',
+      writeOff: 'Write Off'
+    },
     edit: {
       cost: 'Cost Per Unit:',
       delivered: 'Delievered To:',

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -567,13 +567,6 @@ export default {
     }
   },
   inventory: {
-    adjustmentTypes: {
-      add: 'Add',
-      remove: 'Remove',
-      returnToVendor: 'Return To Vendor',
-      return: 'Return',
-      writeOff: 'Write Off'
-    },
     edit: {
       cost: 'Cost Per Unit:',
       delivered: 'Delievered To:',
@@ -589,6 +582,7 @@ export default {
     labels: {
       action: 'Action',
       add: 'Add',
+      addAdjustmentType: 'Add',
       adjust: 'Adjust',
       adjustmentDate: 'Adjustment Date',
       adjustmentFor: 'Adjustment For',
@@ -655,8 +649,11 @@ export default {
       rank: 'Rank',
       reason: 'Reason',
       remove: 'Remove',
+      removeAdjustmentType: 'Remove',
       reorderPoint: 'Reorder Point',
       requestedItems: 'Requested Items',
+      returnAdjustmentType: 'Return',
+      returnToVendorAdjustmentType: 'Return To Vendor',
       salePricePerUnit: 'Sale Price per Unit',
       save: 'Save',
       serialNumber: 'Serial/Lot Number',
@@ -673,6 +670,7 @@ export default {
       unitCost: 'Unit Cost',
       vendor: 'Vendor',
       vendorItemNumber: 'Vendor Item Number',
+      writeOffAdjustmentType: 'Write Off',
       xref: 'XRef'
     },
     messages: {

--- a/app/mixins/inventory-adjustment-types.js
+++ b/app/mixins/inventory-adjustment-types.js
@@ -5,23 +5,23 @@ export default Ember.Mixin.create({
     let i18n = this.get('i18n');
     return [
       {
-        name: i18n.t('inventory.adjustmentTypes.add').toString(),
+        name: i18n.t('inventory.labels.addAdjustmentType').toString(),
         type: 'Adjustment (Add)'
       },
       {
-        name: i18n.t('inventory.adjustmentTypes.remove').toString(),
+        name: i18n.t('inventory.labels.removeAdjustmentType').toString(),
         type: 'Adjustment (Remove)'
       },
       {
-        name: i18n.t('inventory.adjustmentTypes.returnToVendor').toString(),
+        name: i18n.t('inventory.labels.returnToVendorAdjustmentType').toString(),
         type: 'Return To Vendor'
       },
       {
-        name: i18n.t('inventory.adjustmentTypes.return').toString(),
+        name: i18n.t('inventory.labels.returnAdjustmentType').toString(),
         type: 'Return'
       },
       {
-        name: i18n.t('inventory.adjustmentTypes.writeOff').toString(),
+        name: i18n.t('inventory.labels.writeOffAdjustmentType').toString(),
         type: 'Write Off'
       }
     ];

--- a/app/mixins/inventory-adjustment-types.js
+++ b/app/mixins/inventory-adjustment-types.js
@@ -1,19 +1,29 @@
 import Ember from 'ember';
+
 export default Ember.Mixin.create({
-  adjustmentTypes: [{
-    name: 'Add',
-    type: 'Adjustment (Add)'
-  }, {
-    name: 'Remove',
-    type: 'Adjustment (Remove)'
-  }, {
-    name: 'Return To Vendor',
-    type: 'Return To Vendor'
-  }, {
-    name: 'Return',
-    type: 'Return'
-  }, {
-    name: 'Write Off',
-    type: 'Write Off'
-  }]
+  adjustmentTypes: function() {
+    let i18n = this.get('i18n');
+    return [
+      {
+        name: i18n.t('inventory.adjustmentTypes.add').toString(),
+        type: 'Adjustment (Add)'
+      },
+      {
+        name: i18n.t('inventory.adjustmentTypes.remove').toString(),
+        type: 'Adjustment (Remove)'
+      },
+      {
+        name: i18n.t('inventory.adjustmentTypes.returnToVendor').toString(),
+        type: 'Return To Vendor'
+      },
+      {
+        name: i18n.t('inventory.adjustmentTypes.return').toString(),
+        type: 'Return'
+      },
+      {
+        name: i18n.t('inventory.adjustmentTypes.writeOff').toString(),
+        type: 'Write Off'
+      }
+    ];
+  }.property()
 });

--- a/tests/unit/mixins/inventory-adjustment-types-test.js
+++ b/tests/unit/mixins/inventory-adjustment-types-test.js
@@ -1,0 +1,59 @@
+import AdjustmentTypes from 'hospitalrun/mixins/inventory-adjustment-types';
+import { moduleFor, test } from 'ember-qunit';
+import Ember from 'ember';
+import tHelper from 'ember-i18n/helper';
+import localeConfig from 'ember-i18n/config/en';
+
+moduleFor('mixin:inventory-adjustment-types', 'Unit | Mixin | inventory-adjustment-types', {
+  needs: [
+    'service:i18n',
+    'locale:en/translations',
+    'locale:en/config',
+    'util:i18n/missing-message',
+    'util:i18n/compile-template',
+    'config:environment'
+  ],
+  beforeEach() {
+    // set the locale and the config
+    this.container.lookup('service:i18n').set('locale', 'en');
+    this.registry.register('locale:en/config', localeConfig);
+
+    // Inject i18n as the intializer does not run in unit test
+    Ember.getOwner(this).inject('inventory-adjustment-types', 'i18n', 'service:i18n');
+
+    // register t helper
+    this.registry.register('helper:t', tHelper);
+  },
+  subject() {
+    let AdjustmentTypesObject = Ember.Object.extend(AdjustmentTypes);
+    this.registry.register('inventory-adjustment-types:main', AdjustmentTypesObject);
+    return Ember.getOwner(this).lookup('inventory-adjustment-types:main');
+
+  }
+});
+
+test('checkTranslations', function(assert) {
+  let InventoryAdjustmentTypes = this.subject();
+  assert.deepEqual(InventoryAdjustmentTypes.get('adjustmentTypes'), [
+    {
+      name: 'Add',
+      type: 'Adjustment (Add)'
+    },
+    {
+      name: 'Remove',
+      type: 'Adjustment (Remove)'
+    },
+    {
+      name: 'Return To Vendor',
+      type: 'Return To Vendor'
+    },
+    {
+      name: 'Return',
+      type: 'Return'
+    },
+    {
+      name: 'Write Off',
+      type: 'Write Off'
+    }
+  ]);
+});

--- a/tests/unit/models/inv-request-test.js
+++ b/tests/unit/models/inv-request-test.js
@@ -1,5 +1,7 @@
 import { moduleForModel, test } from 'ember-qunit';
 import Ember from 'ember';
+import tHelper from 'ember-i18n/helper';
+import localeConfig from 'ember-i18n/config/en';
 
 import { testValidPropertyValues, testInvalidPropertyValues } from '../../helpers/validate-properties';
 
@@ -17,8 +19,24 @@ moduleForModel('inv-request', 'Unit | Model | inv-request', {
     'model:patient',
     'model:payment',
     'model:price-profile',
-    'model:visit'
-  ]
+    'model:visit',
+    'service:i18n',
+    'locale:en/translations',
+    'locale:en/config',
+    'util:i18n/missing-message',
+    'util:i18n/compile-template',
+    'config:environment'
+  ],
+  beforeEach() {
+    // set the locale and the config
+    this.container.lookup('service:i18n').set('locale', 'en');
+    this.registry.register('locale:en/config', localeConfig);
+
+    Ember.getOwner(this).inject('model', 'i18n', 'service:i18n');
+
+    // register t helper
+    this.registry.register('helper:t', tHelper);
+  }
 });
 
 test('deliveryLocationName', function(assert) {


### PR DESCRIPTION
Fixes #390.

There are two issues, which are related:

1. Localization of drop-down
Added translation keys to app/mixins/inventory-adjustment-types.js. So now the drop-down list for Adjustment Types is translated. Added English translations. I didn't update the files for the other languages - I'm not sure of the process for getting translation text in multiple languages - let me know if you'd like me to do something more about that.

2. Localization of the 'submit' button.
In app/inventory/adjust/controller.js I use the the Transaction Type to find a localized Adjustment Type name.

cc @HospitalRun/core-maintainers
