### PR TITLE
Lang select final

### DIFF
--- a/app/admin/custom-forms/index/route.js
+++ b/app/admin/custom-forms/index/route.js
@@ -16,7 +16,9 @@ export default AbstractIndexRoute.extend(ModalHelper, UserSession, {
   }),
   newButtonText: t('admin.customForms.buttons.newForm'),
 
-  pageTitle: t('admin.customForms.titles.customForms'),
+  pageTitle: computed('i18n.locale', () => {
+    return t('admin.customForms.titles.customForms');
+  }),
   model() {
     let store = this.get('store');
     return store.findAll('custom-form');

--- a/app/admin/lookup/route.js
+++ b/app/admin/lookup/route.js
@@ -5,7 +5,7 @@ const { computed } = Ember;
 
 export default AbstractIndexRoute.extend({
   hideNewButton: true,
-  pageTitle: computed('i18n', () => {
+  pageTitle: computed('i18n.locale', () => {
     return t('admin.lookup.pageTitle');
   }),
   model() {

--- a/app/admin/lookup/route.js
+++ b/app/admin/lookup/route.js
@@ -1,8 +1,13 @@
 import AbstractIndexRoute from 'hospitalrun/routes/abstract-index-route';
 import { translationMacro as t } from 'ember-i18n';
+import Ember from 'ember';
+const { computed } = Ember;
+
 export default AbstractIndexRoute.extend({
   hideNewButton: true,
-  pageTitle: t('admin.lookup.pageTitle'),
+  pageTitle: computed('i18n', () => {
+    return t('admin.lookup.pageTitle');
+  }),
   model() {
     return this.store.findAll('lookup').catch((error) => this.send('error', error));
   },

--- a/app/admin/textreplace/route.js
+++ b/app/admin/textreplace/route.js
@@ -4,7 +4,7 @@ import Ember from 'ember';
 const { computed } = Ember;
 
 export default AbstractIndexRoute.extend({
-  pageTitle: computed('i18n', () => {
+  pageTitle: computed('i18n.locale', () => {
     return t('admin.textReplacements.pageTitle');
   }),
   hideNewButton: true,

--- a/app/admin/textreplace/route.js
+++ b/app/admin/textreplace/route.js
@@ -1,8 +1,12 @@
 import AbstractIndexRoute from 'hospitalrun/routes/abstract-index-route';
 import { translationMacro as t } from 'ember-i18n';
+import Ember from 'ember';
+const { computed } = Ember;
 
 export default AbstractIndexRoute.extend({
-  pageTitle: t('admin.textReplacements.pageTitle'),
+  pageTitle: computed('i18n', () => {
+    return t('admin.textReplacements.pageTitle');
+  }),
   hideNewButton: true,
 
   model() {

--- a/app/appointments/calendar/route.js
+++ b/app/appointments/calendar/route.js
@@ -4,7 +4,8 @@ import { translationMacro as t } from 'ember-i18n';
 
 const {
   get,
-  isEmpty
+  isEmpty,
+  computed
 } = Ember;
 
 export default AppointmentIndexRoute.extend({
@@ -13,7 +14,9 @@ export default AppointmentIndexRoute.extend({
   editReturn: 'appointments.calendar',
   filterParams: ['appointmentType', 'provider', 'status', 'location'],
   modelName: 'appointment',
-  pageTitle: t('appointments.calendarTitle'),
+  pageTitle: computed('i18n.locale', () => {
+    return t('appointments.calendarTitle');
+  }),
 
   queryParams: {
     appointmentType: { refreshModel: true },

--- a/app/appointments/index/route.js
+++ b/app/appointments/index/route.js
@@ -1,12 +1,19 @@
 import AbstractIndexRoute from 'hospitalrun/routes/abstract-index-route';
 import moment from 'moment';
 import { translationMacro as t } from 'ember-i18n';
+import Ember from 'ember';
+
+const { computed } = Ember;
 
 export default AbstractIndexRoute.extend({
   editReturn: 'appointments.index',
   modelName: 'appointment',
-  newButtonText: t('appointments.buttons.newButton'),
-  pageTitle: t('appointments.thisWeek'),
+  newButtonText: computed('i18n.locale', () => {
+    return t('appointments.buttons.newButton');
+  }),
+  pageTitle: computed('i18n.locale', () => {
+    return t('appointments.thisWeek');
+  }),
 
   _getStartKeyFromItem(item) {
     let endDate = item.get('endDate');

--- a/app/appointments/search/route.js
+++ b/app/appointments/search/route.js
@@ -10,7 +10,7 @@ export default AppointmentIndexRoute.extend(DateFormat, {
   editReturn: 'appointments.search',
   filterParams: ['appointmentType', 'provider', 'status'],
   modelName: 'appointment',
-  pageTitle: computed('i18n', () => {
+  pageTitle: computed('i18n.locale', () => {
     return t('appointments.searchTitle');
   }),
 

--- a/app/appointments/search/route.js
+++ b/app/appointments/search/route.js
@@ -4,11 +4,15 @@ import Ember from 'ember';
 import moment from 'moment';
 import { translationMacro as t } from 'ember-i18n';
 
+const { computed } = Ember;
+
 export default AppointmentIndexRoute.extend(DateFormat, {
   editReturn: 'appointments.search',
   filterParams: ['appointmentType', 'provider', 'status'],
   modelName: 'appointment',
-  pageTitle: t('appointments.searchTitle'),
+  pageTitle: computed('i18n', () => {
+    return t('appointments.searchTitle');
+  }),
 
   queryParams: {
     appointmentType: { refreshModel: true },

--- a/app/appointments/theater/route.js
+++ b/app/appointments/theater/route.js
@@ -1,10 +1,17 @@
 import AppointmenCalendarRoute from 'hospitalrun/appointments/calendar/route';
 import { translationMacro as t } from 'ember-i18n';
+import Ember from 'ember';
+
+const { computed } = Ember;
 
 export default AppointmenCalendarRoute.extend({
   editReturn: 'appointments.theater',
-  newButtonText: t('appointments.buttons.scheduleSurgery'),
-  pageTitle: t('appointments.titles.theaterSchedule'),
+  newButtonText: computed('i18n', () => {
+    return t('appointments.buttons.scheduleSurgery');
+  }),
+  pageTitle: computed('i18n', () => {
+    return t('appointments.titles.theaterSchedule');
+  }),
 
   _modelQueryParams(params) {
     let queryParams = this._super(params);

--- a/app/appointments/theater/route.js
+++ b/app/appointments/theater/route.js
@@ -6,7 +6,7 @@ const { computed } = Ember;
 
 export default AppointmenCalendarRoute.extend({
   editReturn: 'appointments.theater',
-  newButtonText: computed('i18n', () => {
+  newButtonText: computed('i18n.locale', () => {
     return t('appointments.buttons.scheduleSurgery');
   }),
   pageTitle: computed('i18n', () => {

--- a/app/appointments/theater/route.js
+++ b/app/appointments/theater/route.js
@@ -9,7 +9,7 @@ export default AppointmenCalendarRoute.extend({
   newButtonText: computed('i18n.locale', () => {
     return t('appointments.buttons.scheduleSurgery');
   }),
-  pageTitle: computed('i18n', () => {
+  pageTitle: computed('i18n.locale', () => {
     return t('appointments.titles.theaterSchedule');
   }),
 

--- a/app/appointments/today/route.js
+++ b/app/appointments/today/route.js
@@ -8,7 +8,7 @@ const { computed } = Ember;
 export default AppointmentIndexRoute.extend({
   editReturn: 'appointments.today',
   modelName: 'appointment',
-  pageTitle: computed('i18n', () => {
+  pageTitle: computed('i18n.locale', () => {
     return t('appointments.todayTitle');
   }),
 

--- a/app/appointments/today/route.js
+++ b/app/appointments/today/route.js
@@ -1,10 +1,16 @@
 import AppointmentIndexRoute from 'hospitalrun/appointments/index/route';
 import moment from 'moment';
 import { translationMacro as t } from 'ember-i18n';
+import Ember from 'ember';
+
+const { computed } = Ember;
+
 export default AppointmentIndexRoute.extend({
   editReturn: 'appointments.today',
   modelName: 'appointment',
-  pageTitle: t('appointments.todayTitle'),
+  pageTitle: computed('i18n', () => {
+    return t('appointments.todayTitle');
+  }),
 
   _modelQueryParams() {
     let endOfDay = moment().endOf('day').toDate().getTime();

--- a/app/components/language-select.js
+++ b/app/components/language-select.js
@@ -16,7 +16,7 @@ export default Ember.Component.extend({
 
   onFinish: null,
 
-  _setUserLanguageChoice(language) {
+  _setUserLanguage(language) {
     let configDB = this.get('config.configDB');
     configDB.get('current_user').then((user) => {
       configDB.put({
@@ -30,7 +30,7 @@ export default Ember.Component.extend({
 
   actions: {
     selectLanguage(selection) {
-      this._setUserLanguageChoice(selection);
+      this._setUserLanguage(selection);
       this.set('i18n.locale', selection);
       this.get('onFinish')();
     }

--- a/app/components/language-select.js
+++ b/app/components/language-select.js
@@ -1,0 +1,39 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  config: Ember.inject.service(),
+  i18n: Ember.inject.service(),
+  languageOptions: Ember.computed(function() {
+    return Object.keys(this.get('languageMap'));
+  }),
+  onFinish: null,
+  languageMap: Ember.computed(() => {
+    return {
+      'English': 'en',
+      'French': 'fr'
+    };
+  }),
+  selectedLanguage: null,
+
+  _setUserLanguageChoice(language) {
+    let configDB = this.get('config.configDB');
+    configDB.get('current_user').then((user) => {
+      configDB.put({
+        lang: language,
+        _id: user._id,
+        _rev: user._rev,
+        value: user.value
+      });
+    });
+  },
+
+  actions: {
+    selectLanguage(_, selection) {
+      this.set('selectedLanguage', this.get('languageMap')[selection]);
+      this._setUserLanguageChoice(this.get('selectedLanguage'));
+      this.set('i18n.locale', this.get('selectedLanguage'));
+      this.get('onFinish')();
+    }
+  }
+
+});

--- a/app/components/language-select.js
+++ b/app/components/language-select.js
@@ -19,7 +19,7 @@ export default Ember.Component.extend({
     let configDB = this.get('config.configDB');
     configDB.get('current_user').then((user) => {
       configDB.put({
-        lang: language,
+        i18n: language,
         _id: user._id,
         _rev: user._rev,
         value: user.value

--- a/app/components/language-select.js
+++ b/app/components/language-select.js
@@ -1,18 +1,17 @@
 import Ember from 'ember';
+// import { translationMacro as t } from 'ember-i18n';
 
 export default Ember.Component.extend({
   config: Ember.inject.service(),
   i18n: Ember.inject.service(),
-  languageOptions: Ember.computed(function() {
-    return Object.keys(this.get('languageMap'));
+  languageOptions: Ember.computed('i18n.locale', function() {
+    // debugger;
+    return [
+      {id: 'en', name: 'languages.english'},
+      {id: 'fr', name: 'languages.french'}
+    ];
   }),
   onFinish: null,
-  languageMap: Ember.computed(() => {
-    return {
-      'English': 'en',
-      'French': 'fr'
-    };
-  }),
   selectedLanguage: null,
 
   _setUserLanguageChoice(language) {
@@ -28,10 +27,10 @@ export default Ember.Component.extend({
   },
 
   actions: {
-    selectLanguage(_, selection) {
-      this.set('selectedLanguage', this.get('languageMap')[selection]);
-      this._setUserLanguageChoice(this.get('selectedLanguage'));
-      this.set('i18n.locale', this.get('selectedLanguage'));
+    selectLanguage(selection) {
+      this.set('selectedLanguage', selection);
+      this._setUserLanguageChoice(selection);
+      this.set('i18n.locale', selection);
       this.get('onFinish')();
     }
   }

--- a/app/components/language-select.js
+++ b/app/components/language-select.js
@@ -19,12 +19,8 @@ export default Ember.Component.extend({
   _setUserLanguage(language) {
     let configDB = this.get('config.configDB');
     configDB.get('current_user').then((user) => {
-      configDB.put({
-        i18n: language,
-        _id: user._id,
-        _rev: user._rev,
-        value: user.value
-      });
+      user.i18n = language;
+      configDB.put(user);
     });
   },
 

--- a/app/components/language-select.js
+++ b/app/components/language-select.js
@@ -3,22 +3,17 @@ import Ember from 'ember';
 export default Ember.Component.extend({
   config: Ember.inject.service(),
   i18n: Ember.inject.service(),
-  // languageOptions: Ember.computed('i18n.locale', function() {
-  //   debugger;
-  //   return [
-  //     {id: 'en', name: 'languages.english'},
-  //     {id: 'fr', name: 'languages.french'}
-  //   ];
-  // }),
+
   languageOptions: function() {
-        let i18n = this.get('i18n');
-        return i18n.get('locales').map((item) => {
-            return {
-                id: item,
-                name: i18n.t(`languages.${item}`)
-            };
-        });
-    }.property('currentLanguage'),
+    let i18n = this.get('i18n');
+    return i18n.get('locales').map((item) => {
+      return {
+        id: item,
+        name: i18n.t(`languages.${item}`)
+      };
+    });
+  }.property('currentLanguage'),
+
   onFinish: null,
 
   _setUserLanguageChoice(language) {

--- a/app/components/language-select.js
+++ b/app/components/language-select.js
@@ -1,18 +1,25 @@
 import Ember from 'ember';
-// import { translationMacro as t } from 'ember-i18n';
 
 export default Ember.Component.extend({
   config: Ember.inject.service(),
   i18n: Ember.inject.service(),
-  languageOptions: Ember.computed('i18n.locale', function() {
-    // debugger;
-    return [
-      {id: 'en', name: 'languages.english'},
-      {id: 'fr', name: 'languages.french'}
-    ];
-  }),
+  // languageOptions: Ember.computed('i18n.locale', function() {
+  //   debugger;
+  //   return [
+  //     {id: 'en', name: 'languages.english'},
+  //     {id: 'fr', name: 'languages.french'}
+  //   ];
+  // }),
+  languageOptions: function() {
+        let i18n = this.get('i18n');
+        return i18n.get('locales').map((item) => {
+            return {
+                id: item,
+                name: i18n.t(`languages.${item}`)
+            };
+        });
+    }.property('currentLanguage'),
   onFinish: null,
-  selectedLanguage: null,
 
   _setUserLanguageChoice(language) {
     let configDB = this.get('config.configDB');
@@ -28,7 +35,6 @@ export default Ember.Component.extend({
 
   actions: {
     selectLanguage(selection) {
-      this.set('selectedLanguage', selection);
       this._setUserLanguageChoice(selection);
       this.set('i18n.locale', selection);
       this.get('onFinish')();

--- a/app/controllers/navigation.js
+++ b/app/controllers/navigation.js
@@ -17,9 +17,6 @@ export default Ember.Controller.extend(HospitalRunVersion, ModalHelper, Progress
   session: Ember.inject.service(),
   syncStatus: '',
   currentOpenNav: null,
-  languages: Ember.computed(function() {
-    return [{ 'en': 'English' }, { 'fr': 'French' }];
-  }),
   selectedLanguage: null,
 
   actions: {

--- a/app/controllers/navigation.js
+++ b/app/controllers/navigation.js
@@ -4,6 +4,7 @@ import ModalHelper from 'hospitalrun/mixins/modal-helper';
 import ProgressDialog from 'hospitalrun/mixins/progress-dialog';
 import UserSession from 'hospitalrun/mixins/user-session';
 import Navigation from 'hospitalrun/mixins/navigation';
+
 export default Ember.Controller.extend(HospitalRunVersion, ModalHelper, ProgressDialog, UserSession, Navigation, {
   ajax: Ember.inject.service(),
   application: Ember.inject.controller(),

--- a/app/controllers/navigation.js
+++ b/app/controllers/navigation.js
@@ -16,6 +16,10 @@ export default Ember.Controller.extend(HospitalRunVersion, ModalHelper, Progress
   session: Ember.inject.service(),
   syncStatus: '',
   currentOpenNav: null,
+  languages: Ember.computed(function() {
+    return [{ 'en': 'English' }, { 'fr': 'French' }];
+  }),
+  selectedLanguage: null,
 
   actions: {
     about() {

--- a/app/imaging/index/route.js
+++ b/app/imaging/index/route.js
@@ -6,7 +6,7 @@ const { computed } = Ember;
 
 export default AbstractIndexRoute.extend({
   modelName: 'imaging',
-  pageTitle: computed('i18n', () => {
+  pageTitle: computed('i18n.locale', () => {
     return t('imaging.pageTitle');
   }),
   searchStatus: 'Requested',

--- a/app/imaging/index/route.js
+++ b/app/imaging/index/route.js
@@ -1,8 +1,14 @@
 import { translationMacro as t } from 'ember-i18n';
 import AbstractIndexRoute from 'hospitalrun/routes/abstract-index-route';
+import Ember from 'ember';
+
+const { computed } = Ember;
+
 export default AbstractIndexRoute.extend({
   modelName: 'imaging',
-  pageTitle: t('imaging.pageTitle'),
+  pageTitle: computed('i18n', () => {
+    return t('imaging.pageTitle');
+  }),
   searchStatus: 'Requested',
 
   _getStartKeyFromItem(item) {

--- a/app/inventory/route.js
+++ b/app/inventory/route.js
@@ -1,14 +1,16 @@
+import { translationMacro as t } from 'ember-i18n';
 import AbstractModuleRoute from 'hospitalrun/routes/abstract-module-route';
 import FulfillRequest from 'hospitalrun/mixins/fulfill-request';
 import InventoryId from 'hospitalrun/mixins/inventory-id';
 import InventoryLocations from 'hospitalrun/mixins/inventory-locations'; // inventory-locations mixin is needed for fulfill-request mixin!
 export default AbstractModuleRoute.extend(FulfillRequest, InventoryId, InventoryLocations, {
   addCapability: 'add_inventory_item',
+  buttonText: t('navigation.subnav.inventoryReceived'),
   additionalButtons: function() {
     if (this.currentUserCan(this.get('addCapability'))) {
       return [{
         buttonAction: 'newInventoryBatch',
-        buttonText: '+ inventory received',
+        buttonText: this.get('buttonText'),
         class: 'btn btn-primary'
       }];
     }

--- a/app/inventory/route.js
+++ b/app/inventory/route.js
@@ -1,4 +1,3 @@
-import { translationMacro as t } from 'ember-i18n';
 import AbstractModuleRoute from 'hospitalrun/routes/abstract-module-route';
 import FulfillRequest from 'hospitalrun/mixins/fulfill-request';
 import InventoryId from 'hospitalrun/mixins/inventory-id';

--- a/app/inventory/route.js
+++ b/app/inventory/route.js
@@ -5,12 +5,11 @@ import InventoryId from 'hospitalrun/mixins/inventory-id';
 import InventoryLocations from 'hospitalrun/mixins/inventory-locations'; // inventory-locations mixin is needed for fulfill-request mixin!
 export default AbstractModuleRoute.extend(FulfillRequest, InventoryId, InventoryLocations, {
   addCapability: 'add_inventory_item',
-  buttonText: t('navigation.subnav.inventoryReceived'),
   additionalButtons: function() {
     if (this.currentUserCan(this.get('addCapability'))) {
       return [{
         buttonAction: 'newInventoryBatch',
-        buttonText: this.get('buttonText'),
+        buttonText: '+ inventory received',
         class: 'btn btn-primary'
       }];
     }

--- a/app/locales/de/translations.js
+++ b/app/locales/de/translations.js
@@ -874,6 +874,17 @@ export default {
     requestsTitle: '',
     sectionTitle: ''
   },
+  languages: {
+    en: '',
+    fr: '',
+    es: '',
+    de: '',
+    ru: '',
+    'es-co': '',
+    'pt-br': '',
+    tr: '',
+    ur: ''
+  },
   loading: {
     messages: {
       '0': '',

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -1073,7 +1073,8 @@ export default {
     about: 'About HospitalRun',
     actions: {
       login: 'Login',
-      logout: 'Logout'
+      logout: 'Logout',
+      selectLanguage: 'Select Language'
     },
     administration: 'Administration',
     billing: 'Billing',

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -900,7 +900,13 @@ export default {
   languages: {
     en: 'English',
     fr: 'French',
-    es: 'Spanish'
+    es: 'Spanish',
+    de: 'German',
+    ru: 'Russian',
+    'es-co': 'Spanish (Colombian)',
+    'pt-br': 'Portuguese (Brazilian)',
+    tr: 'Turkish',
+    ur: 'Urdu'
   },
   loading: {
     messages: {

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -897,6 +897,11 @@ export default {
     requestsTitle: 'Lab Requests',
     sectionTitle: 'Labs'
   },
+  languages: {
+    english: 'English',
+    french: 'French',
+    spanish: 'Spanish'
+  },
   loading: {
     messages: {
       '0': 'The top butterfly flight speed is 12 miles per hour. Some moths can fly 25 miles per hour!',

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -898,9 +898,9 @@ export default {
     sectionTitle: 'Labs'
   },
   languages: {
-    english: 'English',
-    french: 'French',
-    spanish: 'Spanish'
+    en: 'English',
+    fr: 'French',
+    es: 'Spanish'
   },
   loading: {
     messages: {

--- a/app/locales/es-co/translations.js
+++ b/app/locales/es-co/translations.js
@@ -874,6 +874,17 @@ export default {
     requestsTitle: 'Pedido de laboratorio',
     sectionTitle: 'Laboratorios'
   },
+  languages: {
+    en: '',
+    fr: '',
+    es: '',
+    de: '',
+    ru: '',
+    'es-co': '',
+    'pt-br': '',
+    tr: '',
+    ur: ''
+  },
   loading: {
     messages: {
       '0': '',

--- a/app/locales/es/translations.js
+++ b/app/locales/es/translations.js
@@ -877,7 +877,13 @@ export default {
   languages: {
     en: 'Inglés',
     fr: 'Francés',
-    es: 'Español'
+    es: 'Español',
+    de: '',
+    ru: '',
+    'es-co': '',
+    'pt-br': '',
+    tr: '',
+    ur: ''
   },
   loading: {
     messages: {

--- a/app/locales/es/translations.js
+++ b/app/locales/es/translations.js
@@ -874,6 +874,11 @@ export default {
     requestsTitle: 'Pedido de laboratorio',
     sectionTitle: 'Laboratorios'
   },
+  languages: {
+    en: 'Inglés',
+    fr: 'Francés',
+    es: 'Español'
+  },
   loading: {
     messages: {
       '0': '',

--- a/app/locales/fr/translations.js
+++ b/app/locales/fr/translations.js
@@ -1073,7 +1073,8 @@ export default {
     about: 'À propos de HospitalRun',
     actions: {
       login: 'Connexion',
-      logout: 'Deconnexion'
+      logout: 'Deconnexion',
+      selectLanguage: 'Choisir la langue'
     },
     administration: 'Administration',
     billing: 'Facturation',

--- a/app/locales/fr/translations.js
+++ b/app/locales/fr/translations.js
@@ -897,6 +897,11 @@ export default {
     requestsTitle: 'Demandes de labo',
     sectionTitle: 'Labos'
   },
+  languages: {
+    english: 'Anglais',
+    french: 'Français',
+    spanish: 'Espanol'
+  },
   loading: {
     messages: {
       '0': "La vitesse maximal du vol de papillon est de 20 kilomètres par heure. Certaines mites peuvent voler jusqu'à 40 kilomètres par heure !",

--- a/app/locales/fr/translations.js
+++ b/app/locales/fr/translations.js
@@ -900,7 +900,13 @@ export default {
   languages: {
     en: 'Anglais',
     fr: 'Français',
-    es: 'Espanol'
+    es: 'Espanol',
+    de: '',
+    ru: '',
+    'es-co': '',
+    'pt-br': '',
+    tr: '',
+    ur: ''
   },
   loading: {
     messages: {

--- a/app/locales/fr/translations.js
+++ b/app/locales/fr/translations.js
@@ -898,9 +898,9 @@ export default {
     sectionTitle: 'Labos'
   },
   languages: {
-    english: 'Anglais',
-    french: 'Français',
-    spanish: 'Espanol'
+    en: 'Anglais',
+    fr: 'Français',
+    es: 'Espanol'
   },
   loading: {
     messages: {

--- a/app/locales/pt-br/translations.js
+++ b/app/locales/pt-br/translations.js
@@ -874,6 +874,17 @@ export default {
     requestsTitle: 'Requisições de Laboratório',
     sectionTitle: 'Laboratório'
   },
+  languages: {
+    en: '',
+    fr: '',
+    es: '',
+    de: '',
+    ru: '',
+    'es-co': '',
+    'pt-br': '',
+    tr: '',
+    ur: ''
+  },
   loading: {
     messages: {
       '0': 'A velocidade de vôo borboleta superior é de 12 milhas por hora. Alguns meses pode voar 25 milhas por hora!',

--- a/app/locales/ru/translations.js
+++ b/app/locales/ru/translations.js
@@ -874,6 +874,17 @@ export default {
     requestsTitle: '',
     sectionTitle: ''
   },
+  languages: {
+    en: '',
+    fr: '',
+    es: '',
+    de: '',
+    ru: '',
+    'es-co': '',
+    'pt-br': '',
+    tr: '',
+    ur: ''
+  },
   loading: {
     messages: {
       '0': '',

--- a/app/locales/tr/translations.js
+++ b/app/locales/tr/translations.js
@@ -874,6 +874,17 @@ export default {
     requestsTitle: '',
     sectionTitle: ''
   },
+  languages: {
+    en: '',
+    fr: '',
+    es: '',
+    de: '',
+    ru: '',
+    'es-co': '',
+    'pt-br': '',
+    tr: '',
+    ur: ''
+  },
   loading: {
     messages: {
       '0': '',

--- a/app/locales/ur/translations.js
+++ b/app/locales/ur/translations.js
@@ -874,6 +874,17 @@ export default {
     requestsTitle: 'لیب درخواستیں',
     sectionTitle: 'لیبز'
   },
+  languages: {
+    en: '',
+    fr: '',
+    es: '',
+    de: '',
+    ru: '',
+    'es-co': '',
+    'pt-br': '',
+    tr: '',
+    ur: ''
+  },
   loading: {
     messages: {
       '0': 'سب سے تیز تیتلی پرواز کی رفتار فی گھنٹہ 12 میل ہے. کچھ کیڑے 25 میل فی گھنٹہ کی رفتار سے پرواز کر سکتے ہیں',

--- a/app/medication/completed/route.js
+++ b/app/medication/completed/route.js
@@ -1,7 +1,13 @@
 import { translationMacro as t } from 'ember-i18n';
 import MedicationIndexRoute from 'hospitalrun/medication/index/route';
+import Ember from 'ember';
+
+const { computed } = Ember;
+
 export default MedicationIndexRoute.extend({
   modelName: 'medication',
-  pageTitle: t('medication.titles.completedMedication'),
+  pageTitle: computed('i18n.locale', () => {
+    return t('medication.titles.completedMedication');
+  }),
   searchStatus: 'Fulfilled'
 });

--- a/app/medication/index/route.js
+++ b/app/medication/index/route.js
@@ -1,8 +1,14 @@
 import { translationMacro as t } from 'ember-i18n';
 import AbstractIndexRoute from 'hospitalrun/routes/abstract-index-route';
+import Ember from 'ember';
+
+const { computed } = Ember;
+
 export default AbstractIndexRoute.extend({
   modelName: 'medication',
-  pageTitle: t('medication.pageTitle'),
+  pageTitle: computed('i18n.locale', () => {
+    return t('medication.pageTitle');
+  }),
   searchStatus: 'Requested',
 
   _getStartKeyFromItem(item) {

--- a/app/mixins/navigation.js
+++ b/app/mixins/navigation.js
@@ -372,7 +372,7 @@ export default Ember.Mixin.create({
   ],
 
   // Navigation items get mapped localizations
-  localizedNavItems: Ember.computed('navItems.[]', function() {
+  localizedNavItems: Ember.computed('navItems.[]', 'i18n.locale', function() {
     let localizationPrefix = 'navigation.';
     // Supports unlocalized keys for now, otherwise we would get:
     // "Missing translation: key.etc.path"

--- a/app/patients/index/route.js
+++ b/app/patients/index/route.js
@@ -15,7 +15,9 @@ export default AbstractIndexRoute.extend(UserSession, {
     }
   }),
   newButtonText: t('patients.buttons.newPatient'),
-  pageTitle: t('patients.titles.patientListing'),
+  pageTitle: Ember.computed('i18n.locale', () => {
+    return t('patients.titles.patientListing');
+  }),
 
   _getStartKeyFromItem(item) {
     let displayPatientId = item.get('displayPatientId');

--- a/app/patients/reports/route.js
+++ b/app/patients/reports/route.js
@@ -3,7 +3,9 @@ import Ember from 'ember';
 import { translationMacro as t } from 'ember-i18n';
 
 export default AbstractIndexRoute.extend({
-  pageTitle: t('patients.titles.patientReport'),
+  pageTitle: Ember.computed('i18n.locale', () => {
+    return t('patients.titles.patientReport');
+  }),
 
   // No model for reports; data gets retrieved when report is run.
   model() {

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -107,7 +107,8 @@ let ApplicationRoute = Route.extend(ApplicationRouteMixin, ModalHelper, SetupUse
     set(this.controllerFor('navigation'), 'allowSearch', false);
     $('#apploading').remove();
     this.get('config.configDB').get('current_user').then((user) => {
-      this.set('i18n.locale', user.lang);
+      let language = user.i18n || 'en';
+      this.set('i18n.locale', language);
     });
   },
 

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -106,6 +106,9 @@ let ApplicationRoute = Route.extend(ApplicationRouteMixin, ModalHelper, SetupUse
   afterModel() {
     set(this.controllerFor('navigation'), 'allowSearch', false);
     $('#apploading').remove();
+    this.get('config.configDB').get('current_user').then((user) => {
+      this.set('i18n.locale', user.lang);
+    });
   },
 
   renderModal(template) {

--- a/app/styles/components/_sidebar_nav.scss
+++ b/app/styles/components/_sidebar_nav.scss
@@ -88,7 +88,7 @@
     content: ' ';
   }
 
-  > a {
+  > a, div {
     display: block;
     border-top: 1px solid $blue_lightest2;
     padding: 6px 10px;

--- a/app/templates/components/language-select.hbs
+++ b/app/templates/components/language-select.hbs
@@ -1,0 +1,8 @@
+{{select-list
+  className="test-select-lang"
+  prompt=(t 'navigation.actions.selectLanguage')
+  content=languageOptions
+  value=selectedLanguage
+  action=(action 'selectLanguage' selectedLanguage)
+}}
+

--- a/app/templates/components/language-select.hbs
+++ b/app/templates/components/language-select.hbs
@@ -2,7 +2,9 @@
   className="test-select-lang"
   prompt=(t 'navigation.actions.selectLanguage')
   content=languageOptions
-  value=selectedLanguage
-  action=(action 'selectLanguage' selectedLanguage)
+  value=(t 'languages.english')
+  optionLabelPath='name'
+  optionValuePath='id'
+  action=(action 'selectLanguage')
 }}
 

--- a/app/templates/components/language-select.hbs
+++ b/app/templates/components/language-select.hbs
@@ -2,7 +2,6 @@
   className="test-select-lang"
   prompt=(t 'navigation.actions.selectLanguage')
   content=languageOptions
-  value=(t 'languages.english')
   optionLabelPath='name'
   optionValuePath='id'
   action=(action 'selectLanguage')

--- a/app/templates/sidebar_nav/header.hbs
+++ b/app/templates/sidebar_nav/header.hbs
@@ -10,6 +10,7 @@
     <nav class="settings-nav">
       {{#if session.isAuthenticated}}
         <a href="#" class="logout" {{ action 'invalidateSession' }}>{{t "navigation.actions.logout"}}</a>
+      {{language-select onFinish=(action 'toggleSettings')}}
       {{else}}
         {{#link-to 'login'}}{{t "navigation.actions.login"}}{{/link-to}}
       {{/if}}

--- a/tests/acceptance/inventory-test.js
+++ b/tests/acceptance/inventory-test.js
@@ -21,7 +21,7 @@ test('visiting /inventory', function(assert) {
     andThen(function() {
       assert.equal(currentURL(), '/inventory');
       findWithAssert('button:contains(new request)');
-      findWithAssert('button:contains(inventory received)');
+      findWithAssert('button:contains(Inventory Received)');
       findWithAssert('p:contains(No requests found. )');
       findWithAssert('a:contains(Create a new request?)');
     });

--- a/tests/acceptance/inventory-test.js
+++ b/tests/acceptance/inventory-test.js
@@ -21,7 +21,7 @@ test('visiting /inventory', function(assert) {
     andThen(function() {
       assert.equal(currentURL(), '/inventory');
       findWithAssert('button:contains(new request)');
-      findWithAssert('button:contains(Inventory Received)');
+      findWithAssert('button:contains(inventory received)');
       findWithAssert('p:contains(No requests found. )');
       findWithAssert('a:contains(Create a new request?)');
     });

--- a/tests/integration/components/language-select-test.js
+++ b/tests/integration/components/language-select-test.js
@@ -1,0 +1,25 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('language-select', 'Integration | Component | language select', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+
+  this.render(hbs`{{language-select}}`);
+
+  assert.equal(this.$().text().trim(), '');
+
+  // Template block usage:
+  this.render(hbs`
+    {{#language-select}}
+      template block text
+    {{/language-select}}
+  `);
+
+  assert.equal(this.$().text().trim(), 'template block text');
+});

--- a/tests/integration/components/language-select-test.js
+++ b/tests/integration/components/language-select-test.js
@@ -12,14 +12,5 @@ test('it renders', function(assert) {
 
   this.render(hbs`{{language-select}}`);
 
-  assert.equal(this.$().text().trim(), '');
-
-  // Template block usage:
-  this.render(hbs`
-    {{#language-select}}
-      template block text
-    {{/language-select}}
-  `);
-
-  assert.equal(this.$().text().trim(), 'template block text');
+  assert.equal(this.$().text().trim().includes('Select Language'), true);
 });


### PR DESCRIPTION
Addresses #1094 

**Changes proposed in this pull request:**
- Add a dropdown-select element to the settings modal, viewable by clicking the gear icon in the navbar
- The dropdown includes a hard-coded list of languages (for now just 2- English and French), and upon making a selection the language of any text under Handlebars i18n control will immediately update to the new language

NOTE- there are still many elements in the Handlebars views that are either:

a) hard-coded as English, or
b) controlled by i18n but require a page refresh because the i18n logic is in the component, not the view template

In the first case, these will need to be refactored to be controlled by the i18n package.  That's pretty straightforward.

In the 2nd case, this is a little more difficult.  The reasons for putting the i18n logic vary from component to component, so these refactorings will need to be addressed on a case-by-case basis.  For an example, see the logic in `app/inventory/route.js`, which includes a translation for the `inventory received` button text.  There is a function `additionalButtons` which contains information on the button action, button text, classes, etc. which seems to be should be extracted into the view, but this case and others like it require a bit of surgery and I thought it best to get this PR up first.

NB: I was able to extract the button text in the above example from hard-coded english to a translation, but when I try to make it a computed property, the button text renders as empty in the browser.  Not sure why that is, but hopefully the issue will be irrelevant if and when I can extract the i18n logic into the view itself using the "t" view helper.

I'd appreciate any feedback on additional test coverage desired, or on refactoring the code itself to make it more idiomatic for Ember, but any feedback will be considered. :-)

Also, I'll add screenshots of the functionality as it stands now to the Github issue and the comments below, but it may also be advisable to pull down the code from the branch and test it manually on your local machine, before giving a final go-ahead.

cc @HospitalRun/core-maintainers
