### PR TITLE
Refactorings for language select component

### DIFF
--- a/app/components/language-select.js
+++ b/app/components/language-select.js
@@ -15,40 +15,33 @@ export default Ember.Component.extend({
 
   onFinish: null,
 
-  _setUserLanguage(language) {
+  _storeUserI18n(language) {
     let configDB = this.get('config.configDB');
     configDB.get('current_user').then((user) => {
       let username = (typeof user.value === 'string') ? user.value : user.value.name;
       configDB.get('preferences').then((db) => {
-        this._updateUserI18NPreference.bind(this, db, username, language)();
-      }).catch(() => {
+        db[username].i18n = language;
+        configDB.put(db);
+      }).catch((err) => {
         this._initUserI18nPreference.bind(this, username, language)();
       });
     });
   },
 
-  _updateUserI18NPreference(db, username, language) {
-    let configDB = this.get('config.configDB');
-    db.options = db.options || {};
-    let db_key = `${username}_i18n`;
-    db.options[db_key] = language;
-    configDB.put(db);
-  },
-
   _initUserI18nPreference(username, i18n) {
     let configDB = this.get('config.configDB');
     let doc = {
-      _id: 'preferences',
-      options: {
-      }
+      _id: 'preferences'
+    };
+    doc[username] = {
+      i18n: "en"
     }
-    doc.options[username + "_i18n"] = i18n;
     configDB.put(doc);
   },
 
   actions: {
     selectLanguage(selection) {
-      this._setUserLanguage(selection);
+      this._storeUserI18n(selection);
       this.set('i18n.locale', selection);
       this.get('onFinish')();
     }

--- a/app/components/language-select.js
+++ b/app/components/language-select.js
@@ -19,33 +19,22 @@ export default Ember.Component.extend({
   _setUserLanguage(language) {
     let configDB = this.get('config.configDB');
     let doc;
-    let username = this._setUsername();
-    configDB.get('preferences').then(db => {
-      db.options = {};
-      db['options'][username + "_i18n"] = language;
-      configDB.put(db).catch(err => {
-        console.log("ERROR UPDATING PREFERENCES:", err);
-      });
-    }).catch(err => {
-      console.log("ERROR RETRIEVING PREFERENCES DATABASE:", err);
-      doc = {
-        _id: 'preferences',
-        options: {
-        }
-      }
-      doc.options[username + "_i18n"] = language;
-      configDB.put(doc).catch(err => {
-        console.log("ERROR SAVING NEW PREFERENCE DATABASE:", err);
-      });
-    });
-  },
-
-  _setUsername() {
-    let configDB = this.get('config.configDB');
     configDB.get('current_user').then((user) => {
-      return user.value;
-    }).catch(err => {
-      console.log("ERROR RETRIEVING USER FROM DATABASE:", err);
+      let username = user.value;
+      configDB.get('preferences').then((db) => {
+        db.options = db.options || {};
+        let db_key = `${username}_i18n`;
+        db.options[db_key] = language;
+        configDB.put(db);
+      }).catch((err) => {
+        doc = {
+          _id: 'preferences',
+          options: {
+          }
+        }
+        doc.options[username + "_i18n"] = language;
+        configDB.put(doc);
+      });
     });
   },
 

--- a/app/components/language-select.js
+++ b/app/components/language-select.js
@@ -23,6 +23,7 @@ export default Ember.Component.extend({
         db[username].i18n = language;
         configDB.put(db);
       }).catch((err) => {
+        console.log(err);
         this._initUserI18nPreference.bind(this, username, language)();
       });
     });
@@ -34,8 +35,8 @@ export default Ember.Component.extend({
       _id: 'preferences'
     };
     doc[username] = {
-      i18n: "en"
-    }
+      i18n: i18n || 'en'
+    };
     configDB.put(doc);
   },
 

--- a/app/components/language-select.js
+++ b/app/components/language-select.js
@@ -18,9 +18,34 @@ export default Ember.Component.extend({
 
   _setUserLanguage(language) {
     let configDB = this.get('config.configDB');
+    let doc;
+    let username = this._setUsername();
+    configDB.get('preferences').then(db => {
+      db.options = {};
+      db['options'][username + "_i18n"] = language;
+      configDB.put(db).catch(err => {
+        console.log("ERROR UPDATING PREFERENCES:", err);
+      });
+    }).catch(err => {
+      console.log("ERROR RETRIEVING PREFERENCES DATABASE:", err);
+      doc = {
+        _id: 'preferences',
+        options: {
+        }
+      }
+      doc.options[username + "_i18n"] = language;
+      configDB.put(doc).catch(err => {
+        console.log("ERROR SAVING NEW PREFERENCE DATABASE:", err);
+      });
+    });
+  },
+
+  _setUsername() {
+    let configDB = this.get('config.configDB');
     configDB.get('current_user').then((user) => {
-      user.i18n = language;
-      configDB.put(user);
+      return user.value;
+    }).catch(err => {
+      console.log("ERROR RETRIEVING USER FROM DATABASE:", err);
     });
   },
 

--- a/app/components/language-select.js
+++ b/app/components/language-select.js
@@ -24,12 +24,12 @@ export default Ember.Component.extend({
         configDB.put(db);
       }).catch((err) => {
         console.log(err);
-        this._initUserI18nPreference.bind(this, username, language)();
+        this._initPreferencesDB.bind(this, username, language)();
       });
     });
   },
 
-  _initUserI18nPreference(username, i18n) {
+  _initPreferencesDB(username, i18n) {
     let configDB = this.get('config.configDB');
     let doc = {
       _id: 'preferences'

--- a/app/components/language-select.js
+++ b/app/components/language-select.js
@@ -2,9 +2,8 @@ import Ember from 'ember';
 
 export default Ember.Component.extend({
   config: Ember.inject.service(),
-  i18n: Ember.inject.service(),
 
-  languageOptions: function() {
+  languageOptions: Ember.computed('i18n.locale', function() {
     let i18n = this.get('i18n');
     return i18n.get('locales').map((item) => {
       return {
@@ -12,30 +11,39 @@ export default Ember.Component.extend({
         name: i18n.t(`languages.${item}`)
       };
     });
-  }.property('currentLanguage'),
+  }),
 
   onFinish: null,
 
   _setUserLanguage(language) {
     let configDB = this.get('config.configDB');
-    let doc;
     configDB.get('current_user').then((user) => {
-      let username = user.value;
+      let username = (typeof user.value === 'string') ? user.value : user.value.name;
       configDB.get('preferences').then((db) => {
-        db.options = db.options || {};
-        let db_key = `${username}_i18n`;
-        db.options[db_key] = language;
-        configDB.put(db);
-      }).catch((err) => {
-        doc = {
-          _id: 'preferences',
-          options: {
-          }
-        }
-        doc.options[username + "_i18n"] = language;
-        configDB.put(doc);
+        this._updateUserI18NPreference.bind(this, db, username, language)();
+      }).catch(() => {
+        this._initUserI18nPreference.bind(this, username, language)();
       });
     });
+  },
+
+  _updateUserI18NPreference(db, username, language) {
+    let configDB = this.get('config.configDB');
+    db.options = db.options || {};
+    let db_key = `${username}_i18n`;
+    db.options[db_key] = language;
+    configDB.put(db);
+  },
+
+  _initUserI18nPreference(username, i18n) {
+    let configDB = this.get('config.configDB');
+    let doc = {
+      _id: 'preferences',
+      options: {
+      }
+    }
+    doc.options[username + "_i18n"] = i18n;
+    configDB.put(doc);
   },
 
   actions: {

--- a/app/controllers/login.js
+++ b/app/controllers/login.js
@@ -3,34 +3,10 @@ import { isAbortError, isTimeoutError } from 'ember-ajax/errors';
 
 let LoginController = Ember.Controller.extend({
   session: Ember.inject.service(),
-  config: Ember.inject.service(),
-
+  languagePreference: Ember.inject.service(),
   errorMessage: null,
   identification: null,
   password: null,
-
-  _initUserI18nPreference: function() {
-    let configDB = this.get('config.configDB');
-    let username;
-    configDB.get('current_user').then((user) => {
-      username = (typeof user.name === 'string') ? user.name : user.value.name;
-      let db_key = `${username}_i18n`;
-      configDB.get('preferences').then((doc) => {
-        // TODO: change this from hard-coded 'en' to something like 'ENV.i18n.defaultLocale'
-        let language = doc.options[db_key] || 'en';
-        this.set('i18n.locale', language);
-      }).catch(err => {
-        let doc = {
-          _id: 'preferences',
-          options: {
-          }
-        };
-        // TODO: change this from hard-coded 'en' to something like 'ENV.i18n.defaultLocale'
-        doc.options[db_key] = 'en';
-        configDB.put(doc);
-      })
-    });
-  },
 
   actions: {
     authenticate() {
@@ -38,7 +14,7 @@ let LoginController = Ember.Controller.extend({
       this.get('session').authenticate('authenticator:custom', {
         identification,
         password
-      }).then(this._initUserI18nPreference.bind(this)).catch((err) => {
+      }).catch((err) => {
         if (isAbortError(err) || isTimeoutError(err)) {
           this.set('errorMessage', false);
           this.set('offlineError', true);

--- a/app/controllers/login.js
+++ b/app/controllers/login.js
@@ -3,9 +3,33 @@ import { isAbortError, isTimeoutError } from 'ember-ajax/errors';
 
 let LoginController = Ember.Controller.extend({
   session: Ember.inject.service(),
+  config: Ember.inject.service(),
+  i18n: Ember.inject.service(),
+
   errorMessage: null,
   identification: null,
   password: null,
+
+  _initUserI18nPreference: function() {
+    let configDB = this.get('config.configDB');
+    let username;
+    configDB.get('current_user').then((user) => {
+      username = user.value.name;
+      let db_key = `${username}_i18n`;
+      configDB.get('preferences').then((doc) => {
+        let language = doc.options[db_key] || 'en';
+        this.set('i18n.locale', language);
+      }).catch(err => {
+        let doc = {
+          _id: 'preferences',
+          options: {
+          }
+        };
+        doc.options[db_key] = 'en';
+        configDB.put(doc);
+      })
+    });
+  },
 
   actions: {
     authenticate() {
@@ -13,7 +37,7 @@ let LoginController = Ember.Controller.extend({
       this.get('session').authenticate('authenticator:custom', {
         identification,
         password
-      }).catch((err) => {
+      }).then(this._initUserI18nPreference.bind(this)).catch((err) => {
         if (isAbortError(err) || isTimeoutError(err)) {
           this.set('errorMessage', false);
           this.set('offlineError', true);

--- a/app/controllers/login.js
+++ b/app/controllers/login.js
@@ -4,7 +4,6 @@ import { isAbortError, isTimeoutError } from 'ember-ajax/errors';
 let LoginController = Ember.Controller.extend({
   session: Ember.inject.service(),
   config: Ember.inject.service(),
-  i18n: Ember.inject.service(),
 
   errorMessage: null,
   identification: null,
@@ -14,7 +13,7 @@ let LoginController = Ember.Controller.extend({
     let configDB = this.get('config.configDB');
     let username;
     configDB.get('current_user').then((user) => {
-      username = user.value.name;
+      username = (typeof user.name === 'string') ? user.name : user.value.name;
       let db_key = `${username}_i18n`;
       configDB.get('preferences').then((doc) => {
         let language = doc.options[db_key] || 'en';

--- a/app/controllers/login.js
+++ b/app/controllers/login.js
@@ -16,6 +16,7 @@ let LoginController = Ember.Controller.extend({
       username = (typeof user.name === 'string') ? user.name : user.value.name;
       let db_key = `${username}_i18n`;
       configDB.get('preferences').then((doc) => {
+        // TODO: change this from hard-coded 'en' to something like 'ENV.i18n.defaultLocale'
         let language = doc.options[db_key] || 'en';
         this.set('i18n.locale', language);
       }).catch(err => {
@@ -24,6 +25,7 @@ let LoginController = Ember.Controller.extend({
           options: {
           }
         };
+        // TODO: change this from hard-coded 'en' to something like 'ENV.i18n.defaultLocale'
         doc.options[db_key] = 'en';
         configDB.put(doc);
       })

--- a/app/initializers/i18n.js
+++ b/app/initializers/i18n.js
@@ -8,5 +8,6 @@ export default {
     app.inject('controller', 'i18n', 'service:i18n');
     app.inject('mixin', 'i18n', 'service:i18n');
     app.inject('model', 'i18n', 'service:i18n');
+    app.inject('component', 'i18n', 'service:i18n');
   }
 };

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -106,20 +106,6 @@ let ApplicationRoute = Route.extend(ApplicationRouteMixin, ModalHelper, SetupUse
   afterModel() {
     set(this.controllerFor('navigation'), 'allowSearch', false);
     $('#apploading').remove();
-    this._initializeUserLanguage();
-  },
-
-  _initializeUserLanguage() {
-    let username;
-    this.get('config.configDB').get('current_user').then((user) => {
-      username = user.value;
-    });
-    this.get('config.configDB').get('preferences').then(db => {
-      let language = db.options[username + '_i18n'] || 'en';
-      this.set('i18n.locale', language);
-    }).catch(err => {
-      console.log("ERROR INITIALIZING USER LANGUAGE PREFERENCE:", err);
-    });
   },
 
   renderModal(template) {

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -12,6 +12,7 @@ let ApplicationRoute = Route.extend(ApplicationRouteMixin, ModalHelper, SetupUse
   database: inject.service(),
   config: inject.service(),
   session: inject.service(),
+  languagePreference: inject.service(),
   shouldSetupUserRole: true,
 
   actions: {
@@ -106,6 +107,7 @@ let ApplicationRoute = Route.extend(ApplicationRouteMixin, ModalHelper, SetupUse
   afterModel() {
     set(this.controllerFor('navigation'), 'allowSearch', false);
     $('#apploading').remove();
+    this.get('languagePreference').initUserI18nPreference();
   },
 
   renderModal(template) {

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -106,9 +106,19 @@ let ApplicationRoute = Route.extend(ApplicationRouteMixin, ModalHelper, SetupUse
   afterModel() {
     set(this.controllerFor('navigation'), 'allowSearch', false);
     $('#apploading').remove();
+    this._initializeUserLanguage();
+  },
+
+  _initializeUserLanguage() {
+    let username;
     this.get('config.configDB').get('current_user').then((user) => {
-      let language = user.i18n || 'en';
+      username = user.value;
+    });
+    this.get('config.configDB').get('preferences').then(db => {
+      let language = db.options[username + '_i18n'] || 'en';
       this.set('i18n.locale', language);
+    }).catch(err => {
+      console.log("ERROR INITIALIZING USER LANGUAGE PREFERENCE:", err);
     });
   },
 

--- a/app/services/config.js
+++ b/app/services/config.js
@@ -182,16 +182,14 @@ export default Ember.Service.extend({
     }).then((user) => {
       let configDB = this.get('configDB');
       let preferences = configDB.get('preferences');
-      let promises = {
-        user: user,
-        preferences: preferences
-      };
+      let promises = { user, preferences };
       return RSVP.hash(promises);
-    }).then(promises => {
-      let preferences = promises.preferences;
-      let userName = promises.user.name || "default";
+    }).then((promises) => {
+      let { preferences } = promises;
+      let userName = promises.user.name || 'default';
       this.set('i18n.locale', preferences[userName].i18n);
-    }).catch(err => {
+    }).catch((err) => {
+      console.log(err);
       config.put({
         _id: 'current_user',
         value: userName

--- a/app/services/config.js
+++ b/app/services/config.js
@@ -12,6 +12,7 @@ export default Ember.Service.extend({
   configDB: null,
   database: inject.service(),
   session: inject.service(),
+  i18n: inject.service(),
   sessionData: Ember.computed.alias('session.data'),
   standAlone: false,
   needsUserSetup: false,
@@ -177,7 +178,20 @@ export default Ember.Service.extend({
     config.get('current_user').then((doc) => {
       doc.value = userName;
       config.put(doc);
-    }).catch(() => {
+      return userName;
+    }).then((user) => {
+      let configDB = this.get('configDB');
+      let preferences = configDB.get('preferences');
+      let promises = {
+        user: user,
+        preferences: preferences
+      };
+      return RSVP.hash(promises);
+    }).then(promises => {
+      let preferences = promises.preferences;
+      let userName = promises.user.name || "default";
+      this.set('i18n.locale', preferences[userName].i18n);
+    }).catch(err => {
       config.put({
         _id: 'current_user',
         value: userName

--- a/app/services/config.js
+++ b/app/services/config.js
@@ -175,25 +175,20 @@ export default Ember.Service.extend({
     if (!userName && sessionData.authenticated) {
       userName = sessionData.authenticated.name;
     }
-    config.get('current_user').then((doc) => {
+    config.get('current_user').then((doc) => {  // Set username in current_user DB
       doc.value = userName;
       config.put(doc);
-      return userName;
-    }).then((user) => {
+    }).then(() => {  // Fetch preferences DB
       let configDB = this.get('configDB');
-      let preferences = configDB.get('preferences');
-      let promises = { user, preferences };
-      return RSVP.hash(promises);
-    }).then((promises) => {
-      let { preferences } = promises;
-      let userName = promises.user.name || 'default';
-      this.set('i18n.locale', preferences[userName].i18n);
+      return configDB.get('preferences');
+    }).then((doc) => {  //  Set current user's i18n preference
+      let name = (typeof userName === 'object') ? userName.name : userName;
+      let i18nPreference = (doc[name]) ? doc[name].i18n : doc.default.i18n;
+      this.set('i18n.locale', i18nPreference);
+      return Ember.RSVP.Promise.resolve();
     }).catch((err) => {
       console.log(err);
-      config.put({
-        _id: 'current_user',
-        value: userName
-      });
+      config.put({ _id: 'current_user', value: userName });
     });
   }
 

--- a/app/services/language-preference.js
+++ b/app/services/language-preference.js
@@ -1,0 +1,33 @@
+import Ember from 'ember';
+
+export default Ember.Service.extend({
+
+  i18n: Ember.inject.service(),
+  config: Ember.inject.service(),
+
+
+  getUsername(user) {
+    let username = "default";
+    if (typeof user.name === 'string') {
+      username = user.name;
+    } else if (typeof user.value === 'string') {
+      username = user.value;
+    } else if (user.value != undefined && typeof user.value.name === 'string') {
+      username = user.value.name;
+    }
+    return username;
+  },
+
+  initUserI18nPreference: function() {
+    let configDB = this.get('config.configDB');
+    let username;
+    configDB.get('current_user').then((user) => {
+      username = this.getUsername(user);
+      return configDB.get('preferences').then((doc) => {
+        // TODO: change this from hard-coded 'en' to something like 'ENV.i18n.defaultLocale'
+        let language = doc[username].i18n || 'en';
+        this.set('i18n.locale', language);
+      });
+    });
+  }
+});

--- a/app/services/language-preference.js
+++ b/app/services/language-preference.js
@@ -19,9 +19,8 @@ export default Ember.Service.extend({
 
   initUserI18nPreference() {
     let configDB = this.get('config.configDB');
-    let username;
     configDB.get('current_user').then((user) => {
-      username = this.getUsername(user);
+      let username = this.getUsername(user);
       let preferences = configDB.get('preferences');
       let promises = { username, preferences };
       return Ember.RSVP.hash(promises);

--- a/app/services/language-preference.js
+++ b/app/services/language-preference.js
@@ -5,9 +5,8 @@ export default Ember.Service.extend({
   i18n: Ember.inject.service(),
   config: Ember.inject.service(),
 
-
   getUsername(user) {
-    let username = "default";
+    let username = 'default';
     if (typeof user.name === 'string') {
       username = user.name;
     } else if (typeof user.value === 'string') {
@@ -18,16 +17,19 @@ export default Ember.Service.extend({
     return username;
   },
 
-  initUserI18nPreference: function() {
+  initUserI18nPreference() {
     let configDB = this.get('config.configDB');
     let username;
     configDB.get('current_user').then((user) => {
       username = this.getUsername(user);
-      return configDB.get('preferences').then((doc) => {
-        // TODO: change this from hard-coded 'en' to something like 'ENV.i18n.defaultLocale'
-        let language = doc[username].i18n || 'en';
-        this.set('i18n.locale', language);
-      });
+      let preferences = configDB.get('preferences');
+      let promises = { username, preferences };
+      return Ember.RSVP.hash(promises);
+    }).then((promises) => {
+      // TODO: change this from hard-coded 'en' to something like 'ENV.i18n.defaultLocale'
+      let { preferences, username } = promises;
+      let language = preferences[username].i18n || 'en';
+      this.set('i18n.locale', language);
     });
   }
 });

--- a/tests/acceptance/language-select-test.js
+++ b/tests/acceptance/language-select-test.js
@@ -1,0 +1,65 @@
+import Ember from 'ember';
+import { module, test } from 'qunit';
+// import moment from 'moment';
+import startApp from 'hospitalrun/tests/helpers/start-app';
+
+// const DATE_TIME_FORMAT = 'l h:mm A';
+// const TIME_FORMAT = 'h:mm';
+
+module('Acceptance | appointments', {
+  beforeEach() {
+    this.application = startApp();
+  },
+
+  afterEach() {
+    Ember.run(this.application, 'destroy');
+  }
+});
+
+test('setting a language preference persists after logout', function(assert) {
+  assert.expect(1);
+  runWithPouchDump('default', function() {
+    authenticateUser({ name: 'foobar' });
+    visit('/');
+
+    andThen(function() {
+      // debugger;
+      assert.equal(currentURL(), '/');
+    });
+    click('a.settings-trigger');
+    // andThen(function() {
+    //   debugger;
+    //   select('.language-select', 'French');
+    //   debugger;
+    // });
+
+    // andThen(function() {
+    //   debugger;
+    //   invalidateSession();
+    //   debugger;
+    // });
+    // andThen(function() {
+    //   debugger;
+    //   visit('/');
+    //   debugger;
+    // });
+    // authenticateUser({ name: 'hradmin' });
+    // visit('/');
+    // andThen(function() {
+    //   debugger;
+    // });
+
+  });
+});
+
+// test('different users can have different language preferences on the same browser', function(assert) {
+  // assert.expect(1);
+  // runWithPouchDump('default', function() {
+  //   visit('/');
+
+  //   andThen(function() {
+  //     assert.equal(currentURL(), '/login');
+  //   });
+
+  // });
+// });

--- a/tests/integration/components/language-select-test.js
+++ b/tests/integration/components/language-select-test.js
@@ -3,13 +3,12 @@ import hbs from 'htmlbars-inline-precompile';
 
 moduleForComponent('language-select', 'Integration | Component | language select', {
   integration: true
+  // beforeEach() {
+  //   this.inject.service('i18n');
+  // }
 });
 
 test('it renders', function(assert) {
-
-  // Set any properties with this.set('myProperty', 'value');
-  // Handle any actions with this.on('myAction', function(val) { ... });
-
   this.render(hbs`{{language-select}}`);
 
   assert.equal(this.$().text().trim().includes('Select Language'), true);

--- a/tests/unit/services/language-preference-test.js
+++ b/tests/unit/services/language-preference-test.js
@@ -1,0 +1,12 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('service:language-preference', 'Unit | Service | language preference', {
+  // Specify the other units that are required for this test.
+  // needs: ['service:foo']
+});
+
+// Replace this with your real tests.
+test('it exists', function(assert) {
+  let service = this.subject();
+  assert.ok(service);
+});


### PR DESCRIPTION
Fixes #1094.

**Changes proposed in this pull request:**
- Add PouchDB `preferences` DB, where things like user-specific i18n preferences can be stored
- upon language selection, user i18n preference is stored in `preferences` DB
- upon login, `i18n.locale` is set to user-specific preference 
- when a different user logs in, their own preferred i18n setting will be used

NOTE: unless the user does a hard browser refresh on the login screen, they will see a flash of English in their homepage title, before the local language appears.  I can't yet figure out why this is.

*Note: pull requests without proper descriptions may simply be closed without further discussion. We appreciate your contributions, but need to know what you are offering in clearly described format. Thanks! (you can delete this text)*

cc @HospitalRun/core-maintainers
