### PR TITLE
#1268 need to use UTC in dob-days to pass tests in different timezones

### DIFF
--- a/app/mixins/dob-days.js
+++ b/app/mixins/dob-days.js
@@ -37,7 +37,7 @@ export default Ember.Mixin.create({
       }
 
       if (birthDate.getDate) {
-        days = today.getDate() - birthDate.getDate();
+        days = today.getUTCDate() - birthDate.getUTCDate();
         if (days < 0) {
           days += 30;
         }


### PR DESCRIPTION
address #1268 

**Changes proposed in this pull request:**
- perform date comparison using UTC time to pass dob-days phantomJS tests

cc @HospitalRun/core-maintainers
