### PR TITLE
fix(locales/de): languageName

### DIFF
--- a/app/locales/de/translations.js
+++ b/app/locales/de/translations.js
@@ -1,5 +1,5 @@
 export default {
-  languageName: 'Deutsche',
+  languageName: 'Deutsch',
   admin: {
     address: {
       address1Label: 'Adresse 1 Kennzeichen',

--- a/tests/integration/components/language-select-test.js
+++ b/tests/integration/components/language-select-test.js
@@ -27,7 +27,7 @@ test('it renders', function(assert) {
 
   assert.ok(this.$('.language-select').length);
   assert.equal(this.$('option[value=""]', '.language-select').text().trim(), 'Select Language');
-  assert.equal(this.$('option[value="de"]', '.language-select').text().trim(), 'Deutsche');
+  assert.equal(this.$('option[value="de"]', '.language-select').text().trim(), 'Deutsch');
   assert.ok(this.$('option', '.language-select').length > 2, 'There are not so many languages');
 });
 


### PR DESCRIPTION
**Changes proposed in this pull request:**
- languageName for german should be `Deutsch` instead of `Deutsche`

sources for non native speakers: [1](https://www.google.de/imgres?imgurl=https%3A%2F%2Fcdn6.aptoide.com%2Fimgs%2F2%2F9%2F4%2F294dc522f8d99ba19cf93e06491a9c4f_screen.png%3Fh%3D464&imgrefurl=https%3A%2F%2Fwhenair-inc-locale-language.de.aptoide.com%2F&docid=-wEsggtPZZq4VM&tbnid=oglazXJOswA4iM%3A&vet=10ahUKEwjowMLDxoraAhXLI1AKHWP7CcoQMwg8KAAwAA..i&w=261&h=464&itg=1&bih=949&biw=1916&q=spracheeinstellungen&ved=0ahUKEwjowMLDxoraAhXLI1AKHWP7CcoQMwg8KAAwAA&iact=mrc&uact=8), [2](https://www.google.de/imgres?imgurl=http%3A%2F%2Fwww.mynfon.com%2Ffileadmin%2F_processed_%2Fcsm_sprache_9521c9543c.png&imgrefurl=http%3A%2F%2Fwww.mynfon.com%2Fhandbuecher%2Fsoftware%2Fwindows%2Fhandbuch-nsoftphone-premium%2Fe-softphone%2F3-ansichten-im-softphone%2F31-klassik-ansicht%2F318-erweiterte-einstellungen%2F&docid=IlkX0b8DL8akTM&tbnid=Dceh3u1D40-jFM%3A&vet=10ahUKEwjowMLDxoraAhXLI1AKHWP7CcoQMwhaKBQwFA..i&w=250&h=232&itg=1&bih=949&biw=1916&q=spracheeinstellungen&ved=0ahUKEwjowMLDxoraAhXLI1AKHWP7CcoQMwhaKBQwFA&iact=mrc&uact=8), [3](https://www.google.de/imgres?imgurl=http%3A%2F%2Fwww.pc-faq.de%2Fscreenshots%2Fcrm2011-persoenliche-optionen.png&imgrefurl=http%3A%2F%2Fwww.pc-faq.de%2FFAQ%2Fcrm2011%2Fkann-man-das-crm-mehrsprachig-nutzen&docid=vVUaJU5jRDSsJM&tbnid=cDPeXOt7fvo67M%3A&vet=10ahUKEwjowMLDxoraAhXLI1AKHWP7CcoQMwhiKBwwHA..i&w=620&h=202&bih=949&biw=1916&q=spracheeinstellungen&ved=0ahUKEwjowMLDxoraAhXLI1AKHWP7CcoQMwhiKBwwHA&iact=mrc&uact=8)
cc @HospitalRun/core-maintainers
