### PR TITLE
Reduce number of notes in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,12 +37,11 @@ To install the frontend please do the following:
    Depending on your [npm permissions](https://docs.npmjs.com/getting-started/fixing-npm-permissions) you might need root access to install ember-cli.
 4. Install [bower](https://www.npmjs.org/package/bower): `npm install -g bower`.
 5. Clone this repo with `git clone https://github.com/HospitalRun/hospitalrun-frontend`, go to the cloned folder and run `script/bootstrap`.
-  - **Note:** *If installing packages globally via `npm` requires root access on your machine (see `ember-cli` installation), running `script/bootstrap` will also require root access. The contained `bower install` step will fail when running as root. A fix for this is to edit `script/bootstrap` and add the `--allow-root` option to the command: `bower install --allow-root`.*
-  - **Note:** *If you are using Windows with `cygwin` please run the script in the following way to remove trailing `\r` characters:*
+  - **Note:** *Windows users must use [Cygwin](http://cygwin.org/). If that is your case, please run the script in the following way to remove trailing `\r` characters:*
   ``` bash
   bash -o igncr script/bootstrap
   ```
-  - **Note:** *Depending on your [npm permissions](https://docs.npmjs.com/getting-started/fixing-npm-permissions) you might need root access to install PhantomJS2; also, Windows users must run with [Cygwin](http://cygwin.org/)).*
+  - **Note:** *If installing packages globally via `npm` requires root access on your machine (see `ember-cli` installation), running `script/bootstrap` will also require root access to install PhantomJS2. The contained `bower install` step will fail when running as root. A fix for this is to edit `script/bootstrap` and add the `--allow-root` option to the command: `bower install --allow-root`.*
   - **Note:** *If you just want to use the project, cloning is the best option. However, if you wish to contribute to the project, you will need to fork the project first, and then clone your `hospitalrun-frontend` fork and make your contributions via a branch on your fork.*
 6. Install and configure [CouchDB](http://couchdb.apache.org/):
     1. Download and install CouchDB from http://couchdb.apache.org/#download.


### PR DESCRIPTION
Fixes self-reported issue.

**Changes proposed in this pull request:**
* Turns three notes in the bootstrap section into two: the one that was deleted contained information that was relevant inside other, existing notes.
* Moves the "Windows users must run with Cygwin" note above the root issue for bower, as it is of greater importance (at least from my perspective as a Windows user who doesn't use Cygwin all that much).

<hr/>

Sorry about the double PR for the Readme, I completely missed the surroundings of the root & bower install note back in my first PR. I just fully read the instructions and the notes section as it was proved confusing and messy because it discussed the same things in multiple notes.

cc @HospitalRun/core-maintainers
