### PR TITLE
Readme: Add HospitalRun link and brief description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 HospitalRun frontend
 ========
 
-_Ember frontend for HospitalRun_
+_Ember frontend for [HospitalRun](http://hospitalrun.io/): free software for developing world hospitals_
 
 [![Build Status](https://travis-ci.org/HospitalRun/hospitalrun-frontend.svg?branch=master)](https://travis-ci.org/HospitalRun/hospitalrun-frontend) [![CouchDB](https://img.shields.io/badge/couchdb-1.x-green.svg)](http://couchdb.apache.org/)
 


### PR DESCRIPTION
I arrived here without context, and nowhere did the readme actually say what HospitalRun is.

**Changes proposed in this pull request:**
- Add a few details to the top of the readme to explain what HospitalRun is.

cc @HospitalRun/core-maintainers
