### PR TITLE
Fix missing language error for language dropdown menu in navigation bar

### DIFF
--- a/app/locales/de/translations.js
+++ b/app/locales/de/translations.js
@@ -884,7 +884,7 @@ export default {
     'pt-br': 'Portugiesisch (Brasilianer)',
     tr: 'Türkisch',
     ur: 'Urdu',
-    hndi: 'Hindi'
+    hindi: 'Hindi'
   },
   loading: {
     messages: {

--- a/app/locales/de/translations.js
+++ b/app/locales/de/translations.js
@@ -884,7 +884,7 @@ export default {
     'pt-br': 'Portugiesisch (Brasilianer)',
     tr: 'Türkisch',
     ur: 'Urdu',
-    hindi: 'Hindi'
+    hi: 'Hindi'
   },
   loading: {
     messages: {

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -916,7 +916,7 @@ export default {
     'pt-br': 'Portuguese (Brazilian)',
     tr: 'Turkish',
     ur: 'Urdu',
-    hindi: 'Hindi'
+    hi: 'Hindi'
   },
   loading: {
     messages: {

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -916,7 +916,7 @@ export default {
     'pt-br': 'Portuguese (Brazilian)',
     tr: 'Turkish',
     ur: 'Urdu',
-    hndi: 'Hindi'
+    hindi: 'Hindi'
   },
   loading: {
     messages: {

--- a/app/locales/es-co/translations.js
+++ b/app/locales/es-co/translations.js
@@ -884,7 +884,7 @@ export default {
     'pt-br': 'Portugués (Brasileño)',
     tr: 'Turco',
     ur: 'Urdu',
-    hindi: 'Hindi'
+    hi: 'Hindi'
   },
   loading: {
     messages: {

--- a/app/locales/es-co/translations.js
+++ b/app/locales/es-co/translations.js
@@ -884,7 +884,7 @@ export default {
     'pt-br': 'Portugués (Brasileño)',
     tr: 'Turco',
     ur: 'Urdu',
-    hndi: 'Hindi'
+    hindi: 'Hindi'
   },
   loading: {
     messages: {

--- a/app/locales/es/translations.js
+++ b/app/locales/es/translations.js
@@ -884,7 +884,7 @@ export default {
     'pt-br': 'Portugués (Brasileño)',
     tr: 'Turco',
     ur: 'Urdu',
-    hindi: 'Hindi'
+    hi: 'Hindi'
   },
   loading: {
     messages: {

--- a/app/locales/es/translations.js
+++ b/app/locales/es/translations.js
@@ -884,7 +884,7 @@ export default {
     'pt-br': 'Portugués (Brasileño)',
     tr: 'Turco',
     ur: 'Urdu',
-    hndi: 'Hindi'
+    hindi: 'Hindi'
   },
   loading: {
     messages: {

--- a/app/locales/fr/translations.js
+++ b/app/locales/fr/translations.js
@@ -907,7 +907,7 @@ export default {
     'pt-br': 'Portugais (Brésilien)',
     tr: 'Turc',
     ur: 'Ourdou',
-    hndi: 'Hindi'
+    hindi: 'Hindi'
   },
   loading: {
     messages: {

--- a/app/locales/fr/translations.js
+++ b/app/locales/fr/translations.js
@@ -907,7 +907,7 @@ export default {
     'pt-br': 'Portugais (Brésilien)',
     tr: 'Turc',
     ur: 'Ourdou',
-    hindi: 'Hindi'
+    hi: 'Hindi'
   },
   loading: {
     messages: {

--- a/app/locales/hi/translations.js
+++ b/app/locales/hi/translations.js
@@ -914,7 +914,7 @@ export default {
     'pt-br': 'पुर्तगाली (ब्राजील)',
     tr: 'तुर्की',
     ur: 'उर्दू',
-    hindi: 'हिंदी'
+    hi: 'हिंदी'
   },
   loading: {
     messages: {

--- a/app/locales/hindi/translations.js
+++ b/app/locales/hindi/translations.js
@@ -914,7 +914,7 @@ export default {
     'pt-br': 'पुर्तगाली (ब्राजील)',
     tr: 'तुर्की',
     ur: 'उर्दू',
-    hndi: 'हिंदी'
+    hindi: 'हिंदी'
   },
   loading: {
     messages: {

--- a/app/locales/pt-br/translations.js
+++ b/app/locales/pt-br/translations.js
@@ -884,7 +884,7 @@ export default {
     'pt-br': 'Portugues (Brasileiro)',
     tr: 'Turco',
     ur: 'Urdu',
-    hndi: 'Hindi'
+    hindi: 'Hindi'
   },
   loading: {
     messages: {

--- a/app/locales/pt-br/translations.js
+++ b/app/locales/pt-br/translations.js
@@ -884,7 +884,7 @@ export default {
     'pt-br': 'Portugues (Brasileiro)',
     tr: 'Turco',
     ur: 'Urdu',
-    hindi: 'Hindi'
+    hi: 'Hindi'
   },
   loading: {
     messages: {

--- a/app/locales/ru/translations.js
+++ b/app/locales/ru/translations.js
@@ -885,7 +885,7 @@ export default {
     'pt-br': 'Португальский (бразильский)',
     tr: 'турецкий',
     ur: 'урду',
-    hindi: 'хинди'
+    hi: 'хинди'
   },
   loading: {
     messages: {

--- a/app/locales/tr/translations.js
+++ b/app/locales/tr/translations.js
@@ -884,7 +884,7 @@ export default {
     'pt-br': 'Portekizce (Brezilya)',
     tr: 'Türk',
     ur: 'Urduca',
-    hindi: 'Hindi'
+    hindi: 'Hintçe'
   },
   loading: {
     messages: {

--- a/app/locales/tr/translations.js
+++ b/app/locales/tr/translations.js
@@ -884,7 +884,7 @@ export default {
     'pt-br': 'Portekizce (Brezilya)',
     tr: 'Türk',
     ur: 'Urduca',
-    hindi: 'Hintçe'
+    hi: 'Hintçe'
   },
   loading: {
     messages: {

--- a/app/locales/ur/translations.js
+++ b/app/locales/ur/translations.js
@@ -884,7 +884,7 @@ export default {
     'pt-br': 'پرتگالی (برازیل)',
     tr: 'ترکی',
     ur: 'اردو',
-    hindi: 'ہندی'
+    hi: 'ہندی'
   },
   loading: {
     messages: {

--- a/app/locales/ur/translations.js
+++ b/app/locales/ur/translations.js
@@ -883,7 +883,8 @@ export default {
     'es-co': 'ہسپانوی (کولمبیا)',
     'pt-br': 'پرتگالی (برازیل)',
     tr: 'ترکی',
-    ur: 'اردو'
+    ur: 'اردو',
+    hindi: 'ہندی'
   },
   loading: {
     messages: {


### PR DESCRIPTION
Fix missing language error for language dropdown menu in navigation bar

Fixes #1276 .

**Changes proposed in this pull request:**
- translations.js for each language under locales folder

cc @HospitalRun/core-maintainers
