### PR TITLE
Fixes: Navigation arrows obscure database column headings #1068

### DIFF
--- a/app/medication/index/template.hbs
+++ b/app/medication/index/template.hbs
@@ -21,7 +21,7 @@
           <td>{{medicationRequest.quantity}}</td>
           <td>{{medicationRequest.status}}</td>
           {{#if showActions}}
-            <td>
+            <td class="actions">
               <button class="btn btn-primary" {{action 'editItem' medicationRequest bubbles=false }}>{{t 'labels.fulfill'}}</button>
             </td>
           {{/if}}

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -29,6 +29,7 @@
 @import 'components/imaging';
 @import 'components/labs';
 @import 'components/loading_notice';
+@import 'components/medication';
 @import 'components/pagination';
 @import 'components/panel';
 @import 'components/patient_history';

--- a/app/styles/components/_medication.scss
+++ b/app/styles/components/_medication.scss
@@ -1,0 +1,1 @@
+.actions { width: 160px; }


### PR DESCRIPTION
Fixes #1068 .

**Changes proposed in this pull request:**
- Add class="actions" to action column in app/medication/index/template.hbs.
- Create _medication.scss and gave actions a fixed width.
- Update app.scss to reflect new _medications.scss file.

Description: We set a fixed width on the actions column to bump it over to the left, allowing the nav-paging buttons to not be hidden.

Tested: Latest version of Chrome, Safari, Firefox.

[Before]
<img width="1440" alt="Before" src="https://user-images.githubusercontent.com/19983952/29900642-6042e1d6-8db0-11e7-88fb-48216195e424.png">

[After]
<img width="1440" alt="After" src="https://user-images.githubusercontent.com/19983952/29899221-59399456-8da7-11e7-80a1-d5267ef1cdc4.png">

Not added in this solution, but something we came up with along the way, we moved the nav-paging buttons above and below the table. This would allow the tables to never be obstructed by the buttons and gives the ability for the user to change pages when at the bottom scroll. Just something to consider for future.

<img width="1438" alt="example 1" src="https://user-images.githubusercontent.com/19983952/29901466-544b33ec-8db5-11e7-886e-332bfc66c760.png">

<img width="1436" alt="example 2" src="https://user-images.githubusercontent.com/19983952/29901475-6085a1e2-8db5-11e7-842c-c3766d455a0d.png">

cc @HospitalRun/core-maintainers

Contributors @jsullivan5 @the-oem @evansays