### PR TITLE
Add a description about recommended version of Node.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Contributions are welcome via pull requests and issues.  Please see our [contrib
 To install the frontend please do the following:
 
 1. Make sure you have installed [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git).
-2. Make sure you have installed [Node.js](https://nodejs.org/en/download/). Versions 6.0.0 and higher should work.
+2. Make sure you have installed [Node.js](https://nodejs.org/en/download/). Versions 6.0.0 and higher should work. We recommend that you use the mose-recent "Active LTS" version of Node.js.
 3. Install [ember-cli latest](https://www.npmjs.org/package/ember-cli): `npm install -g ember-cli@latest`.
    Depending on your [npm permissions](https://docs.npmjs.com/getting-started/fixing-npm-permissions) you might need root access to install ember-cli.
 4. Install [bower](https://www.npmjs.org/package/bower): `npm install -g bower`.


### PR DESCRIPTION
Prevent warnings displayed when installing current version.
If current version is installed, the following yellow `WARNING` is displayed after execution `make serve` command.

`WARNING: Node v8.5.0 is not tested against Ember CLI on your platform. We recommend that you use the most-recent "Active LTS" version of Node.js`

**Changes proposed in this pull request:**
- Removing the fear that may not be performed stably.
  - I added a description about recommended version of Node.js

*Note: pull requests without proper descriptions may simply be closed without further discussion. We appreciate your contributions, but need to know what you are offering in clearly described format. Thanks! (you can delete this text)*

cc @HospitalRun/core-maintainers
