### PR TITLE
Added in Header type value in Custom Forms

### DIFF
--- a/app/admin/custom-forms/field-edit/controller.js
+++ b/app/admin/custom-forms/field-edit/controller.js
@@ -14,12 +14,15 @@ export default AbstractEditController.extend({
   actions: {
     addValue() {
       let fieldValues = this.get('model.values');
+      let fieldType = this.get('model.type');
       if (isEmpty(fieldValues)) {
         let model = this.get('model');
         fieldValues = [];
         model.set('values', fieldValues);
       }
-      fieldValues.addObject(Ember.Object.create());
+      if (fieldType === 'header' && fieldValues.length < 1 || fieldType != 'header') {
+        fieldValues.addObject(Ember.Object.create());
+      }
     },
 
     deleteValue(valueToDelete) {
@@ -38,6 +41,7 @@ export default AbstractEditController.extend({
   },
 
   fieldTypeValues: [
+    'header',
     'checkbox',
     'radio',
     'select',
@@ -60,7 +64,7 @@ export default AbstractEditController.extend({
 
   showValues: computed('model.type', function() {
     let type = this.get('model.type');
-    return (type === 'checkbox' || type === 'radio' || type === 'select');
+    return (type === 'checkbox' || type === 'radio' || type === 'select' || type === 'header');
   })
 
 });

--- a/app/admin/custom-forms/field-edit/template.hbs
+++ b/app/admin/custom-forms/field-edit/template.hbs
@@ -32,6 +32,9 @@
         {{#if (eq model.type 'checkbox')}}
           {{t 'admin.customForms.titles.checkboxValues'}}
         {{/if}}
+        {{#if (eq model.type 'header')}}
+          {{t 'admin.customForms.titles.headerValues'}}
+        {{/if}}
         <button class="btn btn-primary align-right" {{action 'addValue'}}>
           {{t "buttons.addValue"}}
         </button>

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -34,6 +34,7 @@ export default {
         expenseTo: 'Expense To',
         formName: 'Form Name',
         formType: 'Form Type',
+        header: 'Header',
         incidentFormType: 'Incident',
         includeOtherOption: 'Include Other Option',
         labFormType: 'Lab',
@@ -60,6 +61,7 @@ export default {
         editCustomForm: 'Edit Custom Form',
         fields: 'Fields',
         formSaved: 'Form Saved',
+        headerValues: 'Header Line Value',
         newCustomForm: 'New Custom Form',
         radioValues: 'Radio Values'
       }

--- a/app/templates/components/custom-form.hbs
+++ b/app/templates/components/custom-form.hbs
@@ -36,6 +36,15 @@
           optionLabelPath="label"
         }}
       {{/if}}
+      {{#if (eq field.type 'header')}}
+        <div class="form-group {{field.displayClassNames}}">
+          <label>{{field.label}}</label>
+          {{#each field.values as |split|}}
+            <br>
+            <label>{{split.label}}</label>
+          {{/each}}
+        </div>
+      {{/if}}
     {{/each}}
   </div>
 {{/each}}

--- a/tests/acceptance/custom-forms-test.js
+++ b/tests/acceptance/custom-forms-test.js
@@ -16,7 +16,7 @@ test('crud operations on custom-forms', function(assert) {
   let crusts =  ['Thin', 'Deep Dish', 'Flatbread'];
   let desserts = ['Ice Cream', 'Cookies', 'Cake'];
   let toppings =  ['Cheese', 'Pepperoni', 'Mushrooms'];
-  let header = '______________________________';
+  let header = ['______________________________'];
 
   function addField(fieldType, label, values) {
     click('button:contains(Add Field)');
@@ -58,7 +58,7 @@ test('crud operations on custom-forms', function(assert) {
     waitToAppear('.form-preview');
     andThen(function() {
       assert.equal(find('.form-preview label:contains(Create a Pizza)').length, 1, 'Found Create a Pizza Label');
-      assert.equal(find(`.form-preview label:contains(${header}):has(label)`).length, 1, `Found ${header} Label`);
+      assert.equal(find(`.form-preview label:contains(${header})`).length, 1, `Found ${header} Label`);
       assert.equal(find('.form-preview label:contains(Pizza Toppings)').length, 1, 'Found Pizza Toppings Label');
       toppings.forEach((topping) => {
         assert.equal(find(`.form-preview label:contains(${topping}):has(input[type=checkbox])`).length, 1, `Found ${topping} checkbox`);

--- a/tests/acceptance/custom-forms-test.js
+++ b/tests/acceptance/custom-forms-test.js
@@ -16,6 +16,7 @@ test('crud operations on custom-forms', function(assert) {
   let crusts =  ['Thin', 'Deep Dish', 'Flatbread'];
   let desserts = ['Ice Cream', 'Cookies', 'Cake'];
   let toppings =  ['Cheese', 'Pepperoni', 'Mushrooms'];
+  let header = '______________________________';
 
   function addField(fieldType, label, values) {
     click('button:contains(Add Field)');
@@ -56,6 +57,8 @@ test('crud operations on custom-forms', function(assert) {
     click('button:contains(Preview)');
     waitToAppear('.form-preview');
     andThen(function() {
+      assert.equal(find('.form-preview label:contains(Create a Pizza)').length, 1, 'Found Create a Pizza Label');
+      assert.equal(find(`.form-preview label:contains(${header}):has(label)`).length, 1, `Found ${header} Label`);
       assert.equal(find('.form-preview label:contains(Pizza Toppings)').length, 1, 'Found Pizza Toppings Label');
       toppings.forEach((topping) => {
         assert.equal(find(`.form-preview label:contains(${topping}):has(input[type=checkbox])`).length, 1, `Found ${topping} checkbox`);
@@ -95,6 +98,9 @@ test('crud operations on custom-forms', function(assert) {
     });
     andThen(function() {
       assert.equal(find('.modal-title').text(), 'Form Saved', 'Form is saved');
+      addField('Header', 'Create a Pizza', header);
+    });
+    andThen(function() {
       addField('Checkbox', 'Pizza Toppings', toppings);
     });
     andThen(function() {


### PR DESCRIPTION
Closes #1140 

**Changes proposed in this pull request:**
- Added Header value to the Custom Forms Add Field drop-down
- When user selects the header option, it shows the Add Value section
- Have limited how many values a user can add to 1 for the header option, the rest have no limit still
- Displays the new header value in the form

![hr_custom_form_header_value](https://user-images.githubusercontent.com/10661000/31054549-93bb20ae-a6ac-11e7-8ace-9870890000ed.jpg)


![hr_custom_form_header_label](https://user-images.githubusercontent.com/10661000/31054606-fc3ec54e-a6ad-11e7-9945-35e7ead56294.jpg)



*Note: pull requests without proper descriptions may simply be closed without further discussion. We appreciate your contributions, but need to know what you are offering in clearly described format. Thanks! (you can delete this text)*

cc @HospitalRun/core-maintainers
