### PR TITLE
Simplify ` runWithPouchDump()` test helper

### DIFF
--- a/tests/.eslintrc.js
+++ b/tests/.eslintrc.js
@@ -1,4 +1,8 @@
 module.exports = {
+  parserOptions: {
+    'ecmaVersion': 2017,
+  },
+
   env: {
     'embertest': true
   },

--- a/tests/helpers/run-with-pouch-dump.js
+++ b/tests/helpers/run-with-pouch-dump.js
@@ -131,7 +131,7 @@ function runWithPouchDumpAsyncHelper(app, dumpName, functionToRun) {
       db.setMaxListeners(35);
       createPouchViews(db, true, dumpName).then(function() {
         functionToRun();
-        andThen(function() {
+        wait().then(function() {
           let databasesToClean = [
             configDB,
             db

--- a/tests/helpers/run-with-pouch-dump.js
+++ b/tests/helpers/run-with-pouch-dump.js
@@ -126,34 +126,32 @@ function runWithPouchDumpAsyncHelper(app, dumpName, functionToRun) {
   app.__deprecatedInstance__.register('service:config', InMemoryConfigService);
   app.__deprecatedInstance__.register('service:database', InMemoryDatabaseService);
 
-  return new EmberPromise(function(resolve) {
-    promise.then(function() {
-      db.setMaxListeners(35);
-      createPouchViews(db, true, dumpName).then(function() {
-        functionToRun();
-        wait().then(function() {
-          let databasesToClean = [
-            configDB,
-            db
-          ];
-          if (window.ELECTRON) {
-            databasesToClean.push(usersDB);
-          }
-          cleanupDatabases(db, databasesToClean).then(function() {
-            configDB = null;
-            db = null;
-            if (window.ELECTRON) {
-              usersDB = null;
-            }
-            resolve();
-          }, function(err) {
-            console.log('error cleaning up dbs:', err);
-          });
-        });
-      });
-    }, function(err) {
-      console.log('error loading db', JSON.stringify(err, null, 2));
-    });
+  return promise.then(function() {
+    db.setMaxListeners(35);
+    return createPouchViews(db, true, dumpName);
+
+  }).then(function() {
+    return functionToRun();
+
+  }).then(function() {
+    return wait();
+
+  }).then(function() {
+    let databasesToClean = [
+      configDB,
+      db
+    ];
+    if (window.ELECTRON) {
+      databasesToClean.push(usersDB);
+    }
+    return cleanupDatabases(db, databasesToClean);
+
+  }).then(function() {
+    configDB = null;
+    db = null;
+    if (window.ELECTRON) {
+      usersDB = null;
+    }
   });
 }
 

--- a/tests/helpers/run-with-pouch-dump.js
+++ b/tests/helpers/run-with-pouch-dump.js
@@ -36,7 +36,7 @@ function destroyDatabases(dbs) {
   return all(destroyQueue);
 }
 
-function runWithPouchDumpAsyncHelper(app, dumpName, functionToRun) {
+async function runWithPouchDumpAsyncHelper(app, dumpName, functionToRun) {
   PouchDB.plugin(PouchAdapterMemory);
   PouchDB.plugin(PouchDBUsers);
 
@@ -126,33 +126,28 @@ function runWithPouchDumpAsyncHelper(app, dumpName, functionToRun) {
   app.__deprecatedInstance__.register('service:config', InMemoryConfigService);
   app.__deprecatedInstance__.register('service:database', InMemoryDatabaseService);
 
-  return promise.then(function() {
-    db.setMaxListeners(35);
-    return createPouchViews(db, true, dumpName);
+  await promise;
 
-  }).then(function() {
-    return functionToRun();
+  db.setMaxListeners(35);
+  await createPouchViews(db, true, dumpName);
 
-  }).then(function() {
-    return wait();
+  await functionToRun();
+  await wait();
 
-  }).then(function() {
-    let databasesToClean = [
-      configDB,
-      db
-    ];
-    if (window.ELECTRON) {
-      databasesToClean.push(usersDB);
-    }
-    return cleanupDatabases(db, databasesToClean);
+  let databasesToClean = [
+    configDB,
+    db
+  ];
+  if (window.ELECTRON) {
+    databasesToClean.push(usersDB);
+  }
+  await cleanupDatabases(db, databasesToClean);
 
-  }).then(function() {
-    configDB = null;
-    db = null;
-    if (window.ELECTRON) {
-      usersDB = null;
-    }
-  });
+  configDB = null;
+  db = null;
+  if (window.ELECTRON) {
+    usersDB = null;
+  }
 }
 
 registerAsyncHelper('runWithPouchDump', runWithPouchDumpAsyncHelper);


### PR DESCRIPTION
This PR refactors the `runWithPouchDump()` test helper function to use async/await instead of implicit promise chaining. The goal of this PR is to allow the use of async functions in the tests too, which a follow-up PR will introduce later.

cc @HospitalRun/core-maintainers
