### PR TITLE
Remove deprecated npm crypto module dependency. Close #1155

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "broccoli-asset-rev": "^2.4.5",
     "broccoli-export-text": "0.0.2",
     "broccoli-serviceworker": "0.1.6",
-    "crypto": "1.0.0",
     "csv-parse": "^1.2.0",
     "devtron": "1.4.0",
     "electron-prebuilt-compile": "1.6.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3016,10 +3016,6 @@ crypto-browserify@1.0.9:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/crypto-browserify/-/crypto-browserify-1.0.9.tgz#cc5449685dfb85eb11c9828acc7cb87ab5bbfcc0"
 
-crypto@0.0.3:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/crypto/-/crypto-0.0.3.tgz#470a81b86be4c5ee17acc8207a1f5315ae20dbb0"
-
 cson-parser@^1.0.6:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/cson-parser/-/cson-parser-1.3.5.tgz#7ec675e039145533bf2a6a856073f1599d9c2d24"


### PR DESCRIPTION
Fixes #1155.

**Changes proposed in this pull request:**
- Remove from npm packages.json
- Remove from yarn yarn.lock

This one is quite simple, although I don't understand why there is a yarn.lock file but nothing mention yarn in the install documentation.

cc @HospitalRun/core-maintainers
