### PR TITLE
Fixed Logout UX issue where users could logout accidentally

### DIFF
--- a/app/styles/components/_sidebar_nav.scss
+++ b/app/styles/components/_sidebar_nav.scss
@@ -98,6 +98,10 @@
 
     &:first-of-type { border-top: 0; }
   }
+
+  .logout {
+    float: left;
+  }
 }
 
 // sidebar search


### PR DESCRIPTION
Fixes #1134.

**Changes proposed in this pull request:**
- Fixed css styling for logout class

This code references a class of logout, which is actually not defined anywhere (that I could find anyway). 
``` <a href="#" class="logout" {{ action 'invalidateSession' }}>{{t "navigation.actions.logout"}}</a>```

**Previously**
![en](https://puu.sh/wQSKm.png)
![fr](https://puu.sh/wQSIW.png)

**After**
![en](https://puu.sh/wQSSu.png)
![fr](https://puu.sh/wQSTB.png)

In the after pics, the hyperlink to logout is only accessible via clicking the text "log out"
cc @HospitalRun/core-maintainers
