### PR TITLE
333-inventory-let the user to adjust the location/ archive a location

### DIFF
--- a/app/inventory/edit/template.hbs
+++ b/app/inventory/edit/template.hbs
@@ -68,7 +68,7 @@
           {{/if}}
         </tr>
         {{#each model.locations as |location|}}
-          {{#if location.quantity}}
+          {{#unless location.archived}}
             <tr>
               <td>{{location.location}}</td>
               <td>{{location.aisleLocation}}</td>
@@ -77,10 +77,14 @@
                 <td>
                   <button class="btn btn-primary neutral" {{action "showAdjustment" location}}>{{t 'inventory.labels.adjust'}}</button>
                   <button class="btn btn-primary btn-extra" {{action "showTransfer" location}}>{{t 'inventory.labels.transfer'}}</button>
+                  {{#unless location.quantity}}
+                  <button class="btn btn-default warning" {{action 'deleteItem' location
+                    bubbles=false }}><span class="octicon octicon-x"></span> {{t 'buttons.delete'}}</button>
+                  {{/unless}}
                 </td>
               {{/if}}
             </tr>
-          {{/if}}
+         {{/unless}}
         {{/each}}
       </table>
       {{#if showTransactions}}


### PR DESCRIPTION
Addresses #333.

**Changes proposed in this pull request:**
- Allows a location to be shown and adjust even if the quantity is 0
- A location can be deleted (archived set to true) to remove any unneeded locations
**Base Inventory Edit Screen**
![hr_inv_start_new](https://user-images.githubusercontent.com/10661000/31575264-85854c20-b0da-11e7-8e27-b7e195c96547.jpg)

**Changes that I have made**
![hr_inv_quantity_new](https://user-images.githubusercontent.com/10661000/31575262-79aec7aa-b0da-11e7-8425-526c2491d040.jpg)









*Note: pull requests without proper descriptions may simply be closed without further discussion. We appreciate your contributions, but need to know what you are offering in clearly described format. Thanks! (you can delete this text)*

cc @HospitalRun/core-maintainers
