### PR TITLE
Found a bug in expand text component.

### DIFF
--- a/app/components/expand-text.js
+++ b/app/components/expand-text.js
@@ -18,24 +18,8 @@ export default Component.extend({
 
   didInsertElement() {
 
-    let feedbackDiv = document.createElement('div');
-    feedbackDiv.style.position = 'absolute';
     let [textarea] = this.$('textarea');
     this.set('textarea', textarea);
-    let textPos = textarea.getBoundingClientRect();
-    let fbStyle = feedbackDiv.style;
-    fbStyle.top = `${textPos.bottom}px`;
-    fbStyle.left = `${textPos.left}px`;
-    fbStyle.width = `${textarea.offsetWidth}px`;
-    // THIS CODE NEEDS TO BE CHANGED -- INLINE STYLES ARE EVIL!
-    fbStyle.backgroundColor = 'lightyellow';
-    fbStyle.borderStyle = 'solid';
-    fbStyle.borderWidth = '1px';
-    fbStyle.borderRadius = '3px';
-    fbStyle.paddingLeft = '5px';
-    fbStyle.visibility = 'hidden';
-
-    this.set('feedbackDiv', feedbackDiv);
     this.get('feedbackText');
     this.get('activeExpansionSite');
 


### PR DESCRIPTION
There was extraneous code that was causing the Notes field to fail and kill events on the page. This change fixes that.

Fixes #[replace brackets with the issue number that your pull request addresses].

**Changes proposed in this pull request:**
- removed unneeded code
- remove call to getBoundingClientRect in the didInsertElement that was causing error

cc @HospitalRun/core-maintainers 
