### PR TITLE
Update Docker Compose and Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,23 @@
-FROM ubuntu:14.04
+FROM node:6-alpine
 
-# install couchdb
-RUN apt-get update && apt-get install curl sudo git wget -y
+# install script dependencies
+RUN apk update && apk add sudo curl git wget
 
-# install hospital run
-RUN curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash -
-RUN apt-get update && apt-get install nodejs -y
+# setup folders
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
-COPY . /usr/src/app
 
+# install npm dependencies
+COPY ./package.json /usr/src/app
 RUN npm install -g ember-cli@latest && npm install -g bower
 RUN npm install
 
+# install source code
+COPY . /usr/src/app
 RUN bower install --allow-root
 COPY ./server/config-example.js ./server/config.js
 
+# define settings
 RUN sed -i -e 's/URL="localhost"/URL="couchdb"/g' ./script/initcouch.sh
 RUN sed -i -e "s/couchDbServer: 'localhost'/couchDbServer: 'couchdb'/g" ./server/config.js
 RUN sed -i -e "s/localhost:5984/couchdb:5984/g" ./script/server

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,18 @@
-version: '2'
+version: '2.1'
 services:
   web:
     build: .
     ports:
      - "4200:4200"
     depends_on:
-     - "couchdb"
+      couchdb:
+        condition: "service_healthy"
   couchdb:
-    image: "couchdb:1.6"
+    image: "couchdb:1.7.1"
+    ports:
+     - "5984:5984"
+    healthcheck:
+        test: ["CMD", "curl", "-f", "http://localhost:5984/"]
+        interval: 10s
+        timeout: 90s
+        retries: 9


### PR DESCRIPTION
Fixes https://github.com/HospitalRun/hospitalrun-frontend/issues/1293.

**Changes proposed in this pull request:**
- Update Dockerfile to use `node:6-alpine` instead of `ubuntu`
- Update Dockerfile to install `npm` dependencies first, decreasing build time. (NOTE: should also include bower as well, but bower is deprecated and will need to be fixed anyway).
- Update `docker-compose.yml` to wait for `couchdb` to be launched before launching hospitalrun, prevent errors.

cc @HospitalRun/core-maintainers
