### PR TITLE
Added depends-on option to the service web on docker-compose. Now the…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,5 +4,7 @@ services:
     build: .
     ports:
      - "4200:4200"
+    depends_on:
+     - "couchdb"
   couchdb:
     image: "couchdb:1.6"


### PR DESCRIPTION
Docker services now start in order. Now, "web" depends on "couchdb" to start. The issue I was having was that some times "couchdb" didn't fully started and "web" was already making request. With this dependency, couchdb will always start first.

**Changes proposed in this pull request:**
- Added "depends_on" option for the "web" service in the docker-compose.yml file.

Screenshot of the problem:
![selection_003](https://user-images.githubusercontent.com/6718394/27774958-7cd5b130-5f6a-11e7-9bc9-4c3f25aa4861.png)

cc @HospitalRun/core-maintainers
