### PR TITLE
Fix user on example config

### DIFF
--- a/server/config-example.js
+++ b/server/config-example.js
@@ -4,7 +4,7 @@ var config = {
   couchDbPort: '5984',
   couchDbUseSsl: false,
   couchDbChangesSince: 'now',
-  couchAdminUser: 'couchadmin',
+  couchAdminUser: 'hradmin',
   couchAdminPassword: 'test',
   googleClientId: 'FOR GOOGLE SSO; GOOGLE CLIENT ID GOES HERE',
   googleClientSecret: 'FOR GOOGLE SSO; GOOGLE CLIENT SECRET GOES HERE',


### PR DESCRIPTION
**Changes proposed in this pull request:**
- In the docs, the default username is: `hradmin`. However, on the example-config file it defaults the username to be `couchadmin`. To keep the docs consistent with the code, I updated the username on `config-example.js`

cc @HospitalRun/core-maintainers
