### PR TITLE
Add cloud9 setup tool

### DIFF
--- a/script/setupcloud9
+++ b/script/setupcloud9
@@ -3,12 +3,23 @@
 # Sets up the development environment on a cloud9 workspace and runs the tests to verify.
 
 
-sudo mkdir -p /var/run/couchdb
-sudo chown couchdb:couchdb /var/run/couchdb
+if nvm > /dev/null 2>&1; then
+    echo "setting proper node version"
+    
+else
+    echo "Cannot find nvm. This probably means you are running this script in its own shell. Try again with source ./script/setupcloud9"
+    return 1
+fi
+
 
 nvm install 6
 nvm use 6
 nvm alias default 6
+
+
+sudo mkdir -p /var/run/couchdb
+sudo chown couchdb:couchdb /var/run/couchdb
+
 
 npm install -g npm
 npm cache clean -f

--- a/script/setupcloud9
+++ b/script/setupcloud9
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+sudo mkdir -p /var/run/couchdb
+sudo chown couchdb:couchdb /var/run/couchdb
+
+nvm install 6
+nvm use 6
+nvm alias default 6
+
+npm install -g npm               #optional
+npm cache clean -f               #optional
+npm install -g n                 #optional
+sudo n stable                    #optional
+npm install -g ember-cli@latest
+npm install -g bower
+npm install
+bower install
+npm install -g phantomjs-prebuilt
+
+sudo su couchdb -c /usr/bin/couchdb &
+sleep 5
+
+./script/initcouch.sh
+cp ./server/config-example.js ./server/config.js
+
+./script/test

--- a/script/setupcloud9
+++ b/script/setupcloud9
@@ -1,4 +1,7 @@
 #!/bin/sh
+# Usage: source ./script/setupcloud9
+# Sets up the development environment on a cloud9 workspace and runs the tests to verify.
+
 
 sudo mkdir -p /var/run/couchdb
 sudo chown couchdb:couchdb /var/run/couchdb
@@ -7,10 +10,10 @@ nvm install 6
 nvm use 6
 nvm alias default 6
 
-npm install -g npm               #optional
-npm cache clean -f               #optional
-npm install -g n                 #optional
-sudo n stable                    #optional
+npm install -g npm
+npm cache clean -f
+npm install -g n
+sudo n stable
 npm install -g ember-cli@latest
 npm install -g bower
 npm install


### PR DESCRIPTION
Fixes #1089 .

**Changes proposed in this pull request:**
- Adds a setup script to ./script specifically for the cloud9 development environment
- The script works through the quirks specific to cloud9 to ensure that the app will run correctly and the tests will not give false errors
- To test this script, setup a workspace as described in [the top section of this wiki document](https://github.com/HospitalRun/hospitalrun-frontend/wiki/Optional:-Cloud9-Development-Environment). After the workspace is created, run:  `source ./script/setupcloud9` from the shell window. When the script completes the environment should be setup correctly.

**Additional Notes**
I am a cloud9 user that recently started exploring the hospitalrun project. Initially, I ran into some frustrating issues with test failures. After some investigation I realized that the problem was because of some weirdness on the cloud9 configuration side related to the way they automatically install certain tools such as nvm and couchdb. This pull request is intended to keep other folks from hitting those same issues.

cc @HospitalRun/core-maintainers
