### PR TITLE
1401 highlight current route

### DIFF
--- a/app/mixins/navigation.js
+++ b/app/mixins/navigation.js
@@ -12,7 +12,7 @@ export default Ember.Mixin.create({
     {
       title: 'Inventory',
       iconClass: 'octicon-package',
-      route: 'inventory.index',
+      route: 'inventory',
       capability: 'inventory',
       subnav: [
         {
@@ -45,7 +45,7 @@ export default Ember.Mixin.create({
     {
       title: 'Patients',
       iconClass: 'octicon-organization',
-      route: 'patients.index',
+      route: 'patients',
       capability: 'patients',
       subnav: [
         {
@@ -84,7 +84,7 @@ export default Ember.Mixin.create({
     {
       title: 'Scheduling',
       iconClass: 'octicon-calendar',
-      route: 'appointments.index',
+      route: 'appointments',
       capability: 'appointments',
       subnav: [
         {
@@ -136,7 +136,7 @@ export default Ember.Mixin.create({
     {
       title: 'Imaging',
       iconClass: 'octicon-device-camera',
-      route: 'imaging.index',
+      route: 'imaging',
       capability: 'imaging',
       subnav: [
         {
@@ -163,7 +163,7 @@ export default Ember.Mixin.create({
     {
       title: 'Medication',
       iconClass: 'octicon-file-text',
-      route: 'medication.index',
+      route: 'medication',
       capability: 'medication',
       subnav: [
         {
@@ -204,7 +204,7 @@ export default Ember.Mixin.create({
     {
       title: 'Labs',
       iconClass: 'octicon-microscope',
-      route: 'labs.index',
+      route: 'labs',
       capability: 'labs',
       subnav: [
         {
@@ -231,7 +231,7 @@ export default Ember.Mixin.create({
     {
       title: 'Billing',
       iconClass: 'octicon-credit-card',
-      route: 'invoices.index',
+      route: 'invoices',
       capability: 'invoices',
       subnav: [
         {
@@ -297,7 +297,7 @@ export default Ember.Mixin.create({
     {
       title: 'Administration',
       iconClass: 'octicon-person',
-      route: 'admin.lookup',
+      route: 'admin',
       capability: 'admin',
       subnav: [
         {

--- a/app/styles/components/_sidebar_nav.scss
+++ b/app/styles/components/_sidebar_nav.scss
@@ -214,7 +214,8 @@
     color: $sidebar_sublink_text;
     font-size: 15px;
 
-    &:hover {
+    &:hover,
+    &.active {
       background: $navy_mid;
       color: $white;
 


### PR DESCRIPTION
Fixes `nav-sidebar` highlighting of sub and main routes.

Before: #1401 
Now:
![hr-highlighting3](https://user-images.githubusercontent.com/19377375/37931259-59f50ee2-3145-11e8-8879-22c967bba0aa.png)

Closes: #1401 

cc @HospitalRun/core-maintainers
