### PR TITLE
updated winstaller config icon path for error free windows build

### DIFF
--- a/ember-electron/electron-forge-config.js
+++ b/ember-electron/electron-forge-config.js
@@ -40,7 +40,7 @@ module.exports = {
     icon: 'assets/icons/favicon',
     name: 'HospitalRun',
     noMSI: true,
-    setupIcon: path.join(__dirname, '../../../assets/icons/favicon.ico'),
+    setupIcon: path.join(__dirname, '../assets/icons/favicon.ico'),
     setupExe: 'HospitalRun.exe',
     title: 'HospitalRun'/* ,
      certificateFile: '',


### PR DESCRIPTION
Fixes #1075 - Create the electron windows 64-bit download/install

**Changes proposed in this pull request:**
- [updated icon path in winstaller config to mitigate windows build error]

cc @HospitalRun/core-maintainers
