### PR TITLE
chore(package): update pouchdb to version 6.3.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "loader.js": "^4.0.11",
     "minimatch": "^3.0.2",
     "nano": "6.3.0",
-    "pouchdb": "6.2.0",
+    "pouchdb": "6.3.4",
     "pouchdb-adapter-memory": "6.3.4",
     "pouchdb-list": "^1.1.0",
     "pouchdb-users": "^1.0.3",


### PR DESCRIPTION
Closes #1125 #1260.

**Changes proposed in this pull request:**
- pouchdb is on its latest
- rebased -> no merge conflict

cc @HospitalRun/core-maintainers
