### PR TITLE
removed fixed width from ps-info-label

### DIFF
--- a/app/styles/components/_patient_summary.scss
+++ b/app/styles/components/_patient_summary.scss
@@ -45,7 +45,6 @@
 
   .ps-info-label {
     margin-right: 10px;
-    width: 40px;
     font-size: 16px;
     font-weight: 400;
 


### PR DESCRIPTION
Fixes #1395

**Changes proposed in this pull request:**
- Removed width limit from name field label (from patient summary scss form) because "nombre" in Spanish has 6 characters and it overlaps with the name entered.

![labeloverlap](https://user-images.githubusercontent.com/21223759/37437388-4d2842a0-27c3-11e8-9dd6-0b1c3282c8f1.png)

-This is how it looks with the fix

![removed_width](https://user-images.githubusercontent.com/21223759/37438395-8771a9a6-27c8-11e8-899b-c574c6ea452b.png)



cc @HospitalRun/core-maintainers