### PR TITLE
chore(package): update ember-cli to version 2.16.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "electron-rebuild": "^1.5.7",
     "ember-ajax": "^3.0.0",
     "ember-browserify": "^1.1.12",
-    "ember-cli": "2.10.0",
+    "ember-cli": "2.16.2",
     "ember-cli-active-link-wrapper": "0.3.2",
     "ember-cli-app-version": "^3.0.0",
     "ember-cli-babel": "^5.1.7",


### PR DESCRIPTION
Closes #1257

Fixes #1257.

**Changes proposed in this pull request:**
- update ember-cli to the latest version

cc @HospitalRun/core-maintainers
