### PR TITLE
fix translation-sync instruction and script

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -163,7 +163,7 @@ New test should be added for any new features or views in the app. For more info
 If you know a language other than English and would like to help translate this app, please follow the following steps:
 
 ### Install necessary node modules
-```npm install -g babel-cli eslint-cli```
+```npm install -g babel-cli eslint-cli babel-preset-es2015```
 
 ### Run script to populate missing translation terms
 ```npm run translation-sync```

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "start": "./script/server",
     "test": "./script/test",
     "electron-test": "ember electron:test",
-    "translation-sync": "babel-node script/translation/sync.js  --presets es2015,stage-2; eslint --fix app/locales"
+    "translation-sync": "babel-node script/translation/sync.js --presets es2015 && eslint --fix app/locales"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes #1066 

**Changes proposed in this pull request:**
- Update instruction to run translation-sync script to include missing dependency
- Use `&&` instead of `;` for compatibility with Windows

cc @HospitalRun/core-maintainers
