### PR TITLE
Added missing languages translations in the dropdown

### DIFF
--- a/app/locales/de/translations.js
+++ b/app/locales/de/translations.js
@@ -875,15 +875,15 @@ export default {
     sectionTitle: ''
   },
   languages: {
-    en: '',
-    fr: '',
-    es: '',
-    de: '',
-    ru: '',
-    'es-co': '',
-    'pt-br': '',
-    tr: '',
-    ur: ''
+    en: 'Englisch',
+    fr: 'Französisch',
+    es: 'Spanisch',
+    de: 'Deutsche',
+    ru: 'Russisch',
+    'es-co': 'Spanisch (Kolumbianisch)',
+    'pt-br': 'Portugiesisch (Brasilianer)',
+    tr: 'Türkisch',
+    ur: 'Urdu'
   },
   loading: {
     messages: {
@@ -1060,7 +1060,8 @@ export default {
     about: 'Über HospitalRun',
     actions: {
       login: 'Anmelden',
-      logout: 'Abmelden'
+      logout: 'Abmelden',
+      selectLanguage: 'Sprache auswählen'
     },
     administration: 'Administration',
     billing: 'Abrechnung',

--- a/app/locales/es-co/translations.js
+++ b/app/locales/es-co/translations.js
@@ -875,15 +875,15 @@ export default {
     sectionTitle: 'Laboratorios'
   },
   languages: {
-    en: '',
-    fr: '',
-    es: '',
-    de: '',
-    ru: '',
-    'es-co': '',
-    'pt-br': '',
-    tr: '',
-    ur: ''
+    en: 'Inglés',
+    fr: 'Francés',
+    es: 'Español',
+    de: 'Alemán',
+    ru: 'Ruso',
+    'es-co': 'Español (Colombiano)',
+    'pt-br': 'Portugués (Brasileño)',
+    tr: 'Turco',
+    ur: 'Urdu'
   },
   loading: {
     messages: {

--- a/app/locales/es/translations.js
+++ b/app/locales/es/translations.js
@@ -878,12 +878,12 @@ export default {
     en: 'Inglés',
     fr: 'Francés',
     es: 'Español',
-    de: '',
-    ru: '',
-    'es-co': '',
-    'pt-br': '',
-    tr: '',
-    ur: ''
+    de: 'Alemán',
+    ru: 'Ruso',
+    'es-co': 'Español (Colombiano)',
+    'pt-br': 'Portugués (Brasileño)',
+    tr: 'Turco',
+    ur: 'Urdu'
   },
   loading: {
     messages: {
@@ -1060,7 +1060,8 @@ export default {
     about: 'Información de HospitalRun',
     actions: {
       login: 'Ingresar',
-      logout: 'Salir'
+      logout: 'Salir',
+      selectLanguage: 'Seleccione el idioma'
     },
     administration: 'Administracion',
     billing: 'Facturas',

--- a/app/locales/fr/translations.js
+++ b/app/locales/fr/translations.js
@@ -900,13 +900,13 @@ export default {
   languages: {
     en: 'Anglais',
     fr: 'Français',
-    es: 'Espanol',
-    de: '',
-    ru: '',
-    'es-co': '',
-    'pt-br': '',
-    tr: '',
-    ur: ''
+    es: 'Espagnol',
+    de: 'Allemand',
+    ru: 'Russe',
+    'es-co': 'Espagnol (Colombien)',
+    'pt-br': 'Portugais (Brésilien)',
+    tr: 'Turc',
+    ur: 'Ourdou'
   },
   loading: {
     messages: {

--- a/app/locales/pt-br/translations.js
+++ b/app/locales/pt-br/translations.js
@@ -875,15 +875,15 @@ export default {
     sectionTitle: 'Laboratório'
   },
   languages: {
-    en: '',
-    fr: '',
-    es: '',
-    de: '',
-    ru: '',
-    'es-co': '',
-    'pt-br': '',
-    tr: '',
-    ur: ''
+    en: 'Inglês',
+    fr: 'Francês',
+    es: 'Espanhol',
+    de: 'Alemão',
+    ru: 'Russo',
+    'es-co': 'Espanhol (Colombiano)',
+    'pt-br': 'Portugues (Brasileiro)',
+    tr: 'Turco',
+    ur: 'Urdu'
   },
   loading: {
     messages: {
@@ -1060,7 +1060,8 @@ export default {
     about: 'Sobre HospitalRun',
     actions: {
       login: 'Entrar',
-      logout: 'Sair'
+      logout: 'Sair',
+      selectLanguage: 'Selecione o idioma'
     },
     administration: 'Administração',
     billing: 'Faturamento',

--- a/app/locales/ru/translations.js
+++ b/app/locales/ru/translations.js
@@ -875,15 +875,15 @@ export default {
     sectionTitle: ''
   },
   languages: {
-    en: '',
-    fr: '',
-    es: '',
-    de: '',
-    ru: '',
-    'es-co': '',
-    'pt-br': '',
-    tr: '',
-    ur: ''
+    en: 'английский',
+    fr: 'Французский',
+    es: 'испанский',
+    de: 'Немецкий',
+    ru: 'русский',
+    'es-co': 'Испанский (колумбийский)',
+    'pt-br': 'Португальский (бразильский)',
+    tr: 'турецкий',
+    ur: 'урду'
   },
   loading: {
     messages: {
@@ -1060,7 +1060,8 @@ export default {
     about: '',
     actions: {
       login: '',
-      logout: ''
+      logout: '',
+      selectLanguage: 'Выберите язык'
     },
     administration: '',
     billing: '',

--- a/app/locales/tr/translations.js
+++ b/app/locales/tr/translations.js
@@ -875,15 +875,15 @@ export default {
     sectionTitle: ''
   },
   languages: {
-    en: '',
-    fr: '',
-    es: '',
-    de: '',
-    ru: '',
-    'es-co': '',
-    'pt-br': '',
-    tr: '',
-    ur: ''
+    en: 'Ingilizce',
+    fr: 'Fransızca',
+    es: 'İspanyol',
+    de: 'Almanca',
+    ru: 'Rusça',
+    'es-co': 'İspanyolca (Kolombiyalı)',
+    'pt-br': 'Portekizce (Brezilya)',
+    tr: 'Türk',
+    ur: 'Urduca'
   },
   loading: {
     messages: {
@@ -1060,7 +1060,8 @@ export default {
     about: '',
     actions: {
       login: '',
-      logout: ''
+      logout: '',
+      selectLanguage: 'Dil Seçin'
     },
     administration: '',
     billing: '',

--- a/app/locales/ur/translations.js
+++ b/app/locales/ur/translations.js
@@ -875,15 +875,15 @@ export default {
     sectionTitle: 'لیبز'
   },
   languages: {
-    en: '',
-    fr: '',
-    es: '',
-    de: '',
-    ru: '',
-    'es-co': '',
-    'pt-br': '',
-    tr: '',
-    ur: ''
+    en: 'انگریزی',
+    fr: 'فرانسیسی',
+    es: 'ہسپانوی',
+    de: 'جرمن',
+    ru: 'روسی',
+    'es-co': 'ہسپانوی (کولمبیا)',
+    'pt-br': 'پرتگالی (برازیل)',
+    tr: 'ترکی',
+    ur: 'اردو'
   },
   loading: {
     messages: {
@@ -1060,7 +1060,8 @@ export default {
     about: 'HospitalRun  کے بارے',
     actions: {
       login: 'لاگ ان',
-      logout: 'لاگ آوٹ'
+      logout: 'لاگ آوٹ',
+      selectLanguage: 'زبان منتخب کریں'
     },
     administration: 'انتظامیہ',
     billing: 'بلنگ',

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
   "dependencies": {
     "electron-compile": "^6.3.0",
     "electron-localshortcut": "^1.1.1",
-    "electron-protocol-serve": "1.3.0"    
+    "electron-protocol-serve": "1.3.0"
   },
   "ember-addon": {
     "paths": [


### PR DESCRIPTION
Complements/Addresses #1094.

**Changes proposed in this pull request:**
- Added language translations for all available languages

cc @HospitalRun/core-maintainers
![German](https://puu.sh/wQQmZ.png)
![Spanish](https://puu.sh/wQQo2.png) and so on. 

I am a bit confused how there are two dropdowns for spanish and spanish (colombian). As far as I can tell the languages are pretty much the same and differ in dialect/slang. Would love some clarification. 
https://www.quora.com/What-are-the-major-differences-between-Colombian-Spanish-and-Spanish-from-Spain
https://www.lonelyplanet.com/thorntree/forums/americas-mexico/mexico/how-different-is-mexican-spanish-to-colombian-spanish

Also after reviewing my commit files, should I not have included my package-lock.json file (17k lines of code...)? I couldn't find anything about it in the contributing guidelines. Edit: I have now removed it from the commit files.