### PR TITLE
added 2 appointment tests and 2 test-attributes to template

### DIFF
--- a/app/patients/edit/template.hbs
+++ b/app/patients/edit/template.hbs
@@ -251,10 +251,10 @@
             {{#if canAddAppointment}}
               <div class="panel-heading">
                 <div class="right">
-                  <button type="button" class="btn btn-primary" {{action "newAppointment" bubbles=false }}>
+                  <button type="button" class="btn btn-primary" data-test-selector="appointments-btn" {{action "newAppointment" bubbles=false }}>
                     <span class="octicon octicon-plus"></span>{{t 'patients.buttons.newAppointment'}}
                   </button>&nbsp;
-                  <button type="button" class="btn btn-primary" {{action "newSurgicalAppointment" bubbles=false }}>
+                  <button type="button" class="btn btn-primary" data-test-selector="scheduleSurgery-btn" {{action "newSurgicalAppointment" bubbles=false }}>
                     <span class="octicon octicon-plus"></span>{{t 'patients.buttons.scheduleSurgery'}}
                   </button>
                 </div>


### PR DESCRIPTION
Adds tests to increase code-coverage on appointments/edit controller.js to 100% route.js to 96% . Not sure what test would be needed to test line 70 in route.js.

To run code coverage: `ember install ember-cli-code-coverage@0.3.12` version 0.4 seems broken.
Then run `COVERAGE=true ember test` and open hospitalrun-frontend/coverage/index.html to see the results.

**Changes proposed in this pull request:**
- Added attributes to appointment buttons in template for selecting in testscript
- Added appointment test which changes the type of appointment
- Added appointment test created from patient edit screen

cc @HospitalRun/core-maintainers
