### PR TITLE
fixed max date property on total patient day reports

### DIFF
--- a/app/patients/reports/template.hbs
+++ b/app/patients/reports/template.hbs
@@ -23,10 +23,10 @@
       {{else}}
         <div class="row">
           <div data-test-selector="select-report-start-date">
-            {{date-picker property="startDate" label="Start Date" class="col-sm-4"}}
+            {{date-picker property="startDate" label="Start Date" class="col-sm-4" maxDate="now"}}
           </div>
           <div data-test-selector="select-report-end-date">
-            {{date-picker property="endDate" label="End Date" class="col-sm-4"}}
+            {{date-picker property="endDate" label="End Date" class="col-sm-4" maxDate="now"}}
           </div>
         </div>
       {{/if}}


### PR DESCRIPTION
Fixes #1147 .

**Changes proposed in this pull request:**
-Added `maxDate` property to date-picker which seemed to be missing for this template. All other reporting templates appear to be a-ok from what I can tell.



cc @HospitalRun/core-maintainers
