### PR TITLE
Make language names in dropdown the same regardless of locale

### DIFF
--- a/app/components/language-select.js
+++ b/app/components/language-select.js
@@ -6,12 +6,18 @@ export default Ember.Component.extend({
 
   languageOptions: function() {
     let i18n = this.get('i18n');
-    return i18n.get('locales').map((item) => {
+    // Hacking around the fact that i18n
+    // has no support for t(key, locale).
+    let currentLocale = i18n.get('locale');
+    let options = i18n.get('locales').map((item) => {
+      i18n.set('locale', item);
       return {
         id: item,
-        name: i18n.t(`languages.${item}`)
+        name: i18n.t('languageName')
       };
     });
+    i18n.set('locale', currentLocale);
+    return options;
   }.property('currentLanguage'),
 
   onFinish: null,

--- a/app/locales/de/translations.js
+++ b/app/locales/de/translations.js
@@ -1,4 +1,5 @@
 export default {
+  languageName: 'Deutsche',
   admin: {
     address: {
       address1Label: 'Adresse 1 Kennzeichen',
@@ -873,18 +874,6 @@ export default {
     newTitle: '',
     requestsTitle: '',
     sectionTitle: ''
-  },
-  languages: {
-    en: 'Englisch',
-    fr: 'Französisch',
-    es: 'Spanisch',
-    de: 'Deutsche',
-    ru: 'Russisch',
-    'es-co': 'Spanisch (Kolumbianisch)',
-    'pt-br': 'Portugiesisch (Brasilianer)',
-    tr: 'Türkisch',
-    ur: 'Urdu',
-    hi: 'Hindi'
   },
   loading: {
     messages: {

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -1,4 +1,5 @@
 export default {
+  languageName: 'English',
   admin: {
     address: {
       address1Label: 'Address 1 Label',
@@ -905,18 +906,6 @@ export default {
     newTitle: 'New Lab Request',
     requestsTitle: 'Lab Requests',
     sectionTitle: 'Labs'
-  },
-  languages: {
-    en: 'English',
-    fr: 'French',
-    es: 'Spanish',
-    de: 'German',
-    ru: 'Russian',
-    'es-co': 'Spanish (Colombian)',
-    'pt-br': 'Portuguese (Brazilian)',
-    tr: 'Turkish',
-    ur: 'Urdu',
-    hi: 'Hindi'
   },
   loading: {
     messages: {

--- a/app/locales/es-co/translations.js
+++ b/app/locales/es-co/translations.js
@@ -1,4 +1,5 @@
 export default {
+  languageName: 'Español (Colombiano)',
   admin: {
     address: {
       address1Label: 'Texto direccion 1',
@@ -873,18 +874,6 @@ export default {
     newTitle: 'Nuevo pedido de laboratorio',
     requestsTitle: 'Pedido de laboratorio',
     sectionTitle: 'Laboratorios'
-  },
-  languages: {
-    en: 'Inglés',
-    fr: 'Francés',
-    es: 'Español',
-    de: 'Alemán',
-    ru: 'Ruso',
-    'es-co': 'Español (Colombiano)',
-    'pt-br': 'Portugués (Brasileño)',
-    tr: 'Turco',
-    ur: 'Urdu',
-    hi: 'Hindi'
   },
   loading: {
     messages: {

--- a/app/locales/es/translations.js
+++ b/app/locales/es/translations.js
@@ -1,4 +1,5 @@
 export default {
+  languageName: 'Español',
   admin: {
     address: {
       address1Label: 'Texto dirección 1',
@@ -873,18 +874,6 @@ export default {
     newTitle: 'Nuevo pedido de laboratorio',
     requestsTitle: 'Pedido de laboratorio',
     sectionTitle: 'Laboratorios'
-  },
-  languages: {
-    en: 'Inglés',
-    fr: 'Francés',
-    es: 'Español',
-    de: 'Alemán',
-    ru: 'Ruso',
-    'es-co': 'Español (Colombiano)',
-    'pt-br': 'Portugués (Brasileño)',
-    tr: 'Turco',
-    ur: 'Urdu',
-    hi: 'Hindi'
   },
   loading: {
     messages: {

--- a/app/locales/fr/translations.js
+++ b/app/locales/fr/translations.js
@@ -1,4 +1,5 @@
 export default {
+  languageName: 'Français',
   admin: {
     address: {
       address1Label: "Label de l'adresse 1",
@@ -896,18 +897,6 @@ export default {
     newTitle: 'Nouvelle demande de labo',
     requestsTitle: 'Demandes de labo',
     sectionTitle: 'Labos'
-  },
-  languages: {
-    en: 'Anglais',
-    fr: 'Français',
-    es: 'Espagnol',
-    de: 'Allemand',
-    ru: 'Russe',
-    'es-co': 'Espagnol (Colombien)',
-    'pt-br': 'Portugais (Brésilien)',
-    tr: 'Turc',
-    ur: 'Ourdou',
-    hi: 'Hindi'
   },
   loading: {
     messages: {

--- a/app/locales/hi/translations.js
+++ b/app/locales/hi/translations.js
@@ -1,4 +1,5 @@
 export default {
+  languageName: 'हिंदी',
   admin: {
     address: {
       address1Label: 'पता 1 लेबल',
@@ -903,18 +904,6 @@ export default {
     newTitle: 'New Lab Request',
     requestsTitle: 'Lab Requests',
     sectionTitle: 'Labs'
-  },
-  languages: {
-    en: 'अंग्रेज़ी',
-    fr: 'फ्रेंच',
-    es: 'स्पेनिश',
-    de: 'जर्मन',
-    ru: 'रूसी',
-    'es-co': 'स्पेनिश (कोलम्बियाई)',
-    'pt-br': 'पुर्तगाली (ब्राजील)',
-    tr: 'तुर्की',
-    ur: 'उर्दू',
-    hi: 'हिंदी'
   },
   loading: {
     messages: {

--- a/app/locales/pt-br/translations.js
+++ b/app/locales/pt-br/translations.js
@@ -1,4 +1,5 @@
 export default {
+  languageName: 'Portugues (Brasileiro)',
   admin: {
     address: {
       address1Label: 'Rótulo Endereço 1',
@@ -873,18 +874,6 @@ export default {
     newTitle: 'Nova Requisição de Laboratório',
     requestsTitle: 'Requisições de Laboratório',
     sectionTitle: 'Laboratório'
-  },
-  languages: {
-    en: 'Inglês',
-    fr: 'Francês',
-    es: 'Espanhol',
-    de: 'Alemão',
-    ru: 'Russo',
-    'es-co': 'Espanhol (Colombiano)',
-    'pt-br': 'Portugues (Brasileiro)',
-    tr: 'Turco',
-    ur: 'Urdu',
-    hi: 'Hindi'
   },
   loading: {
     messages: {

--- a/app/locales/ru/translations.js
+++ b/app/locales/ru/translations.js
@@ -1,5 +1,5 @@
-
 export default {
+  languageName: 'русский',
   admin: {
     address: {
       address1Label: '',
@@ -874,18 +874,6 @@ export default {
     newTitle: '',
     requestsTitle: '',
     sectionTitle: ''
-  },
-  languages: {
-    en: 'английский',
-    fr: 'Французский',
-    es: 'испанский',
-    de: 'Немецкий',
-    ru: 'русский',
-    'es-co': 'Испанский (колумбийский)',
-    'pt-br': 'Португальский (бразильский)',
-    tr: 'турецкий',
-    ur: 'урду',
-    hi: 'хинди'
   },
   loading: {
     messages: {

--- a/app/locales/tr/translations.js
+++ b/app/locales/tr/translations.js
@@ -1,4 +1,5 @@
 export default {
+  languageName: 'Türk',
   admin: {
     address: {
       address1Label: '',
@@ -873,18 +874,6 @@ export default {
     newTitle: '',
     requestsTitle: '',
     sectionTitle: ''
-  },
-  languages: {
-    en: 'Ingilizce',
-    fr: 'Fransızca',
-    es: 'İspanyol',
-    de: 'Almanca',
-    ru: 'Rusça',
-    'es-co': 'İspanyolca (Kolombiyalı)',
-    'pt-br': 'Portekizce (Brezilya)',
-    tr: 'Türk',
-    ur: 'Urduca',
-    hi: 'Hintçe'
   },
   loading: {
     messages: {

--- a/app/locales/ur/translations.js
+++ b/app/locales/ur/translations.js
@@ -1,4 +1,5 @@
 export default {
+  languageName: 'اردو',
   admin: {
     address: {
       address1Label: 'ایڈریس 1 لیبل',
@@ -873,18 +874,6 @@ export default {
     newTitle: 'نئے لیب کی گذارش',
     requestsTitle: 'لیب درخواستیں',
     sectionTitle: 'لیبز'
-  },
-  languages: {
-    en: 'انگریزی',
-    fr: 'فرانسیسی',
-    es: 'ہسپانوی',
-    de: 'جرمن',
-    ru: 'روسی',
-    'es-co': 'ہسپانوی (کولمبیا)',
-    'pt-br': 'پرتگالی (برازیل)',
-    tr: 'ترکی',
-    ur: 'اردو',
-    hi: 'ہندی'
   },
   loading: {
     messages: {


### PR DESCRIPTION
Fixes part of #1245

**Changes proposed in this pull request:**
- Make language names in dropdown the same regardless of locale. This is useful so that users can find their preferred language easily regardless of what is already chosen.

cc @HospitalRun/core-maintainers
