### PR TITLE
Update pouchdb-adapter-memory

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "loader.js": "^4.0.11",
     "nano": "6.2.0",
     "pouchdb": "6.2.0",
-    "pouchdb-adapter-memory": "6.2.0",
+    "pouchdb-adapter-memory": "6.3.4",
     "pouchdb-list": "^1.1.0",
     "pouchdb-users": "^1.0.3",
     "stylelint": "~7.7.1",


### PR DESCRIPTION
Update pouchdb-adapter-memory to the latest version 🚀 #1126

Fixes #1126.

**Changes proposed in this pull request:**
- changing version to 6.3.4

*Note: pull requests without proper descriptions may simply be closed without further discussion. We appreciate your contributions, but need to know what you are offering in clearly described format. Thanks! (you can delete this text)*

cc @HospitalRun/core-maintainers
