### PR TITLE
First working acceptance test for appointments/search path; ensures only the correct appointment is displayed based on its start date

### DIFF
--- a/app/appointments/search/template.hbs
+++ b/app/appointments/search/template.hbs
@@ -1,16 +1,17 @@
+
 {{#item-listing paginationProps=paginationProps }}
   <div class="panel panel-info">
     <div class="panel-body">
       {{#em-form model=model submitButton=false }}
         <div class="row">
-          {{date-picker property="selectedStartingDate" label=(t "appointments.labels.selectedStartingDate")class="col-sm-3"}}
-          {{em-select class="col-sm-3 form-input-group" property="selectedStatus"
+          {{date-picker property="selectedStartingDate" label=(t "appointments.labels.selectedStartingDate")class="col-sm-3 test-selected-start-date"}}
+          {{em-select class="col-sm-3 form-input-group test-selected-status" property="selectedStatus"
               label=(t "models.appointment.labels.status") content=appointmentStatusesWithEmpty
           }}
-          {{em-select class="col-sm-3 form-input-group" label=(t "models.appointment.labels.type")
+          {{em-select class="col-sm-3 form-input-group test-selected-appointment-type" label=(t "models.appointment.labels.type")
               property="selectedAppointmentType" content=visitTypesWithEmpty
           }}
-          {{em-select class="col-sm-3 form-input-group" property="selectedProvider"
+          {{em-select class="col-sm-3 form-input-group test-selected-provider" property="selectedProvider"
               label=(t 'models.appointment.labels.provider') content=physicianList
           }}
         </div>

--- a/tests/acceptance/appointments-test.js
+++ b/tests/acceptance/appointments-test.js
@@ -201,6 +201,51 @@ test('Appointment calendar', function(assert) {
   });
 });
 
+test('visiting /appointments/search', function(assert) {
+  runWithPouchDump('appointments', function() {
+    authenticateUser();
+
+    createAppointment(assert);
+    createAppointment(assert, {
+      startDate: moment().startOf('day').add(1, 'years'),
+      startTime: moment().startOf('day').add(1, 'years').format(TIME_FORMAT),
+      endDate: moment().endOf('day').add(1, 'years').add(2, 'days'),
+      endTime: moment().endOf('day').add(1, 'years').add(2, 'days').format(TIME_FORMAT)
+    });
+
+    andThen(function() {
+      visit('/appointments/search');
+    });
+
+    andThen(function() {
+      findWithAssert(':contains(Search Appointments)');
+      findWithAssert(':contains(Show Appointments On Or After)');
+      findWithAssert(':contains(Status)');
+      findWithAssert(':contains(Type)');
+      findWithAssert(':contains(With)');
+    });
+
+    andThen(function() {
+      // debugger;
+      let desiredDate = moment().endOf('day').add(363, 'days').format('l');
+      let datePicker = '.test-selected-start-date input';
+      selectDate(datePicker, desiredDate);
+      click('button:contains(Search)');
+    });
+
+    andThen(function() {
+      let date = moment().endOf('day').add(1, 'years').add(2, 'days').format('l');
+      findWithAssert(`.appointment-status:contains(${status})`);
+      let element = `tr:contains(${date})`;
+      findWithAssert(element);
+      date = moment().startOf('day').add(1, 'years');
+      element = find(`tr:contains(${date})`);
+      assert.equal(element.length, 0);
+    });
+
+  });
+});
+
 test('Theater scheduling', function(assert) {
   runWithPouchDump('appointments', function() {
     authenticateUser();


### PR DESCRIPTION
Addresses #689 

**Changes proposed in this pull request:**

- This PR adds acceptance test for appointment searches based on start date
I plan to write more tests for the other searchable appointment attributes.  Submitting this now for initial feedback.

cc @HospitalRun/core-maintainers
