### PR TITLE
496 : add "clickable" css class to editable objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # See http://help.github.com/ignore-files/ for more about ignoring files.
 /.idea
+/.vscode
 
 # compiled output
 /dist

--- a/app/appointments/edit/template.hbs
+++ b/app/appointments/edit/template.hbs
@@ -3,7 +3,7 @@
     {{#if model.selectPatient}}
       {{patient-typeahead model=model property="patientTypeAhead" label=(t 'models.patient.names.singular') content=patientList selection=selectedPatient class="required test-patient-input"}}
     {{else}}
-      {{patient-summary patient=model.patient returnTo='appointments.edit' returnToContext=model.id disablePatientLink=model.isNew }}
+      {{patient-summary patient=model.patient returnTo='appointments.edit' returnToContext=model.id disablePatientLink=model.isNew class="clickable"}}
     {{/if}}
     <div class="row">
       {{#if isAdmissionAppointment}}

--- a/app/appointments/item/template.hbs
+++ b/app/appointments/item/template.hbs
@@ -1,4 +1,4 @@
-<tr {{action 'editAppointment' appointment}}>
+<tr {{action 'editAppointment' appointment}} class="{{if canEdit "clickable"}}">
   <td class="appointment-date">
     {{appointment.formattedAppointmentDate}}
   </td>

--- a/app/imaging/edit/template.hbs
+++ b/app/imaging/edit/template.hbs
@@ -3,7 +3,7 @@
     {{#if model.selectPatient}}
       {{patient-typeahead model=model property="patientTypeAhead" label=(t 'labels.patient')content=patientList selection=selectedPatient class="required patient-input"}}
     {{else}}
-      {{patient-summary patient=model.patient returnTo='imaging.edit' returnToContext=model.id disablePatientLink=model.isNew }}
+      {{patient-summary patient=model.patient returnTo='imaging.edit' returnToContext=model.id disablePatientLink=model.isNew class="clickable"}}
     {{/if}}
     {{#if model.isNew}}
       <div class="row">

--- a/app/invoices/edit/template.hbs
+++ b/app/invoices/edit/template.hbs
@@ -1,7 +1,7 @@
 {{#edit-panel editPanelProps=editPanelProps}}
   {{#em-form model=model submitButton=false as |form|}}
     {{#unless model.isNew}}
-      {{patient-summary patient=model.patient returnTo='invoices.edit' returnToContext=model.id disablePatientLink=model.isNew }}
+      {{patient-summary patient=model.patient returnTo='invoices.edit' returnToContext=model.id disablePatientLink=model.isNew class="clickable"}}
     {{/unless}}
     <div class="row">
       {{#unless model.isNew}}

--- a/app/labs/edit/template.hbs
+++ b/app/labs/edit/template.hbs
@@ -3,7 +3,7 @@
     {{#if model.selectPatient}}
       {{patient-typeahead model=model property="patientTypeAhead" label=(t 'labels.patient') content=patientList selection=selectedPatient class="required test-patient-name"}}
     {{else}}
-      {{patient-summary patient=model.patient returnTo='labs.edit' returnToContext=model.id disablePatientLink=model.isNew }}
+      {{patient-summary patient=model.patient returnTo='labs.edit' returnToContext=model.id disablePatientLink=model.isNew class="clickable"}}
     {{/if}}
     {{#if model.isNew}}
       <div class="row">

--- a/app/medication/edit/template.hbs
+++ b/app/medication/edit/template.hbs
@@ -1,7 +1,7 @@
 {{#edit-panel editPanelProps=editPanelProps}}
   {{#em-form model=model submitButton=false as |form|}}
     {{#unless model.selectPatient}}
-      {{patient-summary patient=model.patient returnTo='medication.edit' returnToContext=model.id disablePatientLink=model.isNew }}
+      {{patient-summary patient=model.patient returnTo='medication.edit' returnToContext=model.id disablePatientLink=model.isNew class="clickable"}}
     {{/unless}}
     <div class="row">
       {{#if model.selectPatient}}

--- a/app/patients/edit/template.hbs
+++ b/app/patients/edit/template.hbs
@@ -271,7 +271,7 @@
                   <th>{{t 'labels.actions'}}</th>
                 </tr>
                 {{#each model.appointments as |appointment|}}
-                  <tr {{action "editAppointment" appointment}}>
+                  <tr {{action "editAppointment" appointment}} class="{{if canAddAppointment "clickable"}}">
                     <td>{{appointment.formattedAppointmentDate}}</td>
                     <td>{{appointment.provider}}</td>
                     <td>{{appointment.location}}</td>
@@ -314,7 +314,7 @@
                   <th>{{t 'labels.actions'}}</th>
                 </tr>
                 {{#each model.visits as |visit|}}
-                  <tr {{action "editVisit" visit}}>
+                  <tr {{action "editVisit" visit}} class="{{if canAddVisit "clickable"}}">
                     <td>{{date-format visit.startDate}}</td>
                     <td>{{date-format visit.endDate}}</td>
                     <td>{{visit.primaryDiagnoses}}</td>

--- a/app/patients/imaging/template.hbs
+++ b/app/patients/imaging/template.hbs
@@ -10,7 +10,7 @@
     <th>{{t 'labels.actions'}}</th>
   </tr>
   {{#each patientImaging as |imaging|}}
-    <tr {{action "editImaging" imaging}}>
+    <tr {{action "editImaging" imaging}} class="{{if imaging.canEdit (if canAddImaging "clickable")}}">
       <td>{{date-format imaging.requestedDate}}</td>
       <td>{{imaging.imagingType.name}}</td>
       <td>{{imaging.status}}</td>

--- a/app/patients/labs/template.hbs
+++ b/app/patients/labs/template.hbs
@@ -10,7 +10,7 @@
     <th>{{t 'labels.actions'}}</th>
   </tr>
   {{#each patientLabs as |lab|}}
-    <tr {{action "editLab" lab}}>
+    <tr {{action "editLab" lab}} class= "{{if lab.canEdit (if canAddLab "clickable")}}">
       <td>{{date-format lab.requestedDate}}</td>
       <td>{{lab.labType.name}}</td>
       <td>{{lab.status}}</td>

--- a/app/patients/medication/template.hbs
+++ b/app/patients/medication/template.hbs
@@ -8,7 +8,7 @@
     <th>{{t 'labels.actions'}}</th>
   </tr>
   {{#each patientMedications as |medication|}}
-    <tr {{action "editMedication" medication}}>
+    <tr {{action "editMedication" medication}} class="{{if medication.canEdit (if canAddMedication "clickable")}}">
       <td>{{date-format medication.prescriptionDate}}</td>
       <td>{{medication.medicationName}}</td>
       <td>{{medication.status}}</td>

--- a/app/visits/edit/template.hbs
+++ b/app/visits/edit/template.hbs
@@ -17,7 +17,7 @@
         <div class="panel-body">
           {{#em-form model=model submitButton=false as |form|}}
             {{#if model.patient}}
-              {{patient-summary
+              {{patient-summary class= "clickable"
                 patient=model.patient
                 diagnosisContainer=model
                 returnTo='visits.edit'


### PR DESCRIPTION
Fixes #496

**Changes proposed in this pull request:**

Add `class="clickable"` to several clickable elements that were missing the pointer cursor on hover.

Updated the following areas of the app:
- patient tabs
- appointments
- imaging
- invoices
- labs
- medication
- visits

cc @HospitalRun/core-maintainers