### PR TITLE
Convert test code to use async/await

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "ember-concurrency-test-waiter": "0.3.1",
     "ember-data": "2.18.2",
     "ember-electron": "^2.7.2",
+    "ember-exam": "^1.0.0",
     "ember-export-application-global": "^2.0.0",
     "ember-fullcalendar": "1.8.0",
     "ember-i18n": "~5.0.0",

--- a/testem.js
+++ b/testem.js
@@ -1,6 +1,7 @@
 module.exports = {
   test_page: 'tests/index.html?hidepassed',
   disable_watching: true,
+  parallel: -1,
   launch_in_ci: [
     'Chrome'
   ],

--- a/tests/.eslintrc.js
+++ b/tests/.eslintrc.js
@@ -1,4 +1,8 @@
 module.exports = {
+  parserOptions: {
+    'ecmaVersion': 2017,
+  },
+
   env: {
     'embertest': true
   },

--- a/tests/acceptance/admin-test.js
+++ b/tests/acceptance/admin-test.js
@@ -4,141 +4,104 @@ import moduleForAcceptance from 'hospitalrun/tests/helpers/module-for-acceptance
 moduleForAcceptance('Acceptance | admin');
 
 test('visiting /admin', function(assert) {
-  runWithPouchDump('admin', function() {
-    authenticateUser();
-    visit('/admin');
-    andThen(function() {
-      assert.equal(currentURL(), '/admin');
-      select('.lookup-type', 'Visit Types');
-      andThen(() => {
-        assert.dom('h3.panel-title').hasText('Visit Types', 'Visit Types header is displayed');
-        assert.equal(find('td.lookup-type-value:first').text(), 'Admission', 'Admission visit type displays');
-        click('button:contains(Update)');
-        waitToAppear('.modal-dialog');
-        andThen(() => {
-          assert.dom('.modal-title').hasText('List Saved', 'Lookup list is saved');
-        });
-      });
-    });
+  runWithPouchDump('admin', async function() {
+    await authenticateUser();
+    await visit('/admin');
+    assert.equal(currentURL(), '/admin');
+
+    await select('.lookup-type', 'Visit Types');
+    assert.dom('h3.panel-title').hasText('Visit Types', 'Visit Types header is displayed');
+    assert.equal(find('td.lookup-type-value:first').text(), 'Admission', 'Admission visit type displays');
+
+    await click('button:contains(Update)');
+    await waitToAppear('.modal-dialog');
+    assert.dom('.modal-title').hasText('List Saved', 'Lookup list is saved');
   });
 });
 
 test('add new lookup value', function(assert) {
-  runWithPouchDump('admin', function() {
-    authenticateUser();
-    visit('/admin');
-    andThen(function() {
-      assert.equal(currentURL(), '/admin');
-      select('.lookup-type', 'Anesthesiologists');
-      click('button:contains(Add Value)');
-      waitToAppear('.modal-dialog');
-      andThen(() => {
-        assert.dom('.modal-title').hasText('Add Value', 'Add value modal is displayed');
-        fillIn('.lookup-type-value input', 'Dr Smith');
-        click('button:contains(Add):last');
-        andThen(() => {
-          waitToAppear('td.lookup-type-value:contains(Dr Smith)');
-          andThen(() => {
-            assert.equal(find('td.lookup-type-value:contains(Dr Smith)').length, 1, 'Added lookup type is added to list');
-          });
-        });
-      });
-    });
+  runWithPouchDump('admin', async function() {
+    await authenticateUser();
+    await visit('/admin');
+    assert.equal(currentURL(), '/admin');
+
+    await select('.lookup-type', 'Anesthesiologists');
+    await click('button:contains(Add Value)');
+    await waitToAppear('.modal-dialog');
+    assert.dom('.modal-title').hasText('Add Value', 'Add value modal is displayed');
+
+    await fillIn('.lookup-type-value input', 'Dr Smith');
+    await click('button:contains(Add):last');
+    await waitToAppear('td.lookup-type-value:contains(Dr Smith)');
+    assert.equal(find('td.lookup-type-value:contains(Dr Smith)').length, 1, 'Added lookup type is added to list');
   });
 });
 
 test('delete lookup value', function(assert) {
-  runWithPouchDump('admin', function() {
-    authenticateUser();
-    visit('/admin');
-    andThen(function() {
-      assert.equal(currentURL(), '/admin');
-      select('.lookup-type', 'Anesthesia Types');
-      andThen(() => {
-        assert.equal(find('td.lookup-type-value:contains(Epidural)').length, 1, 'Have lookup type to delete from list');
-        click('button:contains(Delete)');
-        waitToAppear('.modal-dialog');
-      });
-      andThen(() => {
-        assert.dom('.modal-title').hasText('Delete Value', 'Delete value modal is displayed');
-        click('.modal-footer button:contains(Ok)');
-      });
-      andThen(() => {
-        assert.equal(find('td.lookup-type-value:contains(Epidural)').length, 0, 'Deleted lookup type is removed from the list');
-      });
-    });
+  runWithPouchDump('admin', async function() {
+    await authenticateUser();
+    await visit('/admin');
+    assert.equal(currentURL(), '/admin');
+
+    await select('.lookup-type', 'Anesthesia Types');
+    assert.equal(find('td.lookup-type-value:contains(Epidural)').length, 1, 'Have lookup type to delete from list');
+
+    await click('button:contains(Delete)');
+    await waitToAppear('.modal-dialog');
+    assert.dom('.modal-title').hasText('Delete Value', 'Delete value modal is displayed');
+
+    await click('.modal-footer button:contains(Ok)');
+    assert.equal(find('td.lookup-type-value:contains(Epidural)').length, 0, 'Deleted lookup type is removed from the list');
   });
 });
 
 test('Update address options', function(assert) {
-  runWithPouchDump('admin', function() {
-    authenticateUser();
-    visit('/admin/address');
-    andThen(function() {
-      assert.equal(currentURL(), '/admin/address');
-      fillIn('input', 'Address Label');
-      click('button:contains(Update)');
-      andThen(() => {
-        waitToAppear('.modal-dialog');
-        andThen(() => {
-          assert.dom('.modal-title').hasText('Options Saved', 'Address Options Saved');
-        });
-      });
-    });
+  runWithPouchDump('admin', async function() {
+    await authenticateUser();
+    await visit('/admin/address');
+    assert.equal(currentURL(), '/admin/address');
+
+    await fillIn('input', 'Address Label');
+    await click('button:contains(Update)');
+    await waitToAppear('.modal-dialog');
+    assert.dom('.modal-title').hasText('Options Saved', 'Address Options Saved');
   });
 });
 
 test('Update header options', function(assert) {
-  runWithPouchDump('admin', function() {
-    authenticateUser();
-    visit('/admin/print-header');
-    andThen(function() {
-      assert.equal(currentURL(), '/admin/print-header');
-      fillIn('input', 'Print Header Label');
-      click('button:contains(Update)');
-      andThen(() => {
-        waitToAppear('.modal-dialog');
-        andThen(() => {
-          assert.dom('.modal-title').hasText('Options Saved', 'Header Options Saved');
-        });
-      });
-    });
+  runWithPouchDump('admin', async function() {
+    await authenticateUser();
+    await visit('/admin/print-header');
+    assert.equal(currentURL(), '/admin/print-header');
+
+    await fillIn('input', 'Print Header Label');
+    await click('button:contains(Update)');
+    await waitToAppear('.modal-dialog');
+    assert.dom('.modal-title').hasText('Options Saved', 'Header Options Saved');
   });
 });
 
 test('Update workflow options', function(assert) {
   let selector = 'input[type=checkbox]';
 
-  runWithPouchDump('admin', function() {
-    authenticateUser();
-    visit('/admin/workflow');
-    andThen(() => {
-      assert.equal(currentURL(), '/admin/workflow', 'Correctly navigated to admin workflow');
+  runWithPouchDump('admin', async function() {
+    await authenticateUser();
+    await visit('/admin/workflow');
+    assert.equal(currentURL(), '/admin/workflow', 'Correctly navigated to admin workflow');
 
-      setAllTo(false, () => {
-        visit('/admin/workflow');
-        andThen(() => {
-          setAllTo(true);
-        });
-      });
-    });
+    await setAllTo(false);
+    await visit('/admin/workflow');
+    await setAllTo(true);
   });
 
-  function setAllTo(checked, cb) {
+  async function setAllTo(checked) {
     Array.prototype.slice.call(document.querySelectorAll(selector)).forEach((node) => {
       node.checked = checked;
     });
-    click('button:contains(Update)');
-    andThen(() => {
-      waitToAppear('.modal-dialog');
-      andThen(() => {
-        assert.equal(find('.modal-title').text(), 'Options Saved', 'Workflow Options Saved');
-        verifyAll(checked);
-        if (cb) {
-          cb();
-        }
-      });
-    });
+    await click('button:contains(Update)');
+    await waitToAppear('.modal-dialog');
+    assert.equal(find('.modal-title').text(), 'Options Saved', 'Workflow Options Saved');
+    verifyAll(checked);
   }
 
   function verifyAll(checked) {

--- a/tests/acceptance/appointments-test.js
+++ b/tests/acceptance/appointments-test.js
@@ -9,317 +9,260 @@ const TIME_FORMAT = 'h:mm';
 moduleForAcceptance('Acceptance | appointments');
 
 test('visiting /appointments', function(assert) {
-  runWithPouchDump('default', function() {
-    authenticateUser();
-    visit('/appointments');
-    andThen(function() {
-      assert.equal(currentURL(), '/appointments');
-      findWithAssert('button:contains(new appointment)');
-      assert.dom('.table-header').exists();
-    });
+  runWithPouchDump('default', async function() {
+    await authenticateUser();
+    await visit('/appointments');
+    assert.equal(currentURL(), '/appointments');
+    findWithAssert('button:contains(new appointment)');
+    assert.dom('.table-header').exists();
   });
 });
 
 test('visiting /appointments/missed', function(assert) {
-  runWithPouchDump('appointments', function() {
-    authenticateUser();
+  runWithPouchDump('appointments', async function() {
+    await authenticateUser();
     let url = '/appointments';
     let today = moment();
     let tomorrow = moment().add(1, 'days');
     let status = 'Missed';
-    createAppointment(assert, {
+    await createAppointment(assert, {
       startDate: today,
       endDate: tomorrow,
       allDay: false,
       status
     });
-    visit(url);
-    andThen(function() {
-      assert.equal(currentURL(), url);
-      findWithAssert(`.appointment-status:contains(${status})`);
-    });
+    await visit(url);
+    assert.equal(currentURL(), url);
+    findWithAssert(`.appointment-status:contains(${status})`);
   });
 });
 
 test('test appointment for today', function(assert) {
-  runWithPouchDump('appointments', function() {
-    authenticateUser();
-    visit('/appointments/today');
+  runWithPouchDump('appointments', async function() {
+    await authenticateUser();
+    await visit('/appointments/today');
     assert.dom('.appointment-date').doesNotExist('should have 0 appointment today');
-    visit('/appointments/edit/new');
-    andThen(function() {
-      assert.equal(currentURL(), '/appointments/edit/new');
-      findWithAssert('button:contains(Cancel)');
-      findWithAssert('button:contains(Add)');
-    });
+    await visit('/appointments/edit/new');
+    assert.equal(currentURL(), '/appointments/edit/new');
+    findWithAssert('button:contains(Cancel)');
+    findWithAssert('button:contains(Add)');
 
-    createAppointment(assert);
+    await createAppointment(assert);
 
-    visit('/appointments/today');
-    andThen(() => {
-      assert.equal(currentURL(), '/appointments/today');
-      assert.dom('.appointment-status').hasText('Scheduled', 'should have 1 appointment today');
-    });
+    await visit('/appointments/today');
+    assert.equal(currentURL(), '/appointments/today');
+    assert.dom('.appointment-status').hasText('Scheduled', 'should have 1 appointment today');
   });
 });
 
 test('Creating a new appointment', function(assert) {
-  runWithPouchDump('appointments', function() {
-    authenticateUser();
-    visit('/appointments/edit/new');
+  runWithPouchDump('appointments', async function() {
+    await authenticateUser();
+    await visit('/appointments/edit/new');
 
-    andThen(function() {
-      assert.equal(currentURL(), '/appointments/edit/new');
-      findWithAssert('button:contains(Cancel)');
-      findWithAssert('button:contains(Add)');
-    });
+    assert.equal(currentURL(), '/appointments/edit/new');
+    findWithAssert('button:contains(Cancel)');
+    findWithAssert('button:contains(Add)');
 
-    createAppointment(assert);
+    await createAppointment(assert);
 
-    andThen(() => {
-      assert.equal(currentURL(), '/appointments');
-      assert.dom('tr').exists({ count: 2 }, 'New appointment has been added');
-      findWithAssert('button:contains(Check In)');
-      findWithAssert('button:contains(Edit)');
-      findWithAssert('button:contains(Delete)');
-    });
+    assert.equal(currentURL(), '/appointments');
+    assert.dom('tr').exists({ count: 2 }, 'New appointment has been added');
+    findWithAssert('button:contains(Check In)');
+    findWithAssert('button:contains(Edit)');
+    findWithAssert('button:contains(Delete)');
   });
 });
 
 test('Creating a new appointment from patient screen', function(assert) {
-  runWithPouchDump('appointments', function() {
+  runWithPouchDump('appointments', async function() {
     let today = moment().startOf('day');
     let tomorrow =  moment(today).add(24, 'hours');
-    authenticateUser();
-    visit('/patients');
-    andThen(function() {
-      findWithAssert('button:contains(Edit)');
-    });
-    click('button:contains(Edit)');
-    andThen(function() {
-      assert.dom('button[data-test-selector="appointments-btn"]').exists({ count: 1 }, 'Tab Appointments shown AFTER clicking edit');
-    });
+    await authenticateUser();
+    await visit('/patients');
+    findWithAssert('button:contains(Edit)');
 
-    click('button[data-test-selector="appointments-btn"]');
+    await click('button:contains(Edit)');
+    assert.dom('button[data-test-selector="appointments-btn"]').exists({ count: 1 }, 'Tab Appointments shown AFTER clicking edit');
 
-    andThen(function() {
-      assert.equal(currentURL().substr(0, 19), '/appointments/edit/', 'Creating appointment');
-    });
+    await click('button[data-test-selector="appointments-btn"]');
 
-    click('.appointment-all-day input');
-    fillIn('.test-appointment-start input', today.format(DATE_FORMAT));
-    fillIn('.test-appointment-end input', tomorrow.format(DATE_FORMAT));
-    typeAheadFillIn('.test-appointment-location', 'Harare');
-    typeAheadFillIn('.test-appointment-with', 'Dr Test');
-    click('button:contains(Add)');
+    assert.equal(currentURL().substr(0, 19), '/appointments/edit/', 'Creating appointment');
 
-    waitToAppear('.modal-dialog');
-    andThen(() => {
-      assert.dom('.modal-title').hasText('Appointment Saved', 'Appointment has been saved');
-      click('.modal-footer button:contains(Ok)');
-    });
+    await click('.appointment-all-day input');
+    await fillIn('.test-appointment-start input', today.format(DATE_FORMAT));
+    await fillIn('.test-appointment-end input', tomorrow.format(DATE_FORMAT));
+    await typeAheadFillIn('.test-appointment-location', 'Harare');
+    await typeAheadFillIn('.test-appointment-with', 'Dr Test');
+    await click('button:contains(Add)');
 
-    click('button:contains(Return)');
-    andThen(() => {
-      assert.equal(currentURL().substr(0, 15), '/patients/edit/', 'Back on patient edit screen');
-    });
+    await waitToAppear('.modal-dialog');
+    assert.dom('.modal-title').hasText('Appointment Saved', 'Appointment has been saved');
+    await click('.modal-footer button:contains(Ok)');
+
+    await click('button:contains(Return)');
+    assert.equal(currentURL().substr(0, 15), '/patients/edit/', 'Back on patient edit screen');
   });
 });
 
 test('Change appointment type', function(assert) {
-  runWithPouchDump('appointments', function() {
+  runWithPouchDump('appointments', async function() {
     let today = moment().startOf('day');
-    authenticateUser();
-    visit('/appointments/edit/new');
+    await authenticateUser();
+    await visit('/appointments/edit/new');
 
-    andThen(function() {
-      assert.equal(currentURL(), '/appointments/edit/new');
-      findWithAssert('button:contains(Cancel)');
-      findWithAssert('button:contains(Add)');
-    });
+    assert.equal(currentURL(), '/appointments/edit/new');
+    findWithAssert('button:contains(Cancel)');
+    findWithAssert('button:contains(Add)');
 
-    createAppointment(assert);
+    await createAppointment(assert);
 
-    andThen(() => {
-      assert.equal(currentURL(), '/appointments');
-      assert.dom('tr').exists({ count: 2 }, 'New appointment has been added');
-      findWithAssert('button:contains(Edit)');
-    });
+    assert.equal(currentURL(), '/appointments');
+    assert.dom('tr').exists({ count: 2 }, 'New appointment has been added');
+    findWithAssert('button:contains(Edit)');
 
-    click('button:contains(Edit)');
+    await click('button:contains(Edit)');
 
-    andThen(() => {
-      assert.equal(currentURL().substring(0, 19), '/appointments/edit/');
-      assert.dom('.appointment-all-day input').hasValue('on', 'All day appointment is on');
-    });
+    assert.equal(currentURL().substring(0, 19), '/appointments/edit/');
+    assert.dom('.appointment-all-day input').hasValue('on', 'All day appointment is on');
 
-    select('.test-appointment-type', 'Clinic');
+    await select('.test-appointment-type', 'Clinic');
 
-    andThen(() => {
-      assert.dom('.test-appointment-date input').hasValue(today.format(DATE_FORMAT), 'Single date field found');
-      assert.equal(find('.appointment-all-day').val(), '', 'All day appointment was turned off');
-    });
+    assert.dom('.test-appointment-date input').hasValue(today.format(DATE_FORMAT), 'Single date field found');
+    assert.equal(find('.appointment-all-day').val(), '', 'All day appointment was turned off');
   });
 });
 
 test('Checkin to a visit from appointment', function(assert) {
-  runWithPouchDump('appointments', function() {
-    authenticateUser();
-    createAppointment(assert);
-    visit('/appointments');
+  runWithPouchDump('appointments', async function() {
+    await authenticateUser();
+    await createAppointment(assert);
+    await visit('/appointments');
 
-    andThen(function() {
-      assert.equal(currentURL(), '/appointments');
-      assert.dom('tr').exists({ count: 2 }, 'New appointment has been added');
-      findWithAssert('button:contains(Check In)');
-      findWithAssert('button:contains(Edit)');
-      findWithAssert('button:contains(Delete)');
-    });
+    assert.equal(currentURL(), '/appointments');
+    assert.dom('tr').exists({ count: 2 }, 'New appointment has been added');
+    findWithAssert('button:contains(Check In)');
+    findWithAssert('button:contains(Edit)');
+    findWithAssert('button:contains(Delete)');
 
-    click('button:contains(Check In)');
+    await click('button:contains(Check In)');
 
-    andThen(() => {
-      assert.equal(currentURL(), '/visits/edit/checkin', 'Now in add visiting information route');
-    });
-    click('.panel-footer button:contains(Check In)');
-    waitToAppear('.modal-dialog');
-    andThen(() => {
-      assert.dom('.modal-title').hasText('Patient Checked In', 'Patient has been checked in');
-    });
-    click('button:contains(Ok)');
-    andThen(() => {
-      findWithAssert('button:contains(New Note)');
-      findWithAssert('button:contains(New Procedure)');
-      findWithAssert('button:contains(New Medication)');
-      findWithAssert('button:contains(New Lab)');
-      findWithAssert('button:contains(New Imaging)');
-      findWithAssert('button:contains(New Vitals)');
-      findWithAssert('button:contains(Add Item)');
-    });
-    click('button:contains(Return)');
+    assert.equal(currentURL(), '/visits/edit/checkin', 'Now in add visiting information route');
 
-    andThen(() => {
-      assert.equal(currentURL(), '/appointments');
-      assert.equal(find('button:contains(Check In)').length, 0, 'Check In button no longer appears');
-      findWithAssert('button:contains(Edit)');
-      findWithAssert('button:contains(Delete)');
-    });
+    await click('.panel-footer button:contains(Check In)');
+    await waitToAppear('.modal-dialog');
+    assert.dom('.modal-title').hasText('Patient Checked In', 'Patient has been checked in');
+
+    await click('button:contains(Ok)');
+    findWithAssert('button:contains(New Note)');
+    findWithAssert('button:contains(New Procedure)');
+    findWithAssert('button:contains(New Medication)');
+    findWithAssert('button:contains(New Lab)');
+    findWithAssert('button:contains(New Imaging)');
+    findWithAssert('button:contains(New Vitals)');
+    findWithAssert('button:contains(Add Item)');
+
+    await click('button:contains(Return)');
+    assert.equal(currentURL(), '/appointments');
+    assert.equal(find('button:contains(Check In)').length, 0, 'Check In button no longer appears');
+    findWithAssert('button:contains(Edit)');
+    findWithAssert('button:contains(Delete)');
   });
 });
 
 test('Delete an appointment', function(assert) {
-  runWithPouchDump('appointments', function() {
-    authenticateUser();
-    createAppointment(assert);
-    visit('/appointments');
+  runWithPouchDump('appointments', async function() {
+    await authenticateUser();
+    await createAppointment(assert);
+    await visit('/appointments');
 
-    andThen(function() {
-      assert.equal(currentURL(), '/appointments');
-      assert.dom('.appointment-date').exists({ count: 1 }, 'One appointment is listed');
-      findWithAssert('button:contains(Check In)');
-      findWithAssert('button:contains(Edit)');
-      findWithAssert('button:contains(Delete)');
-      click('button:contains(Delete)');
-      waitToAppear('.modal-dialog');
-    });
-    andThen(() => {
-      assert.dom('.modal-title').hasText(
-        'Delete Appointment',
-        'Delete Appointment confirmation modal has been displayed'
-      );
-      click('.modal-dialog button:contains(Delete)');
-    });
-    andThen(() => {
-      waitToDisappear('.appointment-date');
-    });
-    andThen(() => {
-      assert.dom('.appointment-date').doesNotExist('No appointments are displayed');
-    });
+    assert.equal(currentURL(), '/appointments');
+    assert.dom('.appointment-date').exists({ count: 1 }, 'One appointment is listed');
+    findWithAssert('button:contains(Check In)');
+    findWithAssert('button:contains(Edit)');
+    findWithAssert('button:contains(Delete)');
+
+    await click('button:contains(Delete)');
+    await waitToAppear('.modal-dialog');
+    assert.dom('.modal-title').hasText(
+      'Delete Appointment',
+      'Delete Appointment confirmation modal has been displayed'
+    );
+
+    await click('.modal-dialog button:contains(Delete)');
+    await waitToDisappear('.appointment-date');
+    assert.dom('.appointment-date').doesNotExist('No appointments are displayed');
   });
 });
 
 test('Appointment calendar', function(assert) {
-  runWithPouchDump('appointments', function() {
-    authenticateUser();
+  runWithPouchDump('appointments', async function() {
+    await authenticateUser();
     let today = moment().startOf('day');
     let later =  moment(today).add(1, 'hours');
     let startTime = today.format(TIME_FORMAT);
     let endTime = later.format(TIME_FORMAT);
     let timeString = `${startTime} - ${endTime}`;
-    createAppointment(assert, {
+
+    await createAppointment(assert, {
       startDate: today,
       endDate: later,
       allDay: false,
       status: 'Scheduled'
     });
 
-    andThen(function() {
-      visit('/appointments/calendar');
-    });
+    await visit('/appointments/calendar');
+    assert.equal(currentURL(), '/appointments/calendar');
+    assert.dom('.view-current-title').hasText('Appointments Calendar', 'Appoinment Calendar displays');
+    assert.dom('.fc-content .fc-time').hasText(timeString, 'Time appears in calendar');
+    assert.dom('.fc-title').hasText('Lennex ZinyandoDr Test', 'Appoinment displays in calendar');
 
-    andThen(function() {
-      assert.equal(currentURL(), '/appointments/calendar');
-      assert.dom('.view-current-title').hasText('Appointments Calendar', 'Appoinment Calendar displays');
-      assert.dom('.fc-content .fc-time').hasText(timeString, 'Time appears in calendar');
-      assert.dom('.fc-title').hasText('Lennex ZinyandoDr Test', 'Appoinment displays in calendar');
-      click('.fc-title');
-    });
-
-    andThen(() => {
-      assert.dom('.view-current-title').hasText('Edit Appointment', 'Edit Appointment displays');
-      assert.dom('.test-appointment-start input').hasValue(today.format(DATE_TIME_FORMAT), 'Start date/time are correct');
-      assert.dom('.test-appointment-end input').hasValue(later.format(DATE_TIME_FORMAT), 'End date/time are correct');
-    });
+    await click('.fc-title');
+    assert.dom('.view-current-title').hasText('Edit Appointment', 'Edit Appointment displays');
+    assert.dom('.test-appointment-start input').hasValue(today.format(DATE_TIME_FORMAT), 'Start date/time are correct');
+    assert.dom('.test-appointment-end input').hasValue(later.format(DATE_TIME_FORMAT), 'End date/time are correct');
   });
 });
 
 test('visiting /appointments/search', function(assert) {
-  runWithPouchDump('appointments', function() {
-    authenticateUser();
+  runWithPouchDump('appointments', async function() {
+    await authenticateUser();
 
-    createAppointment(assert);
-    createAppointment(assert, {
+    await createAppointment(assert);
+    await createAppointment(assert, {
       startDate: moment().startOf('day').add(1, 'years'),
       startTime: moment().startOf('day').add(1, 'years').format(TIME_FORMAT),
       endDate: moment().endOf('day').add(1, 'years').add(2, 'days'),
       endTime: moment().endOf('day').add(1, 'years').add(2, 'days').format(TIME_FORMAT)
     });
 
-    andThen(function() {
-      visit('/appointments/search');
-    });
+    await visit('/appointments/search');
 
-    andThen(function() {
-      findWithAssert(':contains(Search Appointments)');
-      findWithAssert(':contains(Show Appointments On Or After)');
-      findWithAssert(':contains(Status)');
-      findWithAssert(':contains(Type)');
-      findWithAssert(':contains(With)');
-    });
+    findWithAssert(':contains(Search Appointments)');
+    findWithAssert(':contains(Show Appointments On Or After)');
+    findWithAssert(':contains(Status)');
+    findWithAssert(':contains(Type)');
+    findWithAssert(':contains(With)');
 
-    andThen(function() {
-      let desiredDate = moment().endOf('day').add(363, 'days').format('l');
-      let datePicker = '.test-selected-start-date input';
-      selectDate(datePicker, desiredDate);
-      click('button:contains(Search)');
-    });
+    let desiredDate = moment().endOf('day').add(363, 'days').format('l');
+    let datePicker = '.test-selected-start-date input';
+    await selectDate(datePicker, desiredDate);
+    await click('button:contains(Search)');
 
-    andThen(function() {
-      let date = moment().endOf('day').add(1, 'years').add(2, 'days').format('l');
-      findWithAssert(`.appointment-status:contains(${status})`);
-      let element = `tr:contains(${date})`;
-      findWithAssert(element);
-      date = moment().startOf('day').add(1, 'years');
-      element = find(`tr:contains(${date})`);
-      assert.equal(element.length, 0);
-    });
-
+    let date = moment().endOf('day').add(1, 'years').add(2, 'days').format('l');
+    findWithAssert(`.appointment-status:contains(${status})`);
+    let element = `tr:contains(${date})`;
+    findWithAssert(element);
+    date = moment().startOf('day').add(1, 'years');
+    element = find(`tr:contains(${date})`);
+    assert.equal(element.length, 0);
   });
 });
 
 test('Theater scheduling', function(assert) {
-  runWithPouchDump('appointments', function() {
-    authenticateUser();
+  runWithPouchDump('appointments', async function() {
+    await authenticateUser();
+
     let later = moment();
     later.hour(11);
     later.minute(30);
@@ -330,74 +273,69 @@ test('Theater scheduling', function(assert) {
     let endTime = later.format(TIME_FORMAT);
     let timeString = `${startTime} - ${endTime}`;
 
-    createAppointment(assert, {
+    await createAppointment(assert, {
       endDate: later,
       startDate: today,
       isSurgery: true
     });
 
-    andThen(function() {
-      visit('/appointments/theater');
-    });
+    await visit('/appointments/theater');
 
-    andThen(function() {
-      assert.equal(currentURL(), '/appointments/theater', 'Theater schedule url is correct.');
-      assert.dom('.view-current-title').hasText('Theater Schedule', 'Theater Schedule displays');
-      assert.dom('.fc-content .fc-time').hasText(timeString, 'Time appears in calendar');
-      assert.dom('.fc-title').hasText('Lennex ZinyandoDr Test', 'Appoinment displays in calendar');
-      click('.fc-title');
-    });
+    assert.equal(currentURL(), '/appointments/theater', 'Theater schedule url is correct.');
+    assert.dom('.view-current-title').hasText('Theater Schedule', 'Theater Schedule displays');
+    assert.dom('.fc-content .fc-time').hasText(timeString, 'Time appears in calendar');
+    assert.dom('.fc-title').hasText('Lennex ZinyandoDr Test', 'Appoinment displays in calendar');
 
-    andThen(() => {
-      assert.dom('.view-current-title').hasText('Edit Surgical Appointment', 'Edit Surgical Appointment displays');
-      assert.dom('.test-appointment-date input').hasValue(today.format('l'), 'Date is correct');
-      assert.dom('.start-hour').hasValue('10', 'Start hour is correct');
-      assert.dom('.start-minute').hasValue('30', 'Start minute is correct');
-      assert.dom('.end-hour').hasValue('11', 'End hour is correct');
-      assert.dom('.end-minute').hasValue('30', 'End minute is correct');
-    });
+    await click('.fc-title');
+    assert.dom('.view-current-title').hasText('Edit Surgical Appointment', 'Edit Surgical Appointment displays');
+    assert.dom('.test-appointment-date input').hasValue(today.format('l'), 'Date is correct');
+    assert.dom('.start-hour').hasValue('10', 'Start hour is correct');
+    assert.dom('.start-minute').hasValue('30', 'Start minute is correct');
+    assert.dom('.end-hour').hasValue('11', 'End hour is correct');
+    assert.dom('.end-minute').hasValue('30', 'End minute is correct');
   });
 });
 
-function createAppointment(assert, appointment = { startDate: new Date(), endDate: moment().add(1, 'day').toDate(), allDay: true, status: 'Scheduled' }) {
+async function createAppointment(assert, appointment = { startDate: new Date(), endDate: moment().add(1, 'day').toDate(), allDay: true, status: 'Scheduled' }) {
   if (appointment.isSurgery) {
-    visit('/appointments/edit/newsurgery');
+    await visit('/appointments/edit/newsurgery');
   } else {
-    visit('/appointments/edit/new');
+    await visit('/appointments/edit/new');
   }
-  typeAheadFillIn('.test-patient-input', 'Lennex Zinyando - P00017');
+
+  await typeAheadFillIn('.test-patient-input', 'Lennex Zinyando - P00017');
+
   if (appointment.isSurgery) {
-    selectDate('.test-appointment-date input', appointment.startDate);
+    await selectDate('.test-appointment-date input', appointment.startDate);
     let endHour = getHour(appointment.endDate);
     let endMinute = appointment.endDate.format('mm');
     let startHour = getHour(appointment.startDate);
     let startMinute = appointment.startDate.format('mm');
-    select('.end-hour', endHour);
-    select('.end-minute', endMinute);
-    select('.start-hour', startHour);
-    select('.start-minute', startMinute);
+    await select('.end-hour', endHour);
+    await select('.end-minute', endMinute);
+    await select('.start-hour', startHour);
+    await select('.start-minute', startMinute);
+
   } else {
-    select('.test-appointment-status', appointment.status);
+    await select('.test-appointment-status', appointment.status);
     if (!appointment.allDay) {
-      click('.appointment-all-day input');
-      fillIn('.test-appointment-start input', appointment.startDate.format(DATE_TIME_FORMAT));
-      fillIn('.test-appointment-end input', appointment.endDate.format(DATE_TIME_FORMAT));
+      await click('.appointment-all-day input');
+      await fillIn('.test-appointment-start input', appointment.startDate.format(DATE_TIME_FORMAT));
+      await fillIn('.test-appointment-end input', appointment.endDate.format(DATE_TIME_FORMAT));
     } else {
-      selectDate('.test-appointment-start input', appointment.startDate);
-      selectDate('.test-appointment-end input', appointment.endDate);
+      await selectDate('.test-appointment-start input', appointment.startDate);
+      await selectDate('.test-appointment-end input', appointment.endDate);
     }
   }
-  typeAheadFillIn('.test-appointment-location', 'Harare');
-  typeAheadFillIn('.test-appointment-with', 'Dr Test');
-  click('button:contains(Add)');
-  waitToAppear('.modal-dialog');
-  andThen(() => {
-    assert.dom('.modal-title').hasText('Appointment Saved', 'Appointment has been saved');
-    click('.modal-footer button:contains(Ok)');
-  });
-  andThen(() => {
-    click('button:contains(Return)');
-  });
+
+  await typeAheadFillIn('.test-appointment-location', 'Harare');
+  await typeAheadFillIn('.test-appointment-with', 'Dr Test');
+  await click('button:contains(Add)');
+  await waitToAppear('.modal-dialog');
+  assert.dom('.modal-title').hasText('Appointment Saved', 'Appointment has been saved');
+
+  await click('.modal-footer button:contains(Ok)');
+  await click('button:contains(Return)');
 }
 
 function getHour(date) {

--- a/tests/acceptance/custom-forms-test.js
+++ b/tests/acceptance/custom-forms-test.js
@@ -9,97 +9,74 @@ test('crud operations on custom-forms', function(assert) {
   let toppings =  ['Cheese', 'Pepperoni', 'Mushrooms'];
   let header = ['______________________________'];
 
-  function verifyPreview() {
-    click('button:contains(Preview)');
-    waitToAppear('.form-preview');
-    andThen(function() {
-      assert.equal(find('.form-preview label:contains(Create a Pizza)').length, 1, 'Found Create a Pizza Label');
-      assert.equal(find(`.form-preview label:contains(${header})`).length, 1, `Found ${header} Label`);
-      assert.equal(find('.form-preview label:contains(Pizza Toppings)').length, 1, 'Found Pizza Toppings Label');
-      toppings.forEach((topping) => {
-        assert.equal(find(`.form-preview label:contains(${topping}):has(input[type=checkbox])`).length, 1, `Found ${topping} checkbox`);
-      });
-      assert.equal(find('.form-preview label:contains(Pizza Crust)').length, 1, 'Found Pizza Toppings Label');
-      crusts.forEach((crust) => {
-        assert.equal(find(`.form-preview option:contains(${crust})`).length, 1, `Found ${crust} option`);
-      });
-      assert.equal(find('.form-preview label:contains(Dessert)').length, 1, 'Found Pizza Toppings Label');
-      desserts.forEach((dessert) => {
-        assert.equal(find(`.form-preview label:contains(${dessert}):has(input[type=radio])`).length, 1, `Found ${dessert} radio option`);
-      });
-      assert.equal(find('.form-preview label:contains(Beverage)').length, 1, 'Found Beverage Label');
-      assert.dom('.form-preview input[id*=beverage]').exists({ count: 1 }, 'Found Beverage input');
-      assert.equal(find('.form-preview label:contains(Special Instructions)').length, 1, 'Found Special Instructions Label');
-      assert.dom('.form-preview textarea[id*=specialInstructions]').exists({ count: 1 }, 'Found special instructions textarea');
-      click('button:contains(Preview)'); // Hide preview to reset it back to being closed.
+  async function verifyPreview() {
+    await click('button:contains(Preview)');
+    await waitToAppear('.form-preview');
+    assert.equal(find('.form-preview label:contains(Create a Pizza)').length, 1, 'Found Create a Pizza Label');
+    assert.equal(find(`.form-preview label:contains(${header})`).length, 1, `Found ${header} Label`);
+    assert.equal(find('.form-preview label:contains(Pizza Toppings)').length, 1, 'Found Pizza Toppings Label');
+    toppings.forEach((topping) => {
+      assert.equal(find(`.form-preview label:contains(${topping}):has(input[type=checkbox])`).length, 1, `Found ${topping} checkbox`);
     });
+    assert.equal(find('.form-preview label:contains(Pizza Crust)').length, 1, 'Found Pizza Toppings Label');
+    crusts.forEach((crust) => {
+      assert.equal(find(`.form-preview option:contains(${crust})`).length, 1, `Found ${crust} option`);
+    });
+    assert.equal(find('.form-preview label:contains(Dessert)').length, 1, 'Found Pizza Toppings Label');
+    desserts.forEach((dessert) => {
+      assert.equal(find(`.form-preview label:contains(${dessert}):has(input[type=radio])`).length, 1, `Found ${dessert} radio option`);
+    });
+    assert.equal(find('.form-preview label:contains(Beverage)').length, 1, 'Found Beverage Label');
+    assert.dom('.form-preview input[id*=beverage]').exists({ count: 1 }, 'Found Beverage input');
+    assert.equal(find('.form-preview label:contains(Special Instructions)').length, 1, 'Found Special Instructions Label');
+    assert.dom('.form-preview textarea[id*=specialInstructions]').exists({ count: 1 }, 'Found special instructions textarea');
+    await click('button:contains(Preview)'); // Hide preview to reset it back to being closed.
   }
 
-  runWithPouchDump('default', function() {
-    authenticateUser();
-    visit('/admin/custom-forms');
-    andThen(function() {
-      assert.equal(currentURL(), '/admin/custom-forms', 'Navigated to custom forms index page');
-      assert.dom('.custom-form-name').doesNotExist('No custom forms appears in the listing.');
-    });
-    andThen(function() {
-      createCustomFormForType('Visit', false, assert);
-    });
-    andThen(function() {
-      verifyPreview();
-    });
-    andThen(function() {
-      click('button:contains(Return)');
-      waitToAppear('.view-current-title:contains(Custom Forms)');
-    });
-    andThen(function() {
-      assert.equal(find('.custom-form-name:contains(Test Custom Form)').length, 1, 'Custom form appears in listing.');
-      click('button:contains(Edit)');
-      waitToAppear('button:contains(Preview)');
-    });
-    andThen(function() {
-      assert.dom('.view-current-title').hasText('Edit Custom Form', 'Custom form edit page displays');
-      verifyPreview();
-    });
-    andThen(function() {
-      click('button:contains(Return)');
-      waitToAppear('.view-current-title:contains(Custom Forms)');
-    });
-    andThen(function() {
-      click('button:contains(Delete)');
-      waitToAppear('.modal-dialog');
-    });
-    andThen(function() {
-      assert.dom('.modal-title').hasText('Delete Custom Form', 'Delete confirmation displays');
-      click('.modal-footer button:contains(Ok)');
-    });
-    andThen(function() {
-      assert.dom('.custom-form-name').doesNotExist('Deleted custom form disappears from custom form listing.');
-    });
+  runWithPouchDump('default', async function() {
+    await authenticateUser();
+    await visit('/admin/custom-forms');
+    assert.equal(currentURL(), '/admin/custom-forms', 'Navigated to custom forms index page');
+    assert.dom('.custom-form-name').doesNotExist('No custom forms appears in the listing.');
 
+    await createCustomFormForType('Visit', false, assert);
+    await verifyPreview();
+    await click('button:contains(Return)');
+    await waitToAppear('.view-current-title:contains(Custom Forms)');
+    assert.equal(find('.custom-form-name:contains(Test Custom Form)').length, 1, 'Custom form appears in listing.');
+
+    await click('button:contains(Edit)');
+    await waitToAppear('button:contains(Preview)');
+    assert.dom('.view-current-title').hasText('Edit Custom Form', 'Custom form edit page displays');
+
+    await verifyPreview();
+    await click('button:contains(Return)');
+    await waitToAppear('.view-current-title:contains(Custom Forms)');
+    await click('button:contains(Delete)');
+    await waitToAppear('.modal-dialog');
+    assert.dom('.modal-title').hasText('Delete Custom Form', 'Delete confirmation displays');
+
+    await click('.modal-footer button:contains(Ok)');
+    assert.dom('.custom-form-name').doesNotExist('Deleted custom form disappears from custom form listing.');
   });
 });
 
 test('switching between pages with custom forms happens without errors', function(assert) {
-  runWithPouchDump('default', function() {
-    authenticateUser();
+  runWithPouchDump('default', async function() {
+    await authenticateUser();
 
-    createCustomFormForType('Patient', true);
-    createCustomFormForType('Lab', true);
+    await createCustomFormForType('Patient', true);
+    await createCustomFormForType('Lab', true);
 
-    visit('/patients/edit/new');
-    waitToAppear('h4');
-    andThen(function() {
-      assert.dom('h4').hasText(
-        'Test Custom Form for Patient included',
-        'Patient custom form is displayed'
-      );
-    });
+    await visit('/patients/edit/new');
+    await waitToAppear('h4');
+    assert.dom('h4').hasText(
+      'Test Custom Form for Patient included',
+      'Patient custom form is displayed'
+    );
 
-    visit('/labs/edit/new');
-    waitToAppear('h4');
-    andThen(function() {
-      assert.dom('h4').hasText('Test Custom Form for Lab included', 'Lab custom form is displayed');
-    });
+    await visit('/labs/edit/new');
+    await waitToAppear('h4');
+    assert.dom('h4').hasText('Test Custom Form for Lab included', 'Lab custom form is displayed');
   });
 });

--- a/tests/acceptance/imaging-test.js
+++ b/tests/acceptance/imaging-test.js
@@ -4,98 +4,77 @@ import moduleForAcceptance from 'hospitalrun/tests/helpers/module-for-acceptance
 moduleForAcceptance('Acceptance | imaging');
 
 test('visiting /imaging', function(assert) {
-  runWithPouchDump('default', function() {
-    authenticateUser();
-    visit('/imaging');
+  runWithPouchDump('default', async function() {
+    await authenticateUser();
+    await visit('/imaging');
+    assert.equal(currentURL(), '/imaging');
+    let newImagingButton = find('button:contains(new imaging)');
+    assert.equal(newImagingButton.length, 1, 'New Imaging button is visible');
+    findWithAssert('p:contains(No items found. )');
+    findWithAssert('a:contains(Create a new record?)');
 
-    andThen(() => {
-      assert.equal(currentURL(), '/imaging');
-      let newImagingButton = find('button:contains(new imaging)');
-      assert.equal(newImagingButton.length, 1, 'New Imaging button is visible');
-      findWithAssert('p:contains(No items found. )');
-      findWithAssert('a:contains(Create a new record?)');
-    });
-    click('button:contains(new imaging)');
-    andThen(() => {
-      assert.equal(currentURL(), '/imaging/edit/new');
-    });
+    await click('button:contains(new imaging)');
+    assert.equal(currentURL(), '/imaging/edit/new');
   });
 });
 
 test('create a new imaging request', (assert) => {
-  runWithPouchDump('imaging', function() {
-    authenticateUser();
-    visit('/imaging/edit/new');
+  runWithPouchDump('imaging', async function() {
+    await authenticateUser();
+    await visit('/imaging/edit/new');
+    assert.equal(currentURL(), '/imaging/edit/new');
 
-    andThen(() => {
-      assert.equal(currentURL(), '/imaging/edit/new');
-    });
-    typeAheadFillIn('.patient-input', 'Joe Bagadonuts - P00001');
-    typeAheadFillIn('.imaging-type-input', 'Chest Scan');
-    typeAheadFillIn('.radiologist-input', 'Dr Test');
-    fillIn('.result-input input', 'Check is clear');
-    fillIn('textarea', 'Patient is healthy');
-    click('button:contains(Add)');
-    waitToAppear('.modal-dialog');
-    andThen(() => {
-      assert.dom('.modal-title').hasText('Imaging Request Saved', 'Imaging Request was saved successfully');
-    });
-    click('button:contains(Ok)');
-    andThen(() => {
-      findWithAssert('button:contains(Update)');
-      findWithAssert('button:contains(Return)');
-      findWithAssert('button:contains(Complete)');
-    });
-    andThen(() => {
-      assert.dom('.patient-summary').exists({ count: 1 }, 'Patient summary is displayed');
-    });
-    click('button:contains(Return)');
-    andThen(() => {
-      assert.equal(currentURL(), '/imaging');
-      assert.dom('tr').exists({ count: 3 }, 'Two imaging requests are displayed');
-    });
+    await typeAheadFillIn('.patient-input', 'Joe Bagadonuts - P00001');
+    await typeAheadFillIn('.imaging-type-input', 'Chest Scan');
+    await typeAheadFillIn('.radiologist-input', 'Dr Test');
+    await fillIn('.result-input input', 'Check is clear');
+    await fillIn('textarea', 'Patient is healthy');
+    await click('button:contains(Add)');
+    await waitToAppear('.modal-dialog');
+    assert.dom('.modal-title').hasText('Imaging Request Saved', 'Imaging Request was saved successfully');
+
+    await click('button:contains(Ok)');
+    findWithAssert('button:contains(Update)');
+    findWithAssert('button:contains(Return)');
+    findWithAssert('button:contains(Complete)');
+    assert.dom('.patient-summary').exists({ count: 1 }, 'Patient summary is displayed');
+
+    await click('button:contains(Return)');
+    assert.equal(currentURL(), '/imaging');
+    assert.dom('tr').exists({ count: 3 }, 'Two imaging requests are displayed');
   });
 });
 
 test('completed requests are displayed', (assert) => {
-  runWithPouchDump('imaging', function() {
-    authenticateUser();
-    visit('/imaging/completed');
-
-    andThen(() => {
-      assert.equal(currentURL(), '/imaging/completed');
-      assert.dom('.table').exists({ count: 1 }, 'Requests table is visible');
-    });
+  runWithPouchDump('imaging', async function() {
+    await authenticateUser();
+    await visit('/imaging/completed');
+    assert.equal(currentURL(), '/imaging/completed');
+    assert.dom('.table').exists({ count: 1 }, 'Requests table is visible');
   });
 });
 
 test('mark an imaging request as completed', (assert) => {
-  runWithPouchDump('imaging', function() {
-    authenticateUser();
-    visit('/imaging');
+  runWithPouchDump('imaging', async function() {
+    await authenticateUser();
+    await visit('/imaging');
+    assert.equal(currentURL(), '/imaging');
+    assert.dom('.table').exists({ count: 1 }, 'Requests table is visible');
+    assert.dom('tr').exists({ count: 2 }, 'One imaging request not completed');
 
-    andThen(() => {
-      assert.equal(currentURL(), '/imaging');
-      assert.dom('.table').exists({ count: 1 }, 'Requests table is visible');
-      assert.dom('tr').exists({ count: 2 }, 'One imaging request not completed');
-    });
-    click('button:contains(Edit):first');
-    andThen(() => {
-      assert.equal(currentURL(), '/imaging/edit/12DEDA58-4670-7A74-BA8B-9CC5E5CA82E7');
-      findWithAssert('button:contains(Update)');
-      findWithAssert('button:contains(Return)');
-      findWithAssert('button:contains(Complete)');
-    });
-    click('button:contains(Complete)');
-    waitToAppear('.modal-dialog');
-    andThen(() => {
-      assert.dom('.modal-title').hasText('Imaging Request Completed', 'Imaging Request was saved successfully');
-    });
-    click('button:contains(Ok)');
-    click('button:contains(Return)');
-    andThen(() => {
-      assert.equal(currentURL(), '/imaging');
-      findWithAssert('a:contains(Create a new record?)');
-    });
+    await click('button:contains(Edit):first');
+    assert.equal(currentURL(), '/imaging/edit/12DEDA58-4670-7A74-BA8B-9CC5E5CA82E7');
+    findWithAssert('button:contains(Update)');
+    findWithAssert('button:contains(Return)');
+    findWithAssert('button:contains(Complete)');
+
+    await click('button:contains(Complete)');
+    await waitToAppear('.modal-dialog');
+    assert.dom('.modal-title').hasText('Imaging Request Completed', 'Imaging Request was saved successfully');
+
+    await click('button:contains(Ok)');
+    await click('button:contains(Return)');
+    assert.equal(currentURL(), '/imaging');
+    findWithAssert('a:contains(Create a new record?)');
   });
 });

--- a/tests/acceptance/incident-test.js
+++ b/tests/acceptance/incident-test.js
@@ -15,270 +15,201 @@ const REPORTED_TO = 'Jack Bridges';
 moduleForAcceptance('Acceptance | Incidents');
 
 test('Incident category management', function(assert) {
-  runWithPouchDump('incident', function() {
-    authenticateUser();
-    visit('/admin/inc-category');
-    andThen(() => {
-      assert.equal(currentURL(), '/admin/inc-category', 'Incident Categories url is correct');
-      click('button:contains(+ new category)');
-    });
-    andThen(() => {
-      assert.equal(currentURL(), '/admin/inc-category/edit/new', 'New incident category URL is correct');
-      fillIn('.incident-category-name input', 'Infection Control');
-      addItem(assert, 'Surgical Site Infection');
-    });
-    andThen(() => {
-      addItem(assert, 'Hospital Acquired Infection');
-    });
-    andThen(() => {
-      click('button:contains(Delete)');
-      waitToAppear('.modal-dialog');
-    });
-    andThen(() => {
-      assert.dom('.modal-title').hasText('Delete Item', 'Delete Item modal appears');
-      click('.modal-footer button:contains(Ok)');
-      waitToDisappear('.modal-dialog');
-    });
-    andThen(() => {
-      assert.equal(find('.incident-category-item:contains(Surgical Site Infection)').length,
-        0, 'Deleted incident category item disappears');
-      click('.panel-footer button:contains(Update)');
-      waitToAppear('.modal-dialog');
-    });
-    andThen(() => {
-      assert.dom('.modal-title').hasText('Incident Category Saved', 'Incident Category saved modal appears');
-      click('button:contains(Return)');
-    });
-    andThen(() => {
-      assert.equal(currentURL(), '/admin/inc-category', 'Incident Categories url is correct');
-      assert.equal(find('td.incident-catergory-name:contains(Infection Control)').length,
-        1, 'New incident category displays in listing');
-    });
+  runWithPouchDump('incident', async function() {
+    await authenticateUser();
+    await visit('/admin/inc-category');
+    assert.equal(currentURL(), '/admin/inc-category', 'Incident Categories url is correct');
+
+    await click('button:contains(+ new category)');
+    assert.equal(currentURL(), '/admin/inc-category/edit/new', 'New incident category URL is correct');
+
+    await fillIn('.incident-category-name input', 'Infection Control');
+    await addItem(assert, 'Surgical Site Infection');
+    await addItem(assert, 'Hospital Acquired Infection');
+    await click('button:contains(Delete)');
+    await waitToAppear('.modal-dialog');
+    assert.dom('.modal-title').hasText('Delete Item', 'Delete Item modal appears');
+
+    await click('.modal-footer button:contains(Ok)');
+    await waitToDisappear('.modal-dialog');
+    assert.equal(find('.incident-category-item:contains(Surgical Site Infection)').length,
+      0, 'Deleted incident category item disappears');
+    await click('.panel-footer button:contains(Update)');
+    await waitToAppear('.modal-dialog');
+    assert.dom('.modal-title').hasText('Incident Category Saved', 'Incident Category saved modal appears');
+    await click('button:contains(Return)');
+    assert.equal(currentURL(), '/admin/inc-category', 'Incident Categories url is correct');
+    assert.equal(find('td.incident-catergory-name:contains(Infection Control)').length,
+      1, 'New incident category displays in listing');
   });
 });
 
 test('Incident creation and editing', function(assert) {
-  runWithPouchDump('incident', function() {
+  runWithPouchDump('incident', async function() {
     let now = moment();
-    authenticateUser();
-    visit('/incident');
-    andThen(() => {
-      assert.equal(currentURL(), '/incident', 'Incident listing url is correct');
-      click('button:contains(+ new incident)');
-    });
-    andThen(() => {
-      assert.equal(currentURL(), '/incident/edit/new', 'Incident edit url is correct');
-      click('.sentinel-event input');
-      fillIn('.incident-date input', now.format(DATE_TIME_FORMAT));
-      typeAheadFillIn('.incident-department', DEPARTMENT);
-      fillIn('.reported-to input', REPORTED_TO);
-      fillIn('.incident-category select', INCIDENT_CATEGORY);
-      waitToAppear(`.incident-category-item option:contains(${INCIDENT_CATEGORY_ITEM})`);
-    });
-    andThen(() => {
-      select('.incident-category-item', INCIDENT_CATEGORY_ITEM);
-      typeAheadFillIn('.patient-name', 'Joe Bagadonuts - P00001');
-      waitToAppear('.patient-id:contains(P00001)');
-    });
-    andThen(() => {
-      assert.dom('.patient-id').hasText('P00001', 'Selected patient id appears');
-      fillIn('.incident-description textarea', 'Patient blacked out and fell down.');
-    });
-    andThen(() => {
-      click('.panel-footer button:contains(Add)');
-      waitToAppear('.modal-dialog');
-    });
-    andThen(() => {
-      assert.dom('.modal-title').hasText('Incident Saved', ' Incident Saved modal appears');
-      click('.modal-footer button:contains(Ok)');
-    });
-    andThen(() => {
-      assert.equal(find('.tab-nav li a:contains(Notes)').length, 1, 'Notes tab appears');
-      assert.equal(find('.tab-nav li a:contains(Attachment)').length, 1, 'Attachment tab appears');
-      assert.equal(find('.tab-nav li a:contains(Harm Score)').length, 1, 'Harm Score custom form tab appears');
-      assert.equal(find('.tab-nav li a:contains(+ Add Form)').length, 1, 'Add Custom form tab appears');
-      click('button:contains(+ New Note)');
-      waitToAppear('.modal-dialog');
-    });
-    andThen(() => {
-      fillIn('.note-description textarea', INCIDENT_NOTES);
-      click('.modal-footer button:contains(Add)');
-    });
-    andThen(() => {
-      waitToDisappear('.modal-dialog');
-      waitToAppear(`.note-description:contains(${INCIDENT_NOTES})`);
-    });
-    andThen(() => {
-      assert.equal(find(`.note-description:contains(${INCIDENT_NOTES})`).length, 1, 'Added note appears in listing');
-      click('.tab-nav li a:contains(Attachment)');
-    });
-    andThen(() => {
-      click('button:contains(+ New Attachment)');
-      waitToAppear('.modal-dialog');
-    });
-    andThen(() => {
-      assert.dom('.modal-title').hasText('Add Attachment', 'Add attachment dialog appears');
-      // Right now we don't have a good way to test adding attachments.
-      click('.modal-footer button:contains(Cancel)');
-      waitToDisappear('.modal-dialog');
-    });
-    andThen(() => {
-      click('.tab-nav li a:contains(Harm Score)');
-    });
-    andThen(() => {
-      assert.equal(find('#customForm0 label:contains(No Actual Event)').length, 1, 'Always add custom form renders');
-      click('.tab-nav li a:contains(+ Add Form)');
-      waitToAppear('.modal-dialog');
-    });
-    andThen(() => {
-      assert.dom('.modal-title').hasText('Add Custom Form', 'Add custom form dialog appears');
-      select('.form-to-add', 'Incident');
-    });
-    andThen(() => {
-      click('.modal-footer button:contains(Add Form)');
-      waitToDisappear('.modal-dialog');
-    });
-    andThen(() => {
-      assert.equal(find('.tab-nav li a:contains(Pre-Incident Risk Assessment)').length, 1, 'Pre-Incident Risk Assessment form tab now appears');
-      assert.equal(find('.tab-nav li a:contains(+ Add Form)').length, 0, 'Add Custom form tab disappears');
-      click('.tab-nav li a:contains(Pre-Incident Risk Assessment)');
-    });
-    andThen(() => {
-      assert.equal(find('#customForm1 label:contains(Minimum No injuries, low financial loss)').length, 1, 'Pre-Incident Risk Assessment custom form renders');
-      click('.panel-footer button:contains(Update)');
-      waitToAppear('.modal-dialog');
-    });
-    andThen(() => {
-      assert.dom('.modal-title').hasText('Incident Saved', ' Incident Saved modal appears');
-      click('.modal-footer button:contains(Ok)');
-      waitToDisappear('.modal-dialog');
-    });
-    andThen(() => {
-      click('.panel-footer button:contains(Return)');
-    });
-    andThen(() => {
-      assert.equal(currentURL(), '/incident', 'Incident listing url is correct');
-      assert.equal(find('.incident-row').length, 2, 'Two incidents appears');
-      assert.equal(find(`.incident-row td.incident-date:contains(${now.format(DATE_FORMAT)})`).length, 1, 'Incident date appears in listing');
-      assert.equal(find(`.incident-row td.incident-department:contains(${DEPARTMENT})`).length, 1, 'Incident department appears in listing');
-      assert.equal(find(`.incident-row td.incident-category:contains(${INCIDENT_CATEGORY})`).length, 1, 'Incident category appears in listing');
-      assert.equal(find(`.incident-row td.incident-category-item:contains(${INCIDENT_CATEGORY_ITEM})`).length, 1, 'Incident category item appears in listing');
-      assert.equal(find('.incident-row td.incident-status:last').text(), 'Reported', 'Incident status of reported appears in listing');
-      visit('/incident/edit/56c64d71-ba30-4271-b899-f6f6b031f589');
-    });
-    andThen(() => {
-      let incidentDate = moment(1489004400000);
-      assert.equal(currentURL(), '/incident/edit/56c64d71-ba30-4271-b899-f6f6b031f589', 'Incident edit url is correct');
-      assert.dom('.sentinel-event input').isChecked('Sentinel Event checkbox is checked');
-      assert.dom('.incident-date input').hasValue(incidentDate.format(DATE_TIME_FORMAT), 'Date of incident displays');
-      assert.dom('.incident-department .tt-input').hasValue('Reception', 'Incident department displays');
-      assert.dom('.reported-to input').hasValue('Jane Bagadonuts', 'Reported to displays.');
-      assert.equal(find('.incident-category option:selected').text().trim(), 'Accident or Injury', 'Category displays');
-      assert.equal(find('.incident-category-item option:selected').text().trim(), 'Patient', 'Category item displays');
-      assert.dom('.patient-name .tt-input').hasValue('Joe Bagadonuts - P00001', 'Patient impacted name displays');
-      assert.dom('.patient-id').hasText('P00001', 'Patient id displays');
-      assert.dom('.incident-description textarea').hasValue('Patient fell on wet floor.', 'Description displays');
-      fillIn('.incident-description textarea', INCIDENT_DESCRIPTION);
-    });
-    andThen(() => {
-      assert.dom('.incident-description textarea').hasValue(INCIDENT_DESCRIPTION, 'Updated description displays');
-      click('.panel-footer button:contains(Update)');
-      waitToAppear('.modal-dialog');
-    });
-    andThen(() => {
-      assert.dom('.modal-title').hasText('Incident Saved', ' Incident Saved modal appears');
-      click('.modal-footer button:contains(Ok)');
-      waitToDisappear('.modal-dialog');
-    });
-    andThen(() => {
-      click('#notes tr button:contains(Edit)');
-      waitToAppear('.modal-dialog');
-    });
-    andThen(() => {
-      assert.dom('.modal-title').hasText('Edit Note', ' Edit Note modal appears');
-      fillIn('.note-description textarea', EDIT_INCIDENT_NOTE);
-    });
-    andThen(() => {
-      click('.modal-footer button:contains(Update)');
-      waitToDisappear('.modal-dialog');
-    });
-    andThen(() => {
-      assert.dom('.note-description').hasText(EDIT_INCIDENT_NOTE, 'Note is updated');
-      click('#notes tr button:contains(Delete)');
-      waitToAppear('.modal-dialog');
-    });
-    andThen(() => {
-      assert.dom('.modal-title').hasText('Delete Note', ' Delete Note modal appears');
-      click('.modal-footer button:contains(Delete)');
-      waitToDisappear('.modal-dialog');
-    });
-    andThen(() => {
-      assert.dom('.note-description').doesNotExist('Note has been deleted');
-      click('.tab-nav li a:contains(Attachment)');
-      waitToAppear('#attachments td a:contains(Download)');
-    });
-    andThen(() => {
-      assert.equal(find('#attachments td a:contains(Download)').length, 1, 'Download button appears for attachment');
-      click('#attachments td button:contains(Edit)');
-      waitToAppear('.modal-dialog');
-    });
-    andThen(() => {
-      assert.dom('.modal-title').hasText('Edit Attachment', ' Edit Attachment modal appears');
-      fillIn('.attachment-title input', 'Incident Report Form');
-    });
-    andThen(() => {
-      click('.modal-footer button:contains(Update)');
-      waitToDisappear('.modal-dialog');
-    });
-    andThen(() => {
-      assert.equal(find('#attachments td:contains(Incident Report Form)').length, 1, 'Updated attachment title appears');
-      click('#attachments td button:contains(Delete)');
-      waitToAppear('.modal-dialog');
-    });
-    andThen(() => {
-      assert.dom('.modal-title').hasText('Delete Attachment', ' Delete Attachment modal appears');
-      click('.modal-footer button:contains(Ok)');
-    });
-    andThen(() => {
-      assert.equal(find('#attachments td:contains(Incident Report Form)').length, 0, 'Deleted attachment disappears');
-    });
+    await authenticateUser();
+    await visit('/incident');
+    assert.equal(currentURL(), '/incident', 'Incident listing url is correct');
+
+    await click('button:contains(+ new incident)');
+    assert.equal(currentURL(), '/incident/edit/new', 'Incident edit url is correct');
+
+    await click('.sentinel-event input');
+    await fillIn('.incident-date input', now.format(DATE_TIME_FORMAT));
+    await typeAheadFillIn('.incident-department', DEPARTMENT);
+    await fillIn('.reported-to input', REPORTED_TO);
+    await fillIn('.incident-category select', INCIDENT_CATEGORY);
+    await waitToAppear(`.incident-category-item option:contains(${INCIDENT_CATEGORY_ITEM})`);
+    await select('.incident-category-item', INCIDENT_CATEGORY_ITEM);
+    await typeAheadFillIn('.patient-name', 'Joe Bagadonuts - P00001');
+    await waitToAppear('.patient-id:contains(P00001)');
+    assert.dom('.patient-id').hasText('P00001', 'Selected patient id appears');
+
+    await fillIn('.incident-description textarea', 'Patient blacked out and fell down.');
+    await click('.panel-footer button:contains(Add)');
+    await waitToAppear('.modal-dialog');
+    assert.dom('.modal-title').hasText('Incident Saved', ' Incident Saved modal appears');
+
+    await click('.modal-footer button:contains(Ok)');
+    assert.equal(find('.tab-nav li a:contains(Notes)').length, 1, 'Notes tab appears');
+    assert.equal(find('.tab-nav li a:contains(Attachment)').length, 1, 'Attachment tab appears');
+    assert.equal(find('.tab-nav li a:contains(Harm Score)').length, 1, 'Harm Score custom form tab appears');
+    assert.equal(find('.tab-nav li a:contains(+ Add Form)').length, 1, 'Add Custom form tab appears');
+
+    await click('button:contains(+ New Note)');
+    await waitToAppear('.modal-dialog');
+    await fillIn('.note-description textarea', INCIDENT_NOTES);
+    await click('.modal-footer button:contains(Add)');
+    await waitToDisappear('.modal-dialog');
+    await waitToAppear(`.note-description:contains(${INCIDENT_NOTES})`);
+    assert.equal(find(`.note-description:contains(${INCIDENT_NOTES})`).length, 1, 'Added note appears in listing');
+
+    await click('.tab-nav li a:contains(Attachment)');
+    await click('button:contains(+ New Attachment)');
+    await waitToAppear('.modal-dialog');
+    assert.dom('.modal-title').hasText('Add Attachment', 'Add attachment dialog appears');
+
+    // Right now we don't have a good way to test adding attachments.
+    await click('.modal-footer button:contains(Cancel)');
+    await waitToDisappear('.modal-dialog');
+    await click('.tab-nav li a:contains(Harm Score)');
+    assert.equal(find('#customForm0 label:contains(No Actual Event)').length, 1, 'Always add custom form renders');
+
+    await click('.tab-nav li a:contains(+ Add Form)');
+    await waitToAppear('.modal-dialog');
+    assert.dom('.modal-title').hasText('Add Custom Form', 'Add custom form dialog appears');
+
+    await select('.form-to-add', 'Incident');
+    await click('.modal-footer button:contains(Add Form)');
+    await waitToDisappear('.modal-dialog');
+    assert.equal(find('.tab-nav li a:contains(Pre-Incident Risk Assessment)').length, 1, 'Pre-Incident Risk Assessment form tab now appears');
+    assert.equal(find('.tab-nav li a:contains(+ Add Form)').length, 0, 'Add Custom form tab disappears');
+
+    await click('.tab-nav li a:contains(Pre-Incident Risk Assessment)');
+    assert.equal(find('#customForm1 label:contains(Minimum No injuries, low financial loss)').length, 1, 'Pre-Incident Risk Assessment custom form renders');
+
+    await click('.panel-footer button:contains(Update)');
+    await waitToAppear('.modal-dialog');
+    assert.dom('.modal-title').hasText('Incident Saved', ' Incident Saved modal appears');
+
+    await click('.modal-footer button:contains(Ok)');
+    await waitToDisappear('.modal-dialog');
+    await click('.panel-footer button:contains(Return)');
+    assert.equal(currentURL(), '/incident', 'Incident listing url is correct');
+    assert.equal(find('.incident-row').length, 2, 'Two incidents appears');
+    assert.equal(find(`.incident-row td.incident-date:contains(${now.format(DATE_FORMAT)})`).length, 1, 'Incident date appears in listing');
+    assert.equal(find(`.incident-row td.incident-department:contains(${DEPARTMENT})`).length, 1, 'Incident department appears in listing');
+    assert.equal(find(`.incident-row td.incident-category:contains(${INCIDENT_CATEGORY})`).length, 1, 'Incident category appears in listing');
+    assert.equal(find(`.incident-row td.incident-category-item:contains(${INCIDENT_CATEGORY_ITEM})`).length, 1, 'Incident category item appears in listing');
+    assert.equal(find('.incident-row td.incident-status:last').text(), 'Reported', 'Incident status of reported appears in listing');
+
+    await visit('/incident/edit/56c64d71-ba30-4271-b899-f6f6b031f589');
+
+    let incidentDate = moment(1489004400000);
+    assert.equal(currentURL(), '/incident/edit/56c64d71-ba30-4271-b899-f6f6b031f589', 'Incident edit url is correct');
+    assert.dom('.sentinel-event input').isChecked('Sentinel Event checkbox is checked');
+    assert.dom('.incident-date input').hasValue(incidentDate.format(DATE_TIME_FORMAT), 'Date of incident displays');
+    assert.dom('.incident-department .tt-input').hasValue('Reception', 'Incident department displays');
+    assert.dom('.reported-to input').hasValue('Jane Bagadonuts', 'Reported to displays.');
+    assert.equal(find('.incident-category option:selected').text().trim(), 'Accident or Injury', 'Category displays');
+    assert.equal(find('.incident-category-item option:selected').text().trim(), 'Patient', 'Category item displays');
+    assert.dom('.patient-name .tt-input').hasValue('Joe Bagadonuts - P00001', 'Patient impacted name displays');
+    assert.dom('.patient-id').hasText('P00001', 'Patient id displays');
+    assert.dom('.incident-description textarea').hasValue('Patient fell on wet floor.', 'Description displays');
+
+    await fillIn('.incident-description textarea', INCIDENT_DESCRIPTION);
+    assert.dom('.incident-description textarea').hasValue(INCIDENT_DESCRIPTION, 'Updated description displays');
+
+    await click('.panel-footer button:contains(Update)');
+    await waitToAppear('.modal-dialog');
+    assert.dom('.modal-title').hasText('Incident Saved', ' Incident Saved modal appears');
+
+    await click('.modal-footer button:contains(Ok)');
+    await waitToDisappear('.modal-dialog');
+    await click('#notes tr button:contains(Edit)');
+    await waitToAppear('.modal-dialog');
+    assert.dom('.modal-title').hasText('Edit Note', ' Edit Note modal appears');
+
+    await fillIn('.note-description textarea', EDIT_INCIDENT_NOTE);
+    await click('.modal-footer button:contains(Update)');
+    await waitToDisappear('.modal-dialog');
+    assert.dom('.note-description').hasText(EDIT_INCIDENT_NOTE, 'Note is updated');
+
+    await click('#notes tr button:contains(Delete)');
+    await waitToAppear('.modal-dialog');
+    assert.dom('.modal-title').hasText('Delete Note', ' Delete Note modal appears');
+
+    await click('.modal-footer button:contains(Delete)');
+    await waitToDisappear('.modal-dialog');
+    assert.dom('.note-description').doesNotExist('Note has been deleted');
+
+    await click('.tab-nav li a:contains(Attachment)');
+    await waitToAppear('#attachments td a:contains(Download)');
+    assert.equal(find('#attachments td a:contains(Download)').length, 1, 'Download button appears for attachment');
+
+    await click('#attachments td button:contains(Edit)');
+    await waitToAppear('.modal-dialog');
+    assert.dom('.modal-title').hasText('Edit Attachment', ' Edit Attachment modal appears');
+
+    await fillIn('.attachment-title input', 'Incident Report Form');
+    await click('.modal-footer button:contains(Update)');
+    await waitToDisappear('.modal-dialog');
+    assert.equal(find('#attachments td:contains(Incident Report Form)').length, 1, 'Updated attachment title appears');
+
+    await click('#attachments td button:contains(Delete)');
+    await waitToAppear('.modal-dialog');
+    assert.dom('.modal-title').hasText('Delete Attachment', ' Delete Attachment modal appears');
+
+    await click('.modal-footer button:contains(Ok)');
+    assert.equal(find('#attachments td:contains(Incident Report Form)').length, 0, 'Deleted attachment disappears');
   });
 });
 
 test('Incident deletion', function(assert) {
-  runWithPouchDump('incident', function() {
-    authenticateUser();
-    visit('/incident');
-    andThen(() => {
-      assert.equal(currentURL(), '/incident', 'Incident listing url is correct');
-      assert.dom('.incident-row').exists({ count: 1 }, 'One incident appears');
-      click('.incident-row button:contains(Delete)');
-      waitToAppear('.modal-dialog');
-    });
-    andThen(() => {
-      assert.dom('.modal-title').hasText('Delete Incident', ' Delete Incident modal appears');
-      click('.modal-footer button:contains(Delete)');
-      waitToDisappear('.modal-dialog');
-    });
-    andThen(() => {
-      assert.dom('.incident-row').doesNotExist('Incident diappears from list');
-    });
+  runWithPouchDump('incident', async function() {
+    await authenticateUser();
+    await visit('/incident');
+    assert.equal(currentURL(), '/incident', 'Incident listing url is correct');
+    assert.dom('.incident-row').exists({ count: 1 }, 'One incident appears');
+
+    await click('.incident-row button:contains(Delete)');
+    await waitToAppear('.modal-dialog');
+    assert.dom('.modal-title').hasText('Delete Incident', ' Delete Incident modal appears');
+
+    await click('.modal-footer button:contains(Delete)');
+    await waitToDisappear('.modal-dialog');
+    assert.dom('.incident-row').doesNotExist('Incident diappears from list');
   });
 });
 
-function addItem(assert, itemName) {
-  click('button:contains(Add Item)');
-  waitToAppear('.modal-dialog');
-  andThen(() => {
-    assert.dom('.modal-title').hasText('Add Category Item', 'Add Category Item modal appears');
-    fillIn('.incident-category-item input', itemName);
-  });
-  andThen(() => {
-    click('.modal-footer button:contains(Add)');
-    waitToAppear(`.incident-category-item:contains(${itemName})`);
-  });
-  andThen(() => {
-    assert.equal(find(`.incident-category-item:contains(${itemName})`).length,
-      1, 'New incident category item appears');
-  });
+async function addItem(assert, itemName) {
+  await click('button:contains(Add Item)');
+  await waitToAppear('.modal-dialog');
+  assert.dom('.modal-title').hasText('Add Category Item', 'Add Category Item modal appears');
+
+  await fillIn('.incident-category-item input', itemName);
+  await click('.modal-footer button:contains(Add)');
+  await waitToAppear(`.incident-category-item:contains(${itemName})`);
+  assert.equal(find(`.incident-category-item:contains(${itemName})`).length,
+    1, 'New incident category item appears');
 }

--- a/tests/acceptance/inventory-test.js
+++ b/tests/acceptance/inventory-test.js
@@ -5,306 +5,239 @@ import moduleForAcceptance from 'hospitalrun/tests/helpers/module-for-acceptance
 moduleForAcceptance('Acceptance | inventory');
 
 test('visiting /inventory', function(assert) {
-  runWithPouchDump('default', function() {
-    authenticateUser();
-    visit('/inventory');
-
-    andThen(function() {
-      assert.equal(currentURL(), '/inventory');
-      findWithAssert('button:contains(new request)');
-      findWithAssert('button:contains(+ Inventory Received)');
-      findWithAssert('p:contains(No requests found. )');
-      findWithAssert('a:contains(Create a new request?)');
-    });
+  runWithPouchDump('default', async function() {
+    await authenticateUser();
+    await visit('/inventory');
+    assert.equal(currentURL(), '/inventory');
+    findWithAssert('button:contains(new request)');
+    findWithAssert('button:contains(+ Inventory Received)');
+    findWithAssert('p:contains(No requests found. )');
+    findWithAssert('a:contains(Create a new request?)');
   });
 });
 
 test('Adding a new inventory item', (assert) => {
-  runWithPouchDump('default', function() {
-    authenticateUser();
-    visit('/inventory/edit/new');
+  runWithPouchDump('default', async function() {
+    await authenticateUser();
+    await visit('/inventory/edit/new');
+    assert.equal(currentURL(), '/inventory/edit/new');
 
-    andThen(() => {
-      assert.equal(currentURL(), '/inventory/edit/new');
-    });
-    fillIn('.test-inv-name input', 'Biogesic');
-    select('.test-inv-rank', 'B');
-    fillIn('textarea', 'Biogesic nga medisina');
-    select('.test-inv-type', 'Medication');
-    fillIn('.test-inv-cross input', '2600');
-    fillIn('.test-inv-reorder input', '100');
-    fillIn('.test-inv-price input', '5');
-    select('.test-inv-dist-unit', 'tablet');
-    fillIn('.test-inv-quantity input', '1000');
-    fillIn('.test-inv-cost input', '4000');
-    select('.test-inv-unit', 'tablet');
-    typeAheadFillIn('.test-vendor', 'Alpha Pharmacy');
-    click('button:contains(Add)');
-    waitToAppear('.modal-dialog');
+    await fillIn('.test-inv-name input', 'Biogesic');
+    await select('.test-inv-rank', 'B');
+    await fillIn('textarea', 'Biogesic nga medisina');
+    await select('.test-inv-type', 'Medication');
+    await fillIn('.test-inv-cross input', '2600');
+    await fillIn('.test-inv-reorder input', '100');
+    await fillIn('.test-inv-price input', '5');
+    await select('.test-inv-dist-unit', 'tablet');
+    await fillIn('.test-inv-quantity input', '1000');
+    await fillIn('.test-inv-cost input', '4000');
+    await select('.test-inv-unit', 'tablet');
+    await typeAheadFillIn('.test-vendor', 'Alpha Pharmacy');
+    await click('button:contains(Add)');
+    await waitToAppear('.modal-dialog');
+    assert.dom('.modal-title').hasText('Inventory Item Saved', 'Inventory Item was saved successfully');
 
-    andThen(() => {
-      assert.dom('.modal-title').hasText('Inventory Item Saved', 'Inventory Item was saved successfully');
-    });
-    click('button:contains(Ok)');
+    await click('button:contains(Ok)');
+    findWithAssert('button:contains(Add Purchase)');
+    findWithAssert('button:contains(Update)');
+    findWithAssert('button:contains(Return)');
 
-    andThen(() => {
-      findWithAssert('button:contains(Add Purchase)');
-      findWithAssert('button:contains(Update)');
-      findWithAssert('button:contains(Return)');
-    });
-
-    click('button:contains(Return)');
-    andThen(() => {
-      assert.equal(currentURL(), '/inventory/listing');
-      assert.dom('tr').exists({ count: 2 }, 'One item is listed');
-    });
+    await click('button:contains(Return)');
+    assert.equal(currentURL(), '/inventory/listing');
+    assert.dom('tr').exists({ count: 2 }, 'One item is listed');
   });
 });
 
 test('Items with negative quantites should not be saved', (assert) => {
-  runWithPouchDump('default', function() {
-    authenticateUser();
-    visit('/inventory/edit/new');
+  runWithPouchDump('default', async function() {
+    await authenticateUser();
+    await visit('/inventory/edit/new');
+    assert.equal(currentURL(), '/inventory/edit/new');
 
-    andThen(() => {
-      assert.equal(currentURL(), '/inventory/edit/new');
-    });
-    fillIn('.test-inv-name input', 'Biogesic');
-    select('.test-inv-rank', 'B');
-    fillIn('textarea', 'Biogesic nga medisina');
-    select('.test-inv-type', 'Medication');
-    fillIn('.test-inv-cross input', '2600');
-    fillIn('.test-inv-reorder input', '100');
-    fillIn('.test-inv-price input', '5');
-    select('.test-inv-dist-unit', 'tablet');
-    fillIn('.test-inv-quantity input', '-1000');
-    fillIn('.test-inv-cost input', '4000');
-    select('.test-inv-unit', 'tablet');
-    typeAheadFillIn('.test-vendor', 'Alpha Pharmacy');
-    click('button:contains(Add)');
-    waitToAppear('.modal-dialog');
+    await fillIn('.test-inv-name input', 'Biogesic');
+    await select('.test-inv-rank', 'B');
+    await fillIn('textarea', 'Biogesic nga medisina');
+    await select('.test-inv-type', 'Medication');
+    await fillIn('.test-inv-cross input', '2600');
+    await fillIn('.test-inv-reorder input', '100');
+    await fillIn('.test-inv-price input', '5');
+    await select('.test-inv-dist-unit', 'tablet');
+    await fillIn('.test-inv-quantity input', '-1000');
+    await fillIn('.test-inv-cost input', '4000');
+    await select('.test-inv-unit', 'tablet');
+    await typeAheadFillIn('.test-vendor', 'Alpha Pharmacy');
+    await click('button:contains(Add)');
+    await waitToAppear('.modal-dialog');
 
-    andThen(() => {
-      assert.dom('.modal-title').hasText(
-        'Warning!!!!',
-        'Inventory Item with negative quantity should not be saved.'
-      );
-    });
-    click('button:contains(Ok)');
+    assert.dom('.modal-title').hasText(
+      'Warning!!!!',
+      'Inventory Item with negative quantity should not be saved.'
+    );
 
-    andThen(() => {
-      assert.equal(currentURL(), '/inventory/edit/new');
-      findWithAssert('button:contains(Add)');
-      findWithAssert('button:contains(Cancel)');
-      assert.dom('.test-inv-quantity .help-block').hasText(
-        'not a valid number',
-        'Error message should be present for invalid quantities'
-      );
-    });
+    await click('button:contains(Ok)');
+    assert.equal(currentURL(), '/inventory/edit/new');
+    findWithAssert('button:contains(Add)');
+    findWithAssert('button:contains(Cancel)');
+    assert.dom('.test-inv-quantity .help-block').hasText(
+      'not a valid number',
+      'Error message should be present for invalid quantities'
+    );
   });
 });
 
 test('Visiting /inventory/barcode', (assert) => {
-  runWithPouchDump('inventory', function() {
-    authenticateUser();
-    visit('/inventory/listing');
+  runWithPouchDump('inventory', async function() {
+    await authenticateUser();
+    await visit('/inventory/listing');
+    assert.equal(currentURL(), '/inventory/listing');
 
-    andThen(() => {
-      assert.equal(currentURL(), '/inventory/listing');
-      click('a:contains(Barcode)');
-      andThen(() => {
-        assert.equal(currentURL(), '/inventory/barcode/igbmk5zf_is');
-        findWithAssert('.panel-body img[src^="data:image"]');
-      });
-    });
+    await click('a:contains(Barcode)');
+    assert.equal(currentURL(), '/inventory/barcode/igbmk5zf_is');
+    findWithAssert('.panel-body img[src^="data:image"]');
   });
 });
 
 test('Deleting the last inventory item', (assert) => {
-  runWithPouchDump('inventory', function() {
-    authenticateUser();
-    visit('/inventory/listing');
+  runWithPouchDump('inventory', async function() {
+    await authenticateUser();
+    await visit('/inventory/listing');
+    assert.equal(currentURL(), '/inventory/listing');
 
-    andThen(function() {
-      assert.equal(currentURL(), '/inventory/listing');
-      click('button:contains(Delete)');
-      waitToAppear('.modal-dialog');
-      andThen(() => {
-        assert.dom('.modal-title').hasText('Delete Item', 'Deleting confirmation.');
-      });
-      click('.modal-content button:contains(Delete)');
-      waitToAppear('.panel-body .alert-info');
-      andThen(function() {
-        assert.equal(currentURL(), '/inventory/listing');
-        findWithAssert('a:contains(Create a new record?)');
-      });
-    });
+    await click('button:contains(Delete)');
+    await waitToAppear('.modal-dialog');
+    assert.dom('.modal-title').hasText('Delete Item', 'Deleting confirmation.');
+
+    await click('.modal-content button:contains(Delete)');
+    await waitToAppear('.panel-body .alert-info');
+    assert.equal(currentURL(), '/inventory/listing');
+    findWithAssert('a:contains(Create a new record?)');
   });
 });
 
 test('Creating a new inventory request', function(assert) {
-  runWithPouchDump('inventory', function() {
-    authenticateUser();
-    visit('/inventory/request/new');
+  runWithPouchDump('inventory', async function() {
+    await authenticateUser();
+    await visit('/inventory/request/new');
+    assert.equal(currentURL(), '/inventory/request/new');
 
-    andThen(function() {
-      assert.equal(currentURL(), '/inventory/request/new');
-    });
-    typeAheadFillIn('.test-inv-item', 'Biogesic - m00001 (1000 available)');
-    fillIn('.test-inv-quantity input', 500);
-    typeAheadFillIn('.test-delivery-location', 'Harare');
-    typeAheadFillIn('.test-delivery-aisle', 'C100');
-    typeAheadFillIn('.test-bill-to', 'Accounts Dept');
-    click('button:contains(Add)');
-    waitToAppear('.modal-dialog');
+    await typeAheadFillIn('.test-inv-item', 'Biogesic - m00001 (1000 available)');
+    await fillIn('.test-inv-quantity input', 500);
+    await typeAheadFillIn('.test-delivery-location', 'Harare');
+    await typeAheadFillIn('.test-delivery-aisle', 'C100');
+    await typeAheadFillIn('.test-bill-to', 'Accounts Dept');
+    await click('button:contains(Add)');
+    await waitToAppear('.modal-dialog');
+    assert.dom('.modal-title').hasText('Request Updated', 'New request has been saved');
 
-    andThen(() => {
-      assert.dom('.modal-title').hasText('Request Updated', 'New request has been saved');
-    });
-    click('button:contains(Ok)');
-    andThen(() => {
-      findWithAssert('button:contains(Fulfill)');
-      findWithAssert('button:contains(Cancel)');
-    });
-    click('button:contains(Cancel)');
-    andThen(() => {
-      assert.equal(currentURL(), '/inventory');
-      assert.dom('tr').exists({ count: 3 }, 'Two requests are now displayed');
-    });
+    await click('button:contains(Ok)');
+    findWithAssert('button:contains(Fulfill)');
+    findWithAssert('button:contains(Cancel)');
+
+    await click('button:contains(Cancel)');
+    assert.equal(currentURL(), '/inventory');
+    assert.dom('tr').exists({ count: 3 }, 'Two requests are now displayed');
   });
 });
 
 test('Fulfilling an inventory request', function(assert) {
-  runWithPouchDump('inventory', function() {
-    authenticateUser();
-    visit('/inventory');
+  runWithPouchDump('inventory', async function() {
+    await authenticateUser();
+    await visit('/inventory');
+    assert.equal(currentURL(), '/inventory');
+    let tableRows = find('tr').length;
+    assert.equal(tableRows, 2, 'One request not fulfilled');
 
-    andThen(function() {
-      assert.equal(currentURL(), '/inventory');
-      let tableRows = find('tr').length;
-      assert.equal(tableRows, 2, 'One request not fulfilled');
-    });
-    click('button:contains(Fulfill)');
+    await click('button:contains(Fulfill)');
+    findWithAssert('button:contains(Fulfill)');
+    findWithAssert('button:contains(Cancel)');
 
-    andThen(() => {
-      findWithAssert('button:contains(Fulfill)');
-      findWithAssert('button:contains(Cancel)');
-    });
-    waitToAppear('.inventory-location option:contains(No Location)');
-    andThen(() => {
-      click('button:contains(Fulfill)');
-      waitToAppear('.modal-dialog');
-    });
-    andThen(() => {
-      let modalTitle = find('.modal-title');
-      assert.equal(modalTitle.text(), 'Request Fulfilled', 'Inventory request has been fulfilled');
-    });
+    await waitToAppear('.inventory-location option:contains(No Location)');
+    await click('button:contains(Fulfill)');
+    await waitToAppear('.modal-dialog');
 
-    click('button:contains(Ok)');
-    andThen(() => {
-      assert.equal(currentURL(), '/inventory');
-    });
+    let modalTitle = find('.modal-title');
+    assert.equal(modalTitle.text(), 'Request Fulfilled', 'Inventory request has been fulfilled');
+
+    await click('button:contains(Ok)');
+    assert.equal(currentURL(), '/inventory');
   });
 });
 
 test('Deleting an inventory request', function(assert) {
-  runWithPouchDump('inventory', function() {
-    authenticateUser();
-    visit('/inventory');
+  runWithPouchDump('inventory', async function() {
+    await authenticateUser();
+    await visit('/inventory');
+    assert.equal(currentURL(), '/inventory', 'Navigated to /inventory');
+    assert.equal(find('button:contains(Delete)').length, 1, 'There is one request');
 
-    andThen(() => {
-      assert.equal(currentURL(), '/inventory', 'Navigated to /inventory');
-      assert.equal(find('button:contains(Delete)').length, 1, 'There is one request');
-    });
+    await click('button:contains(Delete)');
+    await waitToAppear('.modal-dialog');
+    assert.dom('.modal-title').hasText('Delete Item', 'Deleting confirmation');
 
-    click('button:contains(Delete)');
-    waitToAppear('.modal-dialog');
-
-    andThen(() => {
-      assert.dom('.modal-title').hasText('Delete Item', 'Deleting confirmation');
-    });
-
-    click('.modal-content button:contains(Delete)');
-    waitToAppear('.panel-body .alert-info');
-
-    andThen(function() {
-      assert.equal(currentURL(), '/inventory', 'Navigated to /inventory');
-      assert.equal(find('button:contains(Delete)').length, 0, 'Request was deleted');
-    });
+    await click('.modal-content button:contains(Delete)');
+    await waitToAppear('.panel-body .alert-info');
+    assert.equal(currentURL(), '/inventory', 'Navigated to /inventory');
+    assert.equal(find('button:contains(Delete)').length, 0, 'Request was deleted');
   });
 });
 
 test('User with add_inventory_request and without fulfill_inventory rights should not be able to delete others\' requests', function(assert) {
-  runWithPouchDump('inventory', function() {
-    authenticateUser({
+  runWithPouchDump('inventory', async function() {
+    await authenticateUser({
       name: 'nurse.mgr',
       roles: ['Nurse Manager', 'user'],
       role: 'Nurse Manager'
     });
-    visit('/inventory');
+    await visit('/inventory');
 
-    andThen(() => {
-      assert.equal(currentURL(), '/inventory', 'Navigated to /inventory');
-      assert.equal(find('button:contains(Delete)').length, 0, 'User doesn\'t see Delete button');
-    });
+    assert.equal(currentURL(), '/inventory', 'Navigated to /inventory');
+    assert.equal(find('button:contains(Delete)').length, 0, 'User doesn\'t see Delete button');
   });
 });
 
 test('Receiving inventory', function(assert) {
-  runWithPouchDump('inventory', function() {
-    authenticateUser();
-    visit('/inventory/batch/new');
+  runWithPouchDump('inventory', async function() {
+    await authenticateUser();
+    await visit('/inventory/batch/new');
+    assert.equal(currentURL(), '/inventory/batch/new');
 
-    andThen(function() {
-      assert.equal(currentURL(), '/inventory/batch/new');
-    });
-    typeAheadFillIn('.test-vendor', 'Alpha Pharmacy');
-    fillIn('.test-invoice-number input', 'P2345');
-    typeAheadFillIn('.test-inv-item', 'Biogesic - m00001');
-    fillIn('.test-inv-quantity input', 500);
-    fillIn('.test-inv-cost input', '2000');
-    waitToAppear('.inventory-distribution-unit');
-    andThen(() => {
-      click('button:contains(Save)');
-      waitToAppear('.modal-title');
-    });
-    andThen(() => {
-      let modalTitle = find('.modal-title');
-      assert.equal(modalTitle.text(), 'Inventory Purchases Saved', 'Inventory has been received');
-    });
-    click('button:contains(Ok)');
+    await typeAheadFillIn('.test-vendor', 'Alpha Pharmacy');
+    await fillIn('.test-invoice-number input', 'P2345');
+    await typeAheadFillIn('.test-inv-item', 'Biogesic - m00001');
+    await fillIn('.test-inv-quantity input', 500);
+    await fillIn('.test-inv-cost input', '2000');
+    await waitToAppear('.inventory-distribution-unit');
+    await click('button:contains(Save)');
+    await waitToAppear('.modal-title');
 
-    andThen(() => {
-      assert.equal(currentURL(), '/inventory/listing');
-    });
+    let modalTitle = find('.modal-title');
+    assert.equal(modalTitle.text(), 'Inventory Purchases Saved', 'Inventory has been received');
+
+    await click('button:contains(Ok)');
+    assert.equal(currentURL(), '/inventory/listing');
   });
 });
 
 test('Searching inventory', function(assert) {
-  runWithPouchDump('inventory', function() {
-    authenticateUser();
-    visit('/inventory');
+  runWithPouchDump('inventory', async function() {
+    await authenticateUser();
+    await visit('/inventory');
 
-    fillIn('[role="search"] div input', 'Biogesic');
-    click('.glyphicon-search');
-    andThen(() => {
-      assert.equal(currentURL(), '/inventory/search/Biogesic', 'Searched for Biogesic');
-      assert.equal(find('button:contains(Delete)').length, 1, 'There is one search item');
-    });
+    await fillIn('[role="search"] div input', 'Biogesic');
+    await click('.glyphicon-search');
+    assert.equal(currentURL(), '/inventory/search/Biogesic', 'Searched for Biogesic');
+    assert.equal(find('button:contains(Delete)').length, 1, 'There is one search item');
 
-    fillIn('[role="search"] div input', 'biogesic');
-    click('.glyphicon-search');
-    andThen(() => {
-      assert.equal(currentURL(), '/inventory/search/biogesic', 'Searched with all lower case ');
-      assert.equal(find('button:contains(Delete)').length, 1, 'There is one search item');
-    });
+    await fillIn('[role="search"] div input', 'biogesic');
+    await click('.glyphicon-search');
+    assert.equal(currentURL(), '/inventory/search/biogesic', 'Searched with all lower case ');
+    assert.equal(find('button:contains(Delete)').length, 1, 'There is one search item');
 
-    fillIn('[role="search"] div input', 'ItemNotFound');
-    click('.glyphicon-search');
-    andThen(() => {
-      assert.equal(currentURL(), '/inventory/search/ItemNotFound', 'Searched for ItemNotFound');
-      assert.equal(find('button:contains(Delete)').length, 0, 'There is no search result');
-    });
+    await fillIn('[role="search"] div input', 'ItemNotFound');
+    await click('.glyphicon-search');
+    assert.equal(currentURL(), '/inventory/search/ItemNotFound', 'Searched for ItemNotFound');
+    assert.equal(find('button:contains(Delete)').length, 0, 'There is no search result');
   });
 });
 
@@ -324,48 +257,42 @@ testSingleDateReportForm('Inventory Valuation');
 
 function testSimpleReportForm(reportName) {
   test(`${reportName} report can be generated`, function(assert) {
-    runWithPouchDump('default', function() {
-      authenticateUser();
-      visit('/inventory/reports');
-      andThen(function() {
-        assert.equal(currentURL(), '/inventory/reports');
-      });
+    runWithPouchDump('default', async function() {
+      await authenticateUser();
+      await visit('/inventory/reports');
+      assert.equal(currentURL(), '/inventory/reports');
+
       let startDate = moment('2015-10-01');
       let endDate = moment('2015-10-31');
-      selectDate('.test-start-date input', startDate.toDate());
-      selectDate('.test-end-date input', endDate.toDate());
-      select('#report-type', `${reportName}`);
-      click('button:contains(Generate Report)');
-      waitToAppear('.panel-title');
+      await selectDate('.test-start-date input', startDate.toDate());
+      await selectDate('.test-end-date input', endDate.toDate());
+      await select('#report-type', `${reportName}`);
+      await click('button:contains(Generate Report)');
+      await waitToAppear('.panel-title');
 
-      andThen(() => {
-        let reportTitle = `${reportName} Report ${startDate.format('l')} - ${endDate.format('l')}`;
-        assert.dom('.panel-title').hasText(reportTitle, `${reportName} Report generated`);
-        let exportLink = findWithAssert('a:contains(Export Report)');
-        assert.equal($(exportLink).attr('download'), `${reportTitle}.csv`);
-      });
+      let reportTitle = `${reportName} Report ${startDate.format('l')} - ${endDate.format('l')}`;
+      assert.dom('.panel-title').hasText(reportTitle, `${reportName} Report generated`);
+      let exportLink = findWithAssert('a:contains(Export Report)');
+      assert.equal($(exportLink).attr('download'), `${reportTitle}.csv`);
     });
   });
 }
 
 function testSingleDateReportForm(reportName) {
   test(`${reportName} report can be generated`, function(assert) {
-    runWithPouchDump('default', function() {
-      authenticateUser();
-      visit('/inventory/reports');
-      andThen(function() {
-        assert.equal(currentURL(), '/inventory/reports');
-      });
-      select('#report-type', `${reportName}`);
-      click('button:contains(Generate Report)');
-      waitToAppear('.panel-title');
+    runWithPouchDump('default', async function() {
+      await authenticateUser();
+      await visit('/inventory/reports');
+      assert.equal(currentURL(), '/inventory/reports');
 
-      andThen(() => {
-        let reportTitle = `${reportName} Report ${moment().format('l')}`;
-        assert.dom('.panel-title').hasText(reportTitle, `${reportName} Report generated`);
-        let exportLink = findWithAssert('a:contains(Export Report)');
-        assert.equal($(exportLink).attr('download'), `${reportTitle}.csv`);
-      });
+      await select('#report-type', `${reportName}`);
+      await click('button:contains(Generate Report)');
+      await waitToAppear('.panel-title');
+
+      let reportTitle = `${reportName} Report ${moment().format('l')}`;
+      assert.dom('.panel-title').hasText(reportTitle, `${reportName} Report generated`);
+      let exportLink = findWithAssert('a:contains(Export Report)');
+      assert.equal($(exportLink).attr('download'), `${reportTitle}.csv`);
     });
   });
 }

--- a/tests/acceptance/invoices-test.js
+++ b/tests/acceptance/invoices-test.js
@@ -4,233 +4,191 @@ import moduleForAcceptance from 'hospitalrun/tests/helpers/module-for-acceptance
 moduleForAcceptance('Acceptance | invoices');
 
 test('visiting /invoices', function(assert) {
-  runWithPouchDump('billing', function() {
-    authenticateUser();
-    visit('/invoices');
-    andThen(function() {
-      assert.equal(currentURL(), '/invoices');
-    });
+  runWithPouchDump('billing', async function() {
+    await authenticateUser();
+    await visit('/invoices');
+    assert.equal(currentURL(), '/invoices');
   });
 });
 
 test('create invoice', function(assert) {
-  runWithPouchDump('billing', function() {
-    authenticateUser();
-    visit('/invoices/edit/new');
-    andThen(function() {
-      assert.equal(currentURL(), '/invoices/edit/new');
-    });
-    typeAheadFillIn('.invoice-patient', 'Joe Bagadonuts - TCH 00001');
-    waitToAppear('.invoice-visit option:contains((Admission))');
-    andThen(function() {
-      select('.invoice-visit', '(Admission)');
-      fillIn('.external-invoice-no input', 'inv000002');
-    });
-    waitToAppear('button:contains(Update)');
-    andThen(function() {
-      click('button:contains(Update)');
-    });
-    waitToAppear('.modal-dialog');
-    andThen(() => {
-      assert.dom('.modal-title').hasText('Invoice Saved', 'Invoice was saved successfully');
-    });
+  runWithPouchDump('billing', async function() {
+    await authenticateUser();
+    await visit('/invoices/edit/new');
+    assert.equal(currentURL(), '/invoices/edit/new');
+
+    await typeAheadFillIn('.invoice-patient', 'Joe Bagadonuts - TCH 00001');
+    await waitToAppear('.invoice-visit option:contains((Admission))');
+    await select('.invoice-visit', '(Admission)');
+    await fillIn('.external-invoice-no input', 'inv000002');
+    await waitToAppear('button:contains(Update)');
+    await click('button:contains(Update)');
+    await waitToAppear('.modal-dialog');
+    assert.dom('.modal-title').hasText('Invoice Saved', 'Invoice was saved successfully');
   });
 });
 
 test('print invoice', function(assert) {
-  runWithPouchDump('billing', function() {
+  runWithPouchDump('billing', async function() {
     window.print = function() {}; // Disable browser print dialog.
-    authenticateUser();
-    visit('/invoices');
-    andThen(function() {
-      assert.equal(currentURL(), '/invoices');
-      assert.equal(find('.invoice-number:contains(inv00001)').length, 1, 'Invoice is available for printing');
-      click('button:contains(Edit)');
-      waitToAppear('button:contains(Print)');
-    });
-    andThen(function() {
-      click('button:contains(Print)');
-    });
-    andThen(function() {
-      assert.dom('.invoices-review').exists({ count: 1 }, 'Invoice is displayed for printing');
-    });
+    await authenticateUser();
+    await visit('/invoices');
+    assert.equal(currentURL(), '/invoices');
+    assert.equal(find('.invoice-number:contains(inv00001)').length, 1, 'Invoice is available for printing');
+
+    await click('button:contains(Edit)');
+    await waitToAppear('button:contains(Print)');
+    await click('button:contains(Print)');
+    assert.dom('.invoices-review').exists({ count: 1 }, 'Invoice is displayed for printing');
   });
 });
 
 // test pricing profile
 test('pricing profiles', function(assert) {
-  runWithPouchDump('billing', function() {
-    authenticateUser();
-    visit('/pricing/profiles');
-    andThen(function() {
-      assert.equal(find('.btn-primary:contains(+ new item)').length, 1, 'We can add a new pricing profile');
-      click('button:contains(+ new item)');
-      waitToAppear('h4:contains(New Pricing Profile)');
-    });
+  runWithPouchDump('billing', async function() {
+    await authenticateUser();
+    await visit('/pricing/profiles');
+    assert.equal(find('.btn-primary:contains(+ new item)').length, 1, 'We can add a new pricing profile');
+
+    await click('button:contains(+ new item)');
+    await waitToAppear('h4:contains(New Pricing Profile)');
+
     // % discount
-    andThen(function() {
-      fillIn('.pricing-profile-name input', '50% profile');
-      fillIn('.pricing-profile-percentage input', '50');
-      click('button:contains(Add)');
-      waitToAppear('button:contains(Ok)');
-      click('button:contains(Ok)');
-    });
-    andThen(function() {
-      click('button:contains(+ new item)');
-      waitToAppear('h4:contains(New Pricing Profile)');
-    });
+    await fillIn('.pricing-profile-name input', '50% profile');
+    await fillIn('.pricing-profile-percentage input', '50');
+    await click('button:contains(Add)');
+    await waitToAppear('button:contains(Ok)');
+    await click('button:contains(Ok)');
+    await click('button:contains(+ new item)');
+    await waitToAppear('h4:contains(New Pricing Profile)');
+
     // flat discount
-    andThen(function() {
-      fillIn('.pricing-profile-name input', '$100 discount');
-      fillIn('.pricing-profile-discount input', '100');
-      click('button:contains(Add)');
-      waitToAppear('button:contains(Ok)');
-      click('button:contains(Ok)');
-    });
-    andThen(function() {
-      click('button:contains(+ new item)');
-      waitToAppear('h4:contains(New Pricing Profile)');
-    });
+    await fillIn('.pricing-profile-name input', '$100 discount');
+    await fillIn('.pricing-profile-discount input', '100');
+    await click('button:contains(Add)');
+    await waitToAppear('button:contains(Ok)');
+    await click('button:contains(Ok)');
+    await click('button:contains(+ new item)');
+    await waitToAppear('h4:contains(New Pricing Profile)');
+
     // flat fee
-    andThen(function() {
-      fillIn('.pricing-profile-name input', '$150 fee');
-      fillIn('.pricing-set-fee input', '150');
-      click('button:contains(Add)');
-      waitToAppear('button:contains(Ok)');
-      click('button:contains(Ok)');
-    });
-    visit('/invoices');
-    andThen(function() {
-      assert.equal(currentURL(), '/invoices');
-      assert.equal(find('.invoice-number:contains(inv00001)').length, 1, 'Invoice is available for modifying');
-      click('button:contains(Edit)');
-    });
+    await fillIn('.pricing-profile-name input', '$150 fee');
+    await fillIn('.pricing-set-fee input', '150');
+    await click('button:contains(Add)');
+    await waitToAppear('button:contains(Ok)');
+    await click('button:contains(Ok)');
+
+    await visit('/invoices');
+    assert.equal(currentURL(), '/invoices');
+    assert.equal(find('.invoice-number:contains(inv00001)').length, 1, 'Invoice is available for modifying');
+
+    await click('button:contains(Edit)');
   });
 });
 
 test('delete invoice', function(assert) {
-  runWithPouchDump('billing', function() {
-    authenticateUser();
-    visit('/invoices');
-    andThen(function() {
-      assert.equal(currentURL(), '/invoices');
-      assert.equal(find('.invoice-number:contains(inv00001)').length, 1, 'Invoice is displayed for deletion');
-    });
-    click('button:contains(Delete)');
-    andThen(function() {
-      waitToAppear('.modal-dialog');
-    });
-    andThen(() => {
-      assert.dom('.alert').hasText(
-        'Are you sure you wish to delete inv00001?',
-        'Invoice deletion confirm displays'
-      );
-    });
-    click('button:contains(Delete):last');
-    waitToDisappear('.invoice-number:contains(inv00001)');
-    andThen(() => {
-      assert.equal(find('.invoice-number:contains(inv00001)').length, 0, 'Invoice is deleted');
-    });
+  runWithPouchDump('billing', async function() {
+    await authenticateUser();
+    await visit('/invoices');
+    assert.equal(currentURL(), '/invoices');
+    assert.equal(find('.invoice-number:contains(inv00001)').length, 1, 'Invoice is displayed for deletion');
+
+    await click('button:contains(Delete)');
+    await waitToAppear('.modal-dialog');
+    assert.dom('.alert').hasText(
+      'Are you sure you wish to delete inv00001?',
+      'Invoice deletion confirm displays'
+    );
+
+    await click('button:contains(Delete):last');
+    await waitToDisappear('.invoice-number:contains(inv00001)');
+    assert.equal(find('.invoice-number:contains(inv00001)').length, 0, 'Invoice is deleted');
   });
 });
 
 test('add payment', function(assert) {
-  runWithPouchDump('billing', function() {
-    authenticateUser();
-    visit('/invoices');
-    andThen(function() {
-      assert.equal(currentURL(), '/invoices');
-    });
-    click('button:contains(Add Payment)');
-    waitToAppear('.modal-dialog');
-    andThen(function() {
-      assert.dom('.modal-title').hasText('Add Payment', 'Add Payment modal displays');
-    });
-    fillIn('.payment-amount input', 100);
-    click('.update-payment-btn');
-    waitToAppear('.modal-title:contains(Payment Added)');
-    andThen(() => {
-      assert.dom('.modal-title').hasText('Payment Added', 'Payment was saved successfully');
-      click('.modal-footer button:contains(Ok)');
-      waitToDisappear('.modal-dialog');
-    });
+  runWithPouchDump('billing', async function() {
+    await authenticateUser();
+    await visit('/invoices');
+    assert.equal(currentURL(), '/invoices');
+
+    await click('button:contains(Add Payment)');
+    await waitToAppear('.modal-dialog');
+    assert.dom('.modal-title').hasText('Add Payment', 'Add Payment modal displays');
+
+    await fillIn('.payment-amount input', 100);
+    await click('.update-payment-btn');
+    await waitToAppear('.modal-title:contains(Payment Added)');
+    assert.dom('.modal-title').hasText('Payment Added', 'Payment was saved successfully');
+
+    await click('.modal-footer button:contains(Ok)');
+    await waitToDisappear('.modal-dialog');
   });
 });
 
 test('add deposit', function(assert) {
-  runWithPouchDump('billing', function() {
-    authenticateUser();
-    visit('/invoices');
-    andThen(function() {
-      assert.equal(currentURL(), '/invoices');
-    });
-    click('button:contains(add deposit)');
-    waitToAppear('.modal-dialog');
-    andThen(function() {
-      assert.dom('.modal-title').hasText('Add Deposit', 'Add Deposit modal displays');
-    });
-    fillIn('.payment-amount input', 140);
-    typeAheadFillIn('.payment-patient', 'Joe Bagadonuts - TCH 00001');
-    click('.update-payment-btn');
-    waitToAppear('.modal-title:contains(Deposit Added)');
-    andThen(() => {
-      assert.dom('.modal-title').hasText('Deposit Added', 'Deposit was saved successfully');
-    });
+  runWithPouchDump('billing', async function() {
+    await authenticateUser();
+    await visit('/invoices');
+    assert.equal(currentURL(), '/invoices');
+
+    await click('button:contains(add deposit)');
+    await waitToAppear('.modal-dialog');
+    assert.dom('.modal-title').hasText('Add Deposit', 'Add Deposit modal displays');
+
+    await fillIn('.payment-amount input', 140);
+    await typeAheadFillIn('.payment-patient', 'Joe Bagadonuts - TCH 00001');
+    await click('.update-payment-btn');
+    await waitToAppear('.modal-title:contains(Deposit Added)');
+    assert.dom('.modal-title').hasText('Deposit Added', 'Deposit was saved successfully');
   });
 });
 
 test('cashier role', function(assert) {
-  runWithPouchDump('billing', function() {
-    authenticateUser({
+  runWithPouchDump('billing', async function() {
+    await authenticateUser({
       name: 'cashier@hospitalrun.io',
       roles: ['Cashier', 'user'],
       role: 'Cashier',
       prefix: 'p1'
     });
-    visit('/invoices');
-    andThen(function() {
-      assert.equal(currentURL(), '/invoices');
-      assert.dom('.primary-section-link').exists({ count: 2 }, 'Should have 2 navigations');
-      assert.equal(find('.primary-section-link:contains(Scheduling)').length, 1, 'should see Scheduling navigation');
-      assert.equal(find('.primary-section-link:contains(Billing)').length, 1,  'should see Billing navigation');
 
-      assert.equal(find('li:contains(Billed)').length, 1, 'should see Billed selection');
-      assert.equal(find('li:contains(Drafts)').length, 1, 'should see Drafts selection');
-      assert.equal(find('li:contains(All Invoices)').length, 1, 'should see All Invoices selection');
-    });
-    click('a:contains(Billing)');
-    andThen(function() {
-      assert.dom('.category-sub-item').exists({ count: 2 }, 'Should have 2 sub navigations');
-    });
+    await visit('/invoices');
+    assert.equal(currentURL(), '/invoices');
+    assert.dom('.primary-section-link').exists({ count: 2 }, 'Should have 2 navigations');
+    assert.equal(find('.primary-section-link:contains(Scheduling)').length, 1, 'should see Scheduling navigation');
+    assert.equal(find('.primary-section-link:contains(Billing)').length, 1,  'should see Billing navigation');
+
+    assert.equal(find('li:contains(Billed)').length, 1, 'should see Billed selection');
+    assert.equal(find('li:contains(Drafts)').length, 1, 'should see Drafts selection');
+    assert.equal(find('li:contains(All Invoices)').length, 1, 'should see All Invoices selection');
+
+    await click('a:contains(Billing)');
+    assert.dom('.category-sub-item').exists({ count: 2 }, 'Should have 2 sub navigations');
   });
 });
 
 test('Searching invoices', function(assert) {
-  runWithPouchDump('billing', function() {
-    authenticateUser();
-    visit('/invoices');
+  runWithPouchDump('billing', async function() {
+    await authenticateUser();
+    await visit('/invoices');
 
-    fillIn('[role="search"] div input', 'Joe');
-    click('.glyphicon-search');
+    await fillIn('[role="search"] div input', 'Joe');
+    await click('.glyphicon-search');
 
-    andThen(() => {
-      assert.equal(currentURL(), '/invoices/search/Joe', 'Searched for Joe');
-      assert.dom('.invoice-number').exists({ count: 1 }, 'There is one search item');
-    });
+    assert.equal(currentURL(), '/invoices/search/Joe', 'Searched for Joe');
+    assert.dom('.invoice-number').exists({ count: 1 }, 'There is one search item');
 
-    fillIn('[role="search"] div input', 'joe');
-    click('.glyphicon-search');
+    await fillIn('[role="search"] div input', 'joe');
+    await click('.glyphicon-search');
 
-    andThen(() => {
-      assert.equal(currentURL(), '/invoices/search/joe', 'Searched for all lower case joe');
-      assert.dom('.invoice-number').exists({ count: 1 }, 'There is one search item');
-    });
-    fillIn('[role="search"] div input', 'ItemNotFound');
-    click('.glyphicon-search');
+    assert.equal(currentURL(), '/invoices/search/joe', 'Searched for all lower case joe');
+    assert.dom('.invoice-number').exists({ count: 1 }, 'There is one search item');
 
-    andThen(() => {
-      assert.equal(currentURL(), '/invoices/search/ItemNotFound', 'Searched for ItemNotFound');
-      assert.dom('.invoice-number').doesNotExist('There is no search result');
-    });
+    await fillIn('[role="search"] div input', 'ItemNotFound');
+    await click('.glyphicon-search');
+
+    assert.equal(currentURL(), '/invoices/search/ItemNotFound', 'Searched for ItemNotFound');
+    assert.dom('.invoice-number').doesNotExist('There is no search result');
   });
 });

--- a/tests/acceptance/labs-test.js
+++ b/tests/acceptance/labs-test.js
@@ -4,250 +4,201 @@ import moduleForAcceptance from 'hospitalrun/tests/helpers/module-for-acceptance
 moduleForAcceptance('Acceptance | labs');
 
 test('visiting /labs', function(assert) {
-  runWithPouchDump('default', function() {
-    authenticateUser();
-    visit('/labs');
-
-    andThen(function() {
-      assert.equal(currentURL(), '/labs');
-      findWithAssert('a:contains(Create a new record?)');
-      findWithAssert('button:contains(new lab)');
-    });
+  runWithPouchDump('default', async function() {
+    await authenticateUser();
+    await visit('/labs');
+    assert.equal(currentURL(), '/labs');
+    findWithAssert('a:contains(Create a new record?)');
+    findWithAssert('button:contains(new lab)');
   });
 });
 
 test('Adding a new lab request', function(assert) {
-  runWithPouchDump('labs', function() {
-    authenticateUser();
-    visit('/labs');
+  runWithPouchDump('labs', async function() {
+    await authenticateUser();
+    await visit('/labs');
 
-    click('button:contains(new lab)');
+    await click('button:contains(new lab)');
+    assert.equal(currentURL(), '/labs/edit/new');
 
-    andThen(function() {
-      assert.equal(currentURL(), '/labs/edit/new');
-    });
+    await typeAheadFillIn('.test-patient-name', 'Lennex Zinyando - P00017');
+    await typeAheadFillIn('.test-lab-type', 'Chest Scan');
+    await fillIn('.test-result-input input', 'Chest is clear');
+    await fillIn('textarea', 'Dr test ordered another scan');
+    await click('button:contains(Add)');
+    await waitToAppear('.modal-dialog');
+    assert.dom('.modal-title').hasText('Lab Request Saved', 'Lab Request was saved successfully');
+    assert.dom('.patient-summary').exists();
 
-    typeAheadFillIn('.test-patient-name', 'Lennex Zinyando - P00017');
-    typeAheadFillIn('.test-lab-type', 'Chest Scan');
-    fillIn('.test-result-input input', 'Chest is clear');
-    fillIn('textarea', 'Dr test ordered another scan');
-    click('button:contains(Add)');
-    waitToAppear('.modal-dialog');
+    await click('.modal-footer button:contains(Ok)');
+    assert.dom('.patient-summary').exists({ count: 1 }, 'Patient summary is displayed');
 
-    andThen(() => {
-      assert.dom('.modal-title').hasText('Lab Request Saved', 'Lab Request was saved successfully');
-      assert.dom('.patient-summary').exists();
-    });
-
-    click('.modal-footer button:contains(Ok)');
-
-    andThen(() => {
-      assert.dom('.patient-summary').exists({ count: 1 }, 'Patient summary is displayed');
-    });
-
-    click('.panel-footer button:contains(Return)');
-
-    andThen(() => {
-      assert.equal(currentURL(), '/labs');
-      assert.dom('tr').exists({ count: 3 }, 'Two lab requests are displayed');
-    });
+    await click('.panel-footer button:contains(Return)');
+    assert.equal(currentURL(), '/labs');
+    assert.dom('tr').exists({ count: 3 }, 'Two lab requests are displayed');
   });
 });
 
 test('Marking a lab request as completed', function(assert) {
-  runWithPouchDump('labs', function() {
-    authenticateUser();
-    visit('/labs/completed');
+  runWithPouchDump('labs', async function() {
+    await authenticateUser();
+    await visit('/labs/completed');
+    assert.dom('.alert-info').hasText('No completed items found.', 'No completed requests are displayed');
 
-    andThen(() => {
-      assert.dom('.alert-info').hasText('No completed items found.', 'No completed requests are displayed');
-    });
+    await visit('/labs');
+    await click('button:contains(Edit)');
+    await click('button:contains(Complete)');
+    await waitToAppear('.modal-dialog');
+    assert.dom('.modal-title').hasText('Lab Request Completed', 'Lab Request was completed successfully');
 
-    visit('/labs');
-    click('button:contains(Edit)');
-    click('button:contains(Complete)');
-    waitToAppear('.modal-dialog');
-
-    andThen(function() {
-      assert.dom('.modal-title').hasText('Lab Request Completed', 'Lab Request was completed successfully');
-    });
-
-    click('.modal-footer button:contains(Ok)');
-    click('.panel-footer button:contains(Return)');
-    visit('/labs/completed');
-
-    andThen(() => {
-      assert.dom('tr').exists({ count: 2 }, 'One completed request is displayed');
-    });
+    await click('.modal-footer button:contains(Ok)');
+    await click('.panel-footer button:contains(Return)');
+    await visit('/labs/completed');
+    assert.dom('tr').exists({ count: 2 }, 'One completed request is displayed');
   });
 });
 
 test('Lab with always included custom form', function(assert) {
-  runWithPouchDump('labs', function() {
-    authenticateUser();
+  runWithPouchDump('labs', async function() {
+    await authenticateUser();
 
-    createCustomFormForType('Lab', true);
+    await createCustomFormForType('Lab', true);
 
-    visit('/labs');
-    click('button:contains(new lab)');
+    await visit('/labs');
+    await click('button:contains(new lab)');
 
-    checkCustomFormIsDisplayed(assert, 'Test Custom Form for Lab included');
+    await checkCustomFormIsDisplayed(assert, 'Test Custom Form for Lab included');
 
-    andThen(() => {
-      typeAheadFillIn('.test-patient-name', 'Lennex Zinyando - P00017');
-      typeAheadFillIn('.test-lab-type', 'Chest Scan');
-      fillIn('.test-result-input input', 'Chest is clear');
-      fillIn('.js-lab-notes textarea', 'Dr test ordered another scan');
-      fillCustomForm('Test Custom Form for Lab included');
-      click('.panel-footer button:contains(Add)');
-      waitToAppear('.modal-dialog');
-    });
+    await typeAheadFillIn('.test-patient-name', 'Lennex Zinyando - P00017');
+    await typeAheadFillIn('.test-lab-type', 'Chest Scan');
+    await fillIn('.test-result-input input', 'Chest is clear');
+    await fillIn('.js-lab-notes textarea', 'Dr test ordered another scan');
+    await fillCustomForm('Test Custom Form for Lab included');
+    await click('.panel-footer button:contains(Add)');
+    await waitToAppear('.modal-dialog');
 
-    click('.modal-footer button:contains(Ok)');
-    click('.panel-footer button:contains(Return)');
+    await click('.modal-footer button:contains(Ok)');
+    await click('.panel-footer button:contains(Return)');
 
-    andThen(() => {
-      assert.equal(currentURL(), '/labs');
-      assert.dom('tr').exists({ count: 3 }, 'Two lab requests are displayed');
-    });
+    assert.equal(currentURL(), '/labs');
+    assert.dom('tr').exists({ count: 3 }, 'Two lab requests are displayed');
 
-    click('tr:last');
+    await click('tr:last');
+    assert.dom('.test-result-input input').hasValue('Chest is clear', 'There is result');
+    assert.dom('.js-lab-notes textarea').hasValue('Dr test ordered another scan', 'There is note');
 
-    andThen(() => {
-      assert.dom('.test-result-input input').hasValue('Chest is clear', 'There is result');
-      assert.dom('.js-lab-notes textarea').hasValue('Dr test ordered another scan', 'There is note');
-    });
+    await checkCustomFormIsFilled(assert, 'Test Custom Form for Lab included');
 
-    checkCustomFormIsFilled(assert, 'Test Custom Form for Lab included');
+    await click('button:contains(Complete)');
+    await waitToAppear('.modal-dialog');
+    await click('.modal-footer button:contains(Ok)');
+    await click('.panel-footer button:contains(Return)');
+    await visit('/labs/completed');
 
-    click('button:contains(Complete)');
-    waitToAppear('.modal-dialog');
-    click('.modal-footer button:contains(Ok)');
-    click('.panel-footer button:contains(Return)');
-    visit('/labs/completed');
+    assert.dom('tr').exists({ count: 2 }, 'One completed request is displayed');
 
-    andThen(() => {
-      assert.dom('tr').exists({ count: 2 }, 'One completed request is displayed');
-    });
+    await click('tr:last');
 
-    click('tr:last');
-
-    checkCustomFormIsFilledAndReadonly(assert, 'Test Custom Form for Lab included');
+    await checkCustomFormIsFilledAndReadonly(assert, 'Test Custom Form for Lab included');
   });
 });
 
 test('Lab with additional form', function(assert) {
-  runWithPouchDump('labs', function() {
-    authenticateUser();
+  runWithPouchDump('labs', async function() {
+    await authenticateUser();
 
-    createCustomFormForType('Lab');
+    await createCustomFormForType('Lab');
 
-    visit('/labs');
-    click('button:contains(new lab)');
+    await visit('/labs');
+    await click('button:contains(new lab)');
 
-    attachCustomForm('Test Custom Form for Lab NOT included');
-    checkCustomFormIsDisplayed(assert, 'Test Custom Form for Lab NOT included');
+    await attachCustomForm('Test Custom Form for Lab NOT included');
+    await checkCustomFormIsDisplayed(assert, 'Test Custom Form for Lab NOT included');
 
-    andThen(() => {
-      typeAheadFillIn('.test-patient-name', 'Lennex Zinyando - P00017');
-      typeAheadFillIn('.test-lab-type', 'Chest Scan');
-      fillIn('.test-result-input input', 'Chest is clear');
-      fillIn('.js-lab-notes textarea', 'Dr test ordered another scan');
-      fillCustomForm('Test Custom Form for Lab NOT included');
-      click('.panel-footer button:contains(Add)');
-      waitToAppear('.modal-dialog');
-    });
+    await typeAheadFillIn('.test-patient-name', 'Lennex Zinyando - P00017');
+    await typeAheadFillIn('.test-lab-type', 'Chest Scan');
+    await fillIn('.test-result-input input', 'Chest is clear');
+    await fillIn('.js-lab-notes textarea', 'Dr test ordered another scan');
+    await fillCustomForm('Test Custom Form for Lab NOT included');
+    await click('.panel-footer button:contains(Add)');
+    await waitToAppear('.modal-dialog');
 
-    click('.modal-footer button:contains(Ok)');
-    click('.panel-footer button:contains(Return)');
+    await click('.modal-footer button:contains(Ok)');
+    await click('.panel-footer button:contains(Return)');
 
-    andThen(() => {
-      assert.equal(currentURL(), '/labs');
-      assert.dom('tr').exists({ count: 3 }, 'Two lab requests are displayed');
-    });
+    assert.equal(currentURL(), '/labs');
+    assert.dom('tr').exists({ count: 3 }, 'Two lab requests are displayed');
 
-    click('tr:last');
+    await click('tr:last');
 
-    andThen(() => {
-      assert.dom('.test-result-input input').hasValue('Chest is clear', 'There is result');
-      assert.dom('.js-lab-notes textarea').hasValue('Dr test ordered another scan', 'There is note');
-    });
+    assert.dom('.test-result-input input').hasValue('Chest is clear', 'There is result');
+    assert.dom('.js-lab-notes textarea').hasValue('Dr test ordered another scan', 'There is note');
 
-    checkCustomFormIsFilled(assert, 'Test Custom Form for Lab NOT included');
+    await checkCustomFormIsFilled(assert, 'Test Custom Form for Lab NOT included');
 
-    click('button:contains(Complete)');
-    waitToAppear('.modal-dialog');
-    click('.modal-footer button:contains(Ok)');
-    click('.panel-footer button:contains(Return)');
-    visit('/labs/completed');
+    await click('button:contains(Complete)');
+    await waitToAppear('.modal-dialog');
+    await click('.modal-footer button:contains(Ok)');
+    await click('.panel-footer button:contains(Return)');
+    await visit('/labs/completed');
 
-    andThen(() => {
-      assert.dom('tr').exists({ count: 2 }, 'One completed request is displayed');
-    });
+    assert.dom('tr').exists({ count: 2 }, 'One completed request is displayed');
 
-    click('tr:last');
+    await click('tr:last');
 
-    checkCustomFormIsFilledAndReadonly(assert, 'Test Custom Form for Lab NOT included');
+    await checkCustomFormIsFilledAndReadonly(assert, 'Test Custom Form for Lab NOT included');
   });
 });
 
 test('Lab with always included custom form and additional form', function(assert) {
-  runWithPouchDump('labs', function() {
-    authenticateUser();
+  runWithPouchDump('labs', async function() {
+    await authenticateUser();
 
-    createCustomFormForType('Lab', true);
-    createCustomFormForType('Lab', false);
+    await createCustomFormForType('Lab', true);
+    await createCustomFormForType('Lab', false);
 
-    visit('/labs');
-    click('button:contains(new lab)');
+    await visit('/labs');
+    await click('button:contains(new lab)');
 
-    checkCustomFormIsDisplayed(assert, 'Test Custom Form for Lab included');
+    await checkCustomFormIsDisplayed(assert, 'Test Custom Form for Lab included');
 
-    attachCustomForm('Test Custom Form for Lab NOT included');
-    checkCustomFormIsDisplayed(assert, 'Test Custom Form for Lab NOT included');
+    await attachCustomForm('Test Custom Form for Lab NOT included');
+    await checkCustomFormIsDisplayed(assert, 'Test Custom Form for Lab NOT included');
 
-    andThen(() => {
-      typeAheadFillIn('.test-patient-name', 'Lennex Zinyando - P00017');
-      typeAheadFillIn('.test-lab-type', 'Chest Scan');
-      fillIn('.test-result-input input', 'Chest is clear');
-      fillIn('.js-lab-notes textarea', 'Dr test ordered another scan');
-      fillCustomForm('Test Custom Form for Lab included');
-      fillCustomForm('Test Custom Form for Lab NOT included');
-      click('.panel-footer button:contains(Add)');
-      waitToAppear('.modal-dialog');
-    });
+    await typeAheadFillIn('.test-patient-name', 'Lennex Zinyando - P00017');
+    await typeAheadFillIn('.test-lab-type', 'Chest Scan');
+    await fillIn('.test-result-input input', 'Chest is clear');
+    await fillIn('.js-lab-notes textarea', 'Dr test ordered another scan');
+    await fillCustomForm('Test Custom Form for Lab included');
+    await fillCustomForm('Test Custom Form for Lab NOT included');
+    await click('.panel-footer button:contains(Add)');
+    await waitToAppear('.modal-dialog');
 
-    click('.modal-footer button:contains(Ok)');
-    click('.panel-footer button:contains(Return)');
+    await click('.modal-footer button:contains(Ok)');
+    await click('.panel-footer button:contains(Return)');
 
-    andThen(() => {
-      assert.equal(currentURL(), '/labs');
-      assert.dom('tr').exists({ count: 3 }, 'Two lab requests are displayed');
-    });
+    assert.equal(currentURL(), '/labs');
+    assert.dom('tr').exists({ count: 3 }, 'Two lab requests are displayed');
 
-    click('tr:last');
+    await click('tr:last');
 
-    andThen(() => {
-      assert.dom('.test-result-input input').hasValue('Chest is clear', 'There is result');
-      assert.dom('.js-lab-notes textarea').hasValue('Dr test ordered another scan', 'There is note');
-    });
+    assert.dom('.test-result-input input').hasValue('Chest is clear', 'There is result');
+    assert.dom('.js-lab-notes textarea').hasValue('Dr test ordered another scan', 'There is note');
 
-    checkCustomFormIsFilled(assert, 'Test Custom Form for Lab included');
-    checkCustomFormIsFilled(assert, 'Test Custom Form for Lab NOT included');
+    await checkCustomFormIsFilled(assert, 'Test Custom Form for Lab included');
+    await checkCustomFormIsFilled(assert, 'Test Custom Form for Lab NOT included');
 
-    click('button:contains(Complete)');
-    waitToAppear('.modal-dialog');
-    click('.modal-footer button:contains(Ok)');
-    click('.panel-footer button:contains(Return)');
-    visit('/labs/completed');
+    await click('button:contains(Complete)');
+    await waitToAppear('.modal-dialog');
+    await click('.modal-footer button:contains(Ok)');
+    await click('.panel-footer button:contains(Return)');
+    await visit('/labs/completed');
 
-    andThen(() => {
-      assert.dom('tr').exists({ count: 2 }, 'One completed request is displayed');
-    });
+    assert.dom('tr').exists({ count: 2 }, 'One completed request is displayed');
 
-    click('tr:last');
+    await click('tr:last');
 
-    checkCustomFormIsFilledAndReadonly(assert, 'Test Custom Form for Lab included');
-    checkCustomFormIsFilledAndReadonly(assert, 'Test Custom Form for Lab NOT included');
+    await checkCustomFormIsFilledAndReadonly(assert, 'Test Custom Form for Lab included');
+    await checkCustomFormIsFilledAndReadonly(assert, 'Test Custom Form for Lab NOT included');
   });
 });

--- a/tests/acceptance/language-select-test.js
+++ b/tests/acceptance/language-select-test.js
@@ -8,122 +8,69 @@ import german from 'hospitalrun/locales/de/translations';
 moduleForAcceptance('Acceptance | language dropdown');
 
 test('setting a language preference persists after logout', (assert) => {
-  runWithPouchDump('default', () => {
-    addOfflineUsersForElectron();
+  runWithPouchDump('default', async function() {
+    await addOfflineUsersForElectron();
 
-    andThen(() => {
-      authenticateUser();
-      visit('/');
-    });
+    await authenticateUser();
+    await visit('/');
+    assert.dom('.view-current-title').hasText(english.dashboard.title, 'Title is in English after first log in');
 
-    andThen(() => {
-      assert.dom('.view-current-title').hasText(english.dashboard.title, 'Title is in English after first log in');
-    });
+    await click('a.settings-trigger');
+    await waitToAppear('.settings-nav');
+    await select('.language-select', 'Français');
+    assert.dom('.view-current-title').hasText(french.dashboard.title, 'Title is in French after language change');
 
-    andThen(() => {
-      click('a.settings-trigger');
-      waitToAppear('.settings-nav');
-      select('.language-select', 'Français');
-    });
+    await invalidateSession();
+    await visit('/login');
 
-    andThen(() => {
-      assert.dom('.view-current-title').hasText(french.dashboard.title, 'Title is in French after language change');
-    });
-
-    andThen(() => {
-      invalidateSession();
-      visit('/login');
-    });
-
-    andThen(() => {
-      authenticateUser();
-      visit('/');
-    });
-
-    andThen(() => {
-      assert.dom('.view-current-title').hasText(french.dashboard.title, 'Title is in French after 2nd login');
-    });
+    await authenticateUser();
+    await visit('/');
+    assert.dom('.view-current-title').hasText(french.dashboard.title, 'Title is in French after 2nd login');
   });
 });
 
 test('different users can have different language preferences on the same browser', (assert) => {
-  runWithPouchDump('default', () => {
-    addOfflineUsersForElectron();
+  runWithPouchDump('default', async function() {
+    await addOfflineUsersForElectron();
 
-    andThen(() => {
-      authenticateUser();
-      visit('/');
-    });
+    await authenticateUser();
+    await visit('/');
+    assert.dom('.view-current-title').hasText(english.dashboard.title, 'Title is in English after first log in');
 
-    andThen(() => {
-      assert.dom('.view-current-title').hasText(english.dashboard.title, 'Title is in English after first log in');
-    });
+    await click('a.settings-trigger');
+    await waitToAppear('.settings-nav');
+    await select('.language-select', 'Français');
+    assert.dom('.view-current-title').hasText(french.dashboard.title, 'Title is in French after language change');
 
-    andThen(() => {
-      click('a.settings-trigger');
-      waitToAppear('.settings-nav');
-      select('.language-select', 'Français');
-    });
+    await invalidateSession();
+    await visit('/login');
 
-    andThen(() => {
-      assert.dom('.view-current-title').hasText(french.dashboard.title, 'Title is in French after language change');
+    await authenticateUser({
+      name: 'doctor@hospitalrun.io'
     });
+    await visit('/');
+    assert.dom('.view-current-title').hasText(english.dashboard.title, 'Title is in English for another user');
 
-    andThen(() => {
-      invalidateSession();
-      visit('/login');
-    });
+    await click('a.settings-trigger');
+    await waitToAppear('.settings-nav');
+    await select('.language-select', 'Deutsch');
+    assert.dom('.view-current-title').hasText(german.dashboard.title, 'Title is in German after language change');
 
-    andThen(() => {
-      authenticateUser({
-        name: 'doctor@hospitalrun.io'
-      });
-      visit('/');
-    });
+    await invalidateSession();
+    await visit('/login');
 
-    andThen(() => {
-      assert.dom('.view-current-title').hasText(english.dashboard.title, 'Title is in English for another user');
-    });
+    await authenticateUser();
+    await visit('/');
+    assert.dom('.view-current-title').hasText(french.dashboard.title, 'Title is in French after 2nd login');
 
-    andThen(() => {
-      click('a.settings-trigger');
-      waitToAppear('.settings-nav');
-      select('.language-select', 'Deutsch');
-    });
+    await invalidateSession();
+    await visit('/login');
 
-    andThen(() => {
-      assert.dom('.view-current-title').hasText(german.dashboard.title, 'Title is in German after language change');
+    await authenticateUser({
+      name: 'doctor@hospitalrun.io'
     });
-
-    andThen(() => {
-      invalidateSession();
-      visit('/login');
-    });
-
-    andThen(() => {
-      authenticateUser();
-      visit('/');
-    });
-
-    andThen(() => {
-      assert.dom('.view-current-title').hasText(french.dashboard.title, 'Title is in French after 2nd login');
-    });
-
-    andThen(() => {
-      invalidateSession();
-      visit('/login');
-    });
-
-    andThen(() => {
-      authenticateUser({
-        name: 'doctor@hospitalrun.io'
-      });
-      visit('/');
-    });
-
-    andThen(() => {
-      assert.dom('.view-current-title').hasText(german.dashboard.title, 'Title is in German after 2nd login');
-    });
+    await visit('/');
+    assert.dom('.view-current-title').hasText(german.dashboard.title, 'Title is in German after 2nd login');
   });
 });
 

--- a/tests/acceptance/login-test.js
+++ b/tests/acceptance/login-test.js
@@ -17,13 +17,9 @@ module('Acceptance | login', {
 
 test('visiting / redirects user to login', function(assert) {
   assert.expect(1);
-  runWithPouchDump('default', function() {
-    visit('/');
-
-    andThen(function() {
-      assert.equal(currentURL(), '/login');
-    });
-
+  runWithPouchDump('default', async function() {
+    await visit('/');
+    assert.equal(currentURL(), '/login');
   });
 });
 
@@ -38,8 +34,8 @@ test('incorrect credentials shows an error message on the screen', function(asse
   if (!window.ELECTRON) {
     assert.expect(2);
   }
-  runWithPouchDump('default', function() {
-    visit('/');
+  runWithPouchDump('default', async function() {
+    await visit('/');
 
     let errorMessage = 'Username or password is incorrect.';
 
@@ -48,15 +44,12 @@ test('incorrect credentials shows an error message on the screen', function(asse
       request.error({ 'error': 'unauthorized', 'reason': errorMessage });
     });
 
-    fillIn('#identification', 'hradmin');
-    fillIn('#password', 'tset');
-    click('button:contains(Sign in)');
-    waitToAppear('.form-signin-alert');
+    await fillIn('#identification', 'hradmin');
+    await fillIn('#password', 'tset');
+    await click('button:contains(Sign in)');
+    await waitToAppear('.form-signin-alert');
 
-    andThen(function() {
-      assert.dom('.form-signin-alert').hasText(errorMessage, 'Error reason is shown');
-    });
-
+    assert.dom('.form-signin-alert').hasText(errorMessage, 'Error reason is shown');
   });
 });
 
@@ -64,23 +57,19 @@ function login(assert, spaceAroundUsername) {
   if (!window.ELECTRON) {
     assert.expect(2);
   }
-  runWithPouchDump('default', function() {
-    visit('/login');
+  runWithPouchDump('default', async function() {
+    await visit('/login');
 
     stubRequest('post', '/auth/login', function(request) {
       assert.equal(request.requestBody, 'name=hradmin&password=test', !spaceAroundUsername ? 'credential are sent to the server' : 'username trimmed and credential are sent to the server');
       request.ok({ 'ok': true, 'name': 'hradmin', 'roles': ['System Administrator', 'admin', 'user'] });
     });
 
-    andThen(function() {
-      assert.equal(currentURL(), '/login');
-    });
+    assert.equal(currentURL(), '/login');
 
-    fillIn('#identification', !spaceAroundUsername ? 'hradmin' : ' hradmin');
-    fillIn('#password', 'test');
-    click('button:contains(Sign in)');
-    andThen(() => {
-      waitToAppear('.sidebar-nav-logo');
-    });
+    await fillIn('#identification', !spaceAroundUsername ? 'hradmin' : ' hradmin');
+    await fillIn('#password', 'test');
+    await click('button:contains(Sign in)');
+    await waitToAppear('.sidebar-nav-logo');
   });
 }

--- a/tests/acceptance/medication-test.js
+++ b/tests/acceptance/medication-test.js
@@ -4,188 +4,137 @@ import moduleForAcceptance from 'hospitalrun/tests/helpers/module-for-acceptance
 moduleForAcceptance('Acceptance | medication');
 
 test('visiting /medication', function(assert) {
-  runWithPouchDump('default', function() {
-    authenticateUser();
-    visit('/medication');
+  runWithPouchDump('default', async function() {
+    await authenticateUser();
+    await visit('/medication');
 
-    andThen(function() {
-      assert.equal(currentURL(), '/medication');
-      findWithAssert('button:contains(new request)');
-      findWithAssert('button:contains(dispense medication)');
-      findWithAssert('button:contains(return medication)');
-      findWithAssert('p:contains(No items found. )');
-      findWithAssert('a:contains(Create a new medication request?)');
-    });
+    assert.equal(currentURL(), '/medication');
+    findWithAssert('button:contains(new request)');
+    findWithAssert('button:contains(dispense medication)');
+    findWithAssert('button:contains(return medication)');
+    findWithAssert('p:contains(No items found. )');
+    findWithAssert('a:contains(Create a new medication request?)');
   });
 });
 
 test('creating a new medication request', function(assert) {
-  runWithPouchDump('medication', function() {
-    authenticateUser();
-    visit('/medication/edit/new');
+  runWithPouchDump('medication', async function() {
+    await authenticateUser();
+    await visit('/medication/edit/new');
+    assert.equal(currentURL(), '/medication/edit/new');
 
-    andThen(function() {
-      assert.equal(currentURL(), '/medication/edit/new');
-    });
-    typeAheadFillIn('.test-patient-input', 'Lennex Zinyando - P00017');
-    waitToAppear('.have-inventory-items');
-    andThen(() => {
-      typeAheadFillIn('.test-medication-input', 'Biogesic - m00001 (950 available)');
-    });
-    andThen(() => {
-      fillIn('textarea', '30 Biogesic Pills');
-      fillIn('.test-quantity-input input', '30');
-    });
-    waitToDisappear('.disabled-btn:contains(Add)');
-    andThen(() =>{
-      click('button:contains(Add)');
-      waitToAppear('.modal-dialog');
-    });
-    andThen(() => {
-      assert.dom('.modal-title').hasText('Medication Request Saved', 'New medication request has been saved');
-    });
+    await typeAheadFillIn('.test-patient-input', 'Lennex Zinyando - P00017');
+    await waitToAppear('.have-inventory-items');
+    await typeAheadFillIn('.test-medication-input', 'Biogesic - m00001 (950 available)');
+    await fillIn('textarea', '30 Biogesic Pills');
+    await fillIn('.test-quantity-input input', '30');
+    await waitToDisappear('.disabled-btn:contains(Add)');
+    await click('button:contains(Add)');
+    await waitToAppear('.modal-dialog');
+    assert.dom('.modal-title').hasText('Medication Request Saved', 'New medication request has been saved');
 
-    click('button:contains(Ok)');
-    click('button:contains(Return)');
-    andThen(() => {
-      assert.equal(currentURL(), '/medication');
-      assert.dom('tr').exists({ count: 3 }, 'New medication request is now displayed');
-    });
+    await click('button:contains(Ok)');
+    await click('button:contains(Return)');
+    assert.equal(currentURL(), '/medication');
+    assert.dom('tr').exists({ count: 3 }, 'New medication request is now displayed');
   });
 });
 
 test('fulfilling a medication request', function(assert) {
-  runWithPouchDump('medication', function() {
-    authenticateUser();
-    visit('/medication');
-    click('button:contains(Fulfill)');
+  runWithPouchDump('medication', async function() {
+    await authenticateUser();
+    await visit('/medication');
+    await click('button:contains(Fulfill)');
+    assert.dom('.patient-summary').exists({ count: 1 }, 'Patient summary is displayed');
 
-    andThen(function() {
-      assert.dom('.patient-summary').exists({ count: 1 }, 'Patient summary is displayed');
-    });
-    waitToAppear('.inventory-location option:contains(No Location)');
-    andThen(() => {
-      click('button:contains(Fulfill)');
-      waitToAppear('.modal-dialog');
-    });
-    andThen(() => {
-      assert.dom('.modal-title').hasText('Medication Request Fulfilled', 'Medication Request has been Fulfilled');
-    });
+    await waitToAppear('.inventory-location option:contains(No Location)');
+    await click('button:contains(Fulfill)');
+    await waitToAppear('.modal-dialog');
+    assert.dom('.modal-title').hasText('Medication Request Fulfilled', 'Medication Request has been Fulfilled');
 
-    click('button:contains(Ok)');
-    click('button:contains(Return)');
+    await click('button:contains(Ok)');
+    await click('button:contains(Return)');
 
-    andThen(() => {
-      assert.equal(currentURL(), '/medication');
-      findWithAssert('p:contains(No items found. )');
-      findWithAssert('a:contains(Create a new medication request?)');
-    });
+    assert.equal(currentURL(), '/medication');
+    findWithAssert('p:contains(No items found. )');
+    findWithAssert('a:contains(Create a new medication request?)');
   });
 });
 
 test('complete a medication request', function(assert) {
-  runWithPouchDump('medication', function() {
-    authenticateUser();
-    visit('/medication/completed');
+  runWithPouchDump('medication', async function() {
+    await authenticateUser();
+    await visit('/medication/completed');
     assert.dom('.clickable').doesNotExist('Should have 0 completed request');
-    visit('/medication');
-    click('button:contains(Fulfill)');
 
-    andThen(function() {
-      assert.dom('.patient-summary').exists({ count: 1 }, 'Patient summary is displayed');
-    });
-    waitToAppear('.inventory-location option:contains(No Location)');
-    andThen(() => {
-      click('button:contains(Fulfill)');
-      waitToAppear('.modal-dialog');
-    });
-    andThen(() => {
-      assert.dom('.modal-title').hasText('Medication Request Fulfilled', 'Medication Request has been Fulfilled');
-    });
+    await visit('/medication');
+    await click('button:contains(Fulfill)');
+    assert.dom('.patient-summary').exists({ count: 1 }, 'Patient summary is displayed');
 
-    click('button:contains(Ok)');
-    visit('/medication/completed');
-    andThen(() => {
-      assert.equal(currentURL(), '/medication/completed');
-      assert.dom('.clickable').exists({ count: 1 }, 'Should have 1 completed request');
-    });
+    await waitToAppear('.inventory-location option:contains(No Location)');
+    await click('button:contains(Fulfill)');
+    await waitToAppear('.modal-dialog');
+    assert.dom('.modal-title').hasText('Medication Request Fulfilled', 'Medication Request has been Fulfilled');
+
+    await click('button:contains(Ok)');
+    await visit('/medication/completed');
+    assert.equal(currentURL(), '/medication/completed');
+    assert.dom('.clickable').exists({ count: 1 }, 'Should have 1 completed request');
   });
 });
 
 test('returning medication', function(assert) {
-  runWithPouchDump('medication', function() {
-    authenticateUser();
-    visit('/medication/return/new');
+  runWithPouchDump('medication', async function() {
+    await authenticateUser();
+    await visit('/medication/return/new');
+    assert.equal(currentURL(), '/medication/return/new');
 
-    andThen(function() {
-      assert.equal(currentURL(), '/medication/return/new');
-    });
-    waitToAppear('.have-inventory-items');
-    andThen(() => {
-      typeAheadFillIn('.test-medication-input', 'Biogesic - m00001');
-    });
-    andThen(() => {
-      fillIn('.test-medication-quantity input', 30);
-      waitToDisappear('.disabled-btn:contains(Return Medication)');
-    });
-    andThen(() => {
-      click('button:contains(Return Medication)');
-      waitToAppear('.modal-dialog');
-    });
-    andThen(() => {
-      assert.dom('.modal-title').hasText('Medication Returned', 'Medication has been return successfully');
-    });
-    click('button:contains(Ok)');
+    await waitToAppear('.have-inventory-items');
+    await typeAheadFillIn('.test-medication-input', 'Biogesic - m00001');
+    await fillIn('.test-medication-quantity input', 30);
+    await waitToDisappear('.disabled-btn:contains(Return Medication)');
+    await click('button:contains(Return Medication)');
+    await waitToAppear('.modal-dialog');
+    assert.dom('.modal-title').hasText('Medication Returned', 'Medication has been return successfully');
 
-    andThen(() => {
-      assert.equal(currentURL(), '/medication');
-    });
+    await click('button:contains(Ok)');
+    assert.equal(currentURL(), '/medication');
   });
 });
 
 test('Searching medications', function(assert) {
-  runWithPouchDump('medication', function() {
-    authenticateUser();
-    visit('/medication');
+  runWithPouchDump('medication', async function() {
+    await authenticateUser();
+    await visit('/medication');
 
-    fillIn('[role="search"] div input', 'Biogesic');
-    click('.glyphicon-search');
+    await fillIn('[role="search"] div input', 'Biogesic');
+    await click('.glyphicon-search');
 
-    andThen(() => {
-      assert.equal(currentURL(), '/medication/search/Biogesic', 'Searched for Medication Title: Biogesic');
-      assert.dom('.clickable').exists({ count: 1 }, 'There is one search item');
-    });
+    assert.equal(currentURL(), '/medication/search/Biogesic', 'Searched for Medication Title: Biogesic');
+    assert.dom('.clickable').exists({ count: 1 }, 'There is one search item');
 
-    fillIn('[role="search"] div input', 'gesic');
-    click('.glyphicon-search');
+    await fillIn('[role="search"] div input', 'gesic');
+    await click('.glyphicon-search');
 
-    andThen(() => {
-      assert.equal(currentURL(), '/medication/search/gesic', 'Searched for all lower case gesic');
-      assert.dom('.clickable').exists({ count: 1 }, 'There is one search item');
-    });
+    assert.equal(currentURL(), '/medication/search/gesic', 'Searched for all lower case gesic');
+    assert.dom('.clickable').exists({ count: 1 }, 'There is one search item');
 
-    fillIn('[role="search"] div input', 'hradmin');
-    click('.glyphicon-search');
+    await fillIn('[role="search"] div input', 'hradmin');
+    await click('.glyphicon-search');
 
-    andThen(() => {
-      assert.equal(currentURL(), '/medication/search/hradmin', 'Searched for Prescriber: hradmin');
-      assert.notEqual(find('.clickable').length, 0, 'There are one or more search item');
-    });
+    assert.equal(currentURL(), '/medication/search/hradmin', 'Searched for Prescriber: hradmin');
+    assert.notEqual(find('.clickable').length, 0, 'There are one or more search item');
 
-    fillIn('[role="search"] div input', '60 Biogesic Pills');
-    click('.glyphicon-search');
+    await fillIn('[role="search"] div input', '60 Biogesic Pills');
+    await click('.glyphicon-search');
 
-    andThen(() => {
-      assert.equal(currentURL(), '/medication/search/60%20Biogesic%20Pills', 'Searched for Prescription: 60 Biogesic Pills');
-      assert.dom('.clickable').exists({ count: 1 }, 'There is one search item');
-    });
+    assert.equal(currentURL(), '/medication/search/60%20Biogesic%20Pills', 'Searched for Prescription: 60 Biogesic Pills');
+    assert.dom('.clickable').exists({ count: 1 }, 'There is one search item');
 
-    fillIn('[role="search"] div input', 'ItemNotFound');
-    click('.glyphicon-search');
+    await fillIn('[role="search"] div input', 'ItemNotFound');
+    await click('.glyphicon-search');
 
-    andThen(() => {
-      assert.equal(currentURL(), '/medication/search/ItemNotFound', 'Searched for ItemNotFound');
-      assert.dom('.clickable').doesNotExist('There is no search result');
-    });
+    assert.equal(currentURL(), '/medication/search/ItemNotFound', 'Searched for ItemNotFound');
+    assert.dom('.clickable').doesNotExist('There is no search result');
   });
 });

--- a/tests/acceptance/navigation-test.js
+++ b/tests/acceptance/navigation-test.js
@@ -16,54 +16,43 @@ module('Acceptance | navigation', {
 });
 
 test('about dialog', function(assert) {
-  runWithPouchDump('default', function() {
-    authenticateUser();
-    visit('/');
+  runWithPouchDump('default', async function() {
+    await authenticateUser();
+    await visit('/');
 
     stubRequest('get', '/serverinfo', function(request) {
       request.ok({ 'ok': true });
     });
 
-    click('.settings-trigger');
-    waitToAppear('a:contains(About HospitalRun)');
-    click('a:contains(About HospitalRun)');
+    await click('.settings-trigger');
+    await waitToAppear('a:contains(About HospitalRun)');
+    await click('a:contains(About HospitalRun)');
 
-    waitToAppear('.modal-dialog');
-
-    andThen(() => {
-      assert.dom('.modal-title').hasText('About HospitalRun', 'About dialog is shown');
-    });
+    await waitToAppear('.modal-dialog');
+    assert.dom('.modal-title').hasText('About HospitalRun', 'About dialog is shown');
   });
 });
 
 test('search text clears after search', function(assert) {
-  runWithPouchDump('default', function() {
-    authenticateUser();
-    visit('/patients');
+  runWithPouchDump('default', async function() {
+    await authenticateUser();
+    await visit('/patients');
 
-    andThen(() => {
-      fillIn('.sidebar-nav-search div input', 'fakeSearchText');
-      click('.glyphicon-search');
-      waitToAppear('h1:contains(Search Results)');
-    });
-    andThen(() => {
-      assert.dom('.sidebar-nav-search div input').hasValue('');
-    });
+    await fillIn('.sidebar-nav-search div input', 'fakeSearchText');
+    await click('.glyphicon-search');
+    await waitToAppear('h1:contains(Search Results)');
+    assert.dom('.sidebar-nav-search div input').hasValue('');
   });
 });
 
 test('search text clears after selecting new nav item', function(assert) {
-  runWithPouchDump('default', function() {
-    authenticateUser();
-    visit('/patients');
+  runWithPouchDump('default', async function() {
+    await authenticateUser();
+    await visit('/patients');
 
-    andThen(() => {
-      fillIn('.sidebar-nav-search div input', 'fakeSearchText');
-      click('a:contains(Inventory)');
-      waitToAppear('h1:contains(Requests)');
-    });
-    andThen(() => {
-      assert.dom('.sidebar-nav-search div input').hasValue('');
-    });
+    await fillIn('.sidebar-nav-search div input', 'fakeSearchText');
+    await click('a:contains(Inventory)');
+    await waitToAppear('h1:contains(Requests)');
+    assert.dom('.sidebar-nav-search div input').hasValue('');
   });
 });

--- a/tests/acceptance/operative-test.js
+++ b/tests/acceptance/operative-test.js
@@ -11,112 +11,87 @@ const PROCEDURE_HIP = 'hip adductor release';
 moduleForAcceptance('Acceptance | Operative Plan and Operation Report');
 
 test('Plan and report creation', function(assert) {
-  runWithPouchDump('operative', function() {
-    authenticateUser();
-    visit('/patients');
-    andThen(() => {
-      assert.equal(currentURL(), '/patients', 'Patients listing url is correct');
-      click('button:contains(Edit)');
-    });
-    andThen(() => {
-      assert.equal(currentURL(), '/patients/edit/cd572865-dcc0-441e-a2ad-be400dc256da', 'Patient edit URL is correct');
-      assert.equal(find('a.primary-diagnosis:contains(Broken Arm)').length, 1, 'Primary diagnosis appears');
-      assert.equal(find('a.secondary-diagnosis:contains(Tennis Elbow)').length, 1, 'Secondary diagnosis appears');
-      click('a:contains(Add Operative Plan)');
-      waitToAppear('span.secondary-diagnosis:contains(Tennis Elbow)');
-    });
-    andThen(() => {
-      assert.equal(currentURL(), '/patients/operative-plan/new?forPatientId=cd572865-dcc0-441e-a2ad-be400dc256da', 'New operative plan URL is correct');
-      assert.dom('.patient-name .ps-info-data').hasText('Joe Bagadonuts', 'Joe Bagadonuts patient header displays');
-      assert.dom('.view-current-title').hasText('New Operative Plan', 'New operative plan title is correct');
-      assert.equal(find('span.primary-diagnosis:contains(Broken Arm)').length, 1, 'Primary diagnosis appears as read only');
-      assert.equal(find('span.secondary-diagnosis:contains(Tennis Elbow)').length, 1, 'Secondary diagnosis appears as read only');
-      fillIn('.operation-description textarea', OPERATION_DESCRIPTION);
-      typeAheadFillIn('.procedure-description', PROCEDURE_HIP);
-    });
-    andThen(() => {
-      click('button:contains(Add Procedure)');
-      waitToAppear('.procedure-listing td.procedure-description');
-    });
-    andThen(() => {
-      assert.dom('.procedure-listing td.procedure-description').hasText(PROCEDURE_HIP, 'Added procedure displays in procedure table');
-      typeAheadFillIn('.procedure-description', 'Delete Me');
-    });
-    andThen(() => {
-      click('button:contains(Add Procedure)');
-      waitToAppear('.procedure-listing td.procedure-description:contains(Delete Me)');
-    });
-    andThen(() => {
-      findWithAssert('.procedure-listing td.procedure-description:contains(Delete Me)');
-      click('.procedure-listing tr:last button:contains(Delete)');
-    });
-    andThen(() => {
-      assert.equal(find('.procedure-listing td.procedure-description:contains(Delete Me)').length, 0, 'Procedure is properly deleted');
-      typeAheadFillIn('.procedure-description', PROCEDURE_FIX_ARM); // Leave typeahead filled in with value to automatically add on save.
-      typeAheadFillIn('.plan-surgeon', OPERATION_SURGEON);
-      assert.dom('.plan-status select').hasValue('planned', 'Plan status is set to planned');
-      fillIn('.case-complexity input', CASE_COMPLEXITY);
-      fillIn('.admission-instructions textarea', 'Get blood tests done on admission.');
-      fillIn('.additional-notes textarea', ADDITIONAL_NOTES);
-    });
-    andThen(() => {
-      click('.panel-footer button:contains(Add)');
-      waitToAppear('.modal-dialog');
-    });
-    andThen(() => {
-      assert.dom('.modal-title').hasText('Plan Saved', 'Plan saved modal displays');
-      click('.modal-footer button:contains(Ok)');
-    });
-    andThen(() => {
-      assert.equal(find('.view-current-title').text(), 'Edit Operative Plan', 'Edit operative plan title is correct');
-      assert.equal(find(`.procedure-listing td.procedure-description:contains(${PROCEDURE_FIX_ARM})`).length, 1, 'Procedure from typeahead gets added to procedure list on save');
-      click('button:contains(Return)');
-    });
-    andThen(() => {
-      assert.equal(currentURL(), '/patients/edit/cd572865-dcc0-441e-a2ad-be400dc256da', 'Return goes back to patient screen');
-      assert.equal(find('a:contains(Current Operative Plan)').length, 1, 'Link to newly created plan appears');
-      click('a:contains(Current Operative Plan)');
-    });
-    andThen(() => {
-      assert.dom('.view-current-title').hasText('Edit Operative Plan', 'Edit operative plan title is correct');
-      assert.equal(find('button:contains(Complete Plan)').length, 1, 'Complete Plan button appears');
-      click('button:contains(Complete Plan)');
-      waitToAppear('.modal-dialog');
-    });
-    andThen(() => {
-      assert.dom('.modal-title').hasText('Plan Completed', 'Plan completed modal displays');
-      click('.modal-footer button:contains(Ok)');
-    });
-    andThen(() => {
-      assert.dom('.view-current-title').hasText('Edit Operation Report', 'Edit Operation Report title is correct');
-      assert.dom('.patient-name .ps-info-data').hasText('Joe Bagadonuts', 'Joe Bagadonuts patient header displays');
-      assert.equal(find('a.primary-diagnosis:contains(Broken Arm)').length, 1, 'Primary diagnosis appears as editable');
-      assert.equal(find('a.secondary-diagnosis:contains(Tennis Elbow)').length, 1, 'Secondary diagnosis appears as  editable');
-      assert.equal(find('.operation-description textarea').val(), OPERATION_DESCRIPTION, 'Operation description is copied from operative plan');
-      assert.equal(find('.operation-surgeon .tt-input').val(), OPERATION_SURGEON, 'Surgeon is copied from operative plan');
-      assert.equal(find('.case-complexity input').val(), CASE_COMPLEXITY, 'Case complexity is copied from operative plan');
-      assert.equal(find(`.procedure-listing td.procedure-description:contains(${PROCEDURE_HIP})`).length, 1, `Procedure ${PROCEDURE_HIP} is copied from operative plan`);
-      assert.equal(find(`.procedure-listing td.procedure-description:contains(${PROCEDURE_FIX_ARM})`).length, 1, `Procedure ${PROCEDURE_FIX_ARM} is copied from operative plan`);
-      typeAheadFillIn('.operation-assistant', 'Dr Cindy');
-    });
-    andThen(() => {
-      click('.panel-footer button:contains(Update)');
-      waitToAppear('.modal-dialog');
-    });
-    andThen(() => {
-      assert.dom('.modal-title').hasText('Report Saved', 'Report Saved modal displays');
-      click('.modal-footer button:contains(Ok)');
-    });
-    andThen(() => {
-      click('button:contains(Return)');
-    });
-    andThen(() => {
-      assert.equal(currentURL(), '/patients/edit/cd572865-dcc0-441e-a2ad-be400dc256da', 'Patient edit URL is correct');
-      assert.equal(find('a.patient-procedure:contains(fix broken arm)').length, 1, 'Procedure/operative report shows on patient header');
-      click('a.patient-procedure:contains(fix broken arm)');
-    });
-    andThen(() => {
-      assert.dom('.view-current-title').hasText('Edit Operation Report', 'Operation Report appears for editing');
-    });
+  runWithPouchDump('operative', async function() {
+    await authenticateUser();
+    await visit('/patients');
+    assert.equal(currentURL(), '/patients', 'Patients listing url is correct');
+
+    await click('button:contains(Edit)');
+    assert.equal(currentURL(), '/patients/edit/cd572865-dcc0-441e-a2ad-be400dc256da', 'Patient edit URL is correct');
+    assert.equal(find('a.primary-diagnosis:contains(Broken Arm)').length, 1, 'Primary diagnosis appears');
+    assert.equal(find('a.secondary-diagnosis:contains(Tennis Elbow)').length, 1, 'Secondary diagnosis appears');
+
+    await click('a:contains(Add Operative Plan)');
+    await waitToAppear('span.secondary-diagnosis:contains(Tennis Elbow)');
+    assert.equal(currentURL(), '/patients/operative-plan/new?forPatientId=cd572865-dcc0-441e-a2ad-be400dc256da', 'New operative plan URL is correct');
+    assert.dom('.patient-name .ps-info-data').hasText('Joe Bagadonuts', 'Joe Bagadonuts patient header displays');
+    assert.dom('.view-current-title').hasText('New Operative Plan', 'New operative plan title is correct');
+    assert.equal(find('span.primary-diagnosis:contains(Broken Arm)').length, 1, 'Primary diagnosis appears as read only');
+    assert.equal(find('span.secondary-diagnosis:contains(Tennis Elbow)').length, 1, 'Secondary diagnosis appears as read only');
+
+    await fillIn('.operation-description textarea', OPERATION_DESCRIPTION);
+    await typeAheadFillIn('.procedure-description', PROCEDURE_HIP);
+    await click('button:contains(Add Procedure)');
+    await waitToAppear('.procedure-listing td.procedure-description');
+    assert.dom('.procedure-listing td.procedure-description').hasText(PROCEDURE_HIP, 'Added procedure displays in procedure table');
+
+    await typeAheadFillIn('.procedure-description', 'Delete Me');
+    await click('button:contains(Add Procedure)');
+    await waitToAppear('.procedure-listing td.procedure-description:contains(Delete Me)');
+    findWithAssert('.procedure-listing td.procedure-description:contains(Delete Me)');
+
+    await click('.procedure-listing tr:last button:contains(Delete)');
+    assert.equal(find('.procedure-listing td.procedure-description:contains(Delete Me)').length, 0, 'Procedure is properly deleted');
+
+    await typeAheadFillIn('.procedure-description', PROCEDURE_FIX_ARM); // Leave typeahead filled in with value to automatically add on save.
+    await typeAheadFillIn('.plan-surgeon', OPERATION_SURGEON);
+    assert.dom('.plan-status select').hasValue('planned', 'Plan status is set to planned');
+
+    await fillIn('.case-complexity input', CASE_COMPLEXITY);
+    await fillIn('.admission-instructions textarea', 'Get blood tests done on admission.');
+    await fillIn('.additional-notes textarea', ADDITIONAL_NOTES);
+    await click('.panel-footer button:contains(Add)');
+    await waitToAppear('.modal-dialog');
+    assert.dom('.modal-title').hasText('Plan Saved', 'Plan saved modal displays');
+
+    await click('.modal-footer button:contains(Ok)');
+    assert.equal(find('.view-current-title').text(), 'Edit Operative Plan', 'Edit operative plan title is correct');
+    assert.equal(find(`.procedure-listing td.procedure-description:contains(${PROCEDURE_FIX_ARM})`).length, 1, 'Procedure from typeahead gets added to procedure list on save');
+
+    await click('button:contains(Return)');
+    assert.equal(currentURL(), '/patients/edit/cd572865-dcc0-441e-a2ad-be400dc256da', 'Return goes back to patient screen');
+    assert.equal(find('a:contains(Current Operative Plan)').length, 1, 'Link to newly created plan appears');
+
+    await click('a:contains(Current Operative Plan)');
+    assert.dom('.view-current-title').hasText('Edit Operative Plan', 'Edit operative plan title is correct');
+    assert.equal(find('button:contains(Complete Plan)').length, 1, 'Complete Plan button appears');
+
+    await click('button:contains(Complete Plan)');
+    await waitToAppear('.modal-dialog');
+    assert.dom('.modal-title').hasText('Plan Completed', 'Plan completed modal displays');
+
+    await click('.modal-footer button:contains(Ok)');
+    assert.dom('.view-current-title').hasText('Edit Operation Report', 'Edit Operation Report title is correct');
+    assert.dom('.patient-name .ps-info-data').hasText('Joe Bagadonuts', 'Joe Bagadonuts patient header displays');
+    assert.equal(find('a.primary-diagnosis:contains(Broken Arm)').length, 1, 'Primary diagnosis appears as editable');
+    assert.equal(find('a.secondary-diagnosis:contains(Tennis Elbow)').length, 1, 'Secondary diagnosis appears as  editable');
+    assert.equal(find('.operation-description textarea').val(), OPERATION_DESCRIPTION, 'Operation description is copied from operative plan');
+    assert.equal(find('.operation-surgeon .tt-input').val(), OPERATION_SURGEON, 'Surgeon is copied from operative plan');
+    assert.equal(find('.case-complexity input').val(), CASE_COMPLEXITY, 'Case complexity is copied from operative plan');
+    assert.equal(find(`.procedure-listing td.procedure-description:contains(${PROCEDURE_HIP})`).length, 1, `Procedure ${PROCEDURE_HIP} is copied from operative plan`);
+    assert.equal(find(`.procedure-listing td.procedure-description:contains(${PROCEDURE_FIX_ARM})`).length, 1, `Procedure ${PROCEDURE_FIX_ARM} is copied from operative plan`);
+
+    await typeAheadFillIn('.operation-assistant', 'Dr Cindy');
+    await click('.panel-footer button:contains(Update)');
+    await waitToAppear('.modal-dialog');
+    assert.dom('.modal-title').hasText('Report Saved', 'Report Saved modal displays');
+
+    await click('.modal-footer button:contains(Ok)');
+    await click('button:contains(Return)');
+    assert.equal(currentURL(), '/patients/edit/cd572865-dcc0-441e-a2ad-be400dc256da', 'Patient edit URL is correct');
+    assert.equal(find('a.patient-procedure:contains(fix broken arm)').length, 1, 'Procedure/operative report shows on patient header');
+
+    await click('a.patient-procedure:contains(fix broken arm)');
+    assert.dom('.view-current-title').hasText('Edit Operation Report', 'Operation Report appears for editing');
   });
 });

--- a/tests/acceptance/outpatient-test.js
+++ b/tests/acceptance/outpatient-test.js
@@ -5,148 +5,120 @@ import moduleForAcceptance from 'hospitalrun/tests/helpers/module-for-acceptance
 moduleForAcceptance('Acceptance | outpatient');
 
 test('Check In/Check Out Existing outpatient', function(assert) {
-  runWithPouchDump('patient', function() {
-    authenticateUser();
-    visit('/patients/outpatient');
-    andThen(function() {
-      assert.equal(currentURL(), '/patients/outpatient', 'Outpatient url is correct');
-      assert.dom('.view-current-title').hasText('Today\'s Outpatients', 'Title is correct');
-      click('button:contains(Patient Check In)');
-    });
-    andThen(function() {
-      assert.equal(currentURL(), '/visits/edit/checkin', 'Check In url is correct');
-      typeAheadFillIn('.patient-name', 'Joe Bagadonuts - P00001');
-      waitToAppear('.patient-name .ps-info-data');
-    });
-    andThen(function() {
-      assert.dom('.patient-name .ps-info-data').hasText('Joe Bagadonuts', 'Joe Bagadonuts patient record displays');
-      assert.dom('.new-patient-checkbox input').isNotChecked('New Patient checkbox is not checked');
-      select('.visit-type', 'Clinic');
-      click('button:contains(Check In)');
-      waitToAppear('.modal-dialog');
-    });
-    andThen(function() {
-      assert.dom('.modal-title').hasText('Patient Checked In', 'Patient has been checked in');
-      click('.modal-footer button:contains(Ok)');
-    });
-    andThen(function() {
-      findWithAssert('button:contains(Check Out)');
-      click('button:contains(Return)');
-    });
-    andThen(function() {
-      assert.equal(currentURL(), '/patients/outpatient', 'Returned to Outpatient');
-      assert.equal(find('.outpatient-list td:contains(Joe Bagadonuts)').length, 1, 'Checked in patient appears in list');
-      click('button:contains(Check Out)');
-      waitToAppear('.modal-dialog');
-    });
-    andThen(function() {
-      assert.dom('.modal-title').hasText('Patient Check Out', 'Patient checkout confirmation displays');
-      click('button:contains(Ok)');
-      waitToAppear('.modal-title:contains(Patient Checked Out)');
-    });
-    andThen(function() {
-      assert.dom('.modal-title').hasText('Patient Checked Out', 'Patient has been checked out confirmation');
-      click('button:contains(Ok)');
-    });
-    andThen(function() {
-      assert.equal(find('.outpatient-list td:contains(Joe Bagadonuts)').length, 0, 'Checked out patient no longer appears');
-    });
+  runWithPouchDump('patient', async function() {
+    await authenticateUser();
+    await visit('/patients/outpatient');
+    assert.equal(currentURL(), '/patients/outpatient', 'Outpatient url is correct');
+    assert.dom('.view-current-title').hasText('Today\'s Outpatients', 'Title is correct');
+
+    await click('button:contains(Patient Check In)');
+    assert.equal(currentURL(), '/visits/edit/checkin', 'Check In url is correct');
+
+    await typeAheadFillIn('.patient-name', 'Joe Bagadonuts - P00001');
+    await waitToAppear('.patient-name .ps-info-data');
+    assert.dom('.patient-name .ps-info-data').hasText('Joe Bagadonuts', 'Joe Bagadonuts patient record displays');
+    assert.dom('.new-patient-checkbox input').isNotChecked('New Patient checkbox is not checked');
+
+    await select('.visit-type', 'Clinic');
+    await click('button:contains(Check In)');
+    await waitToAppear('.modal-dialog');
+    assert.dom('.modal-title').hasText('Patient Checked In', 'Patient has been checked in');
+
+    await click('.modal-footer button:contains(Ok)');
+    findWithAssert('button:contains(Check Out)');
+
+    await click('button:contains(Return)');
+    assert.equal(currentURL(), '/patients/outpatient', 'Returned to Outpatient');
+    assert.equal(find('.outpatient-list td:contains(Joe Bagadonuts)').length, 1, 'Checked in patient appears in list');
+
+    await click('button:contains(Check Out)');
+    await waitToAppear('.modal-dialog');
+    assert.dom('.modal-title').hasText('Patient Check Out', 'Patient checkout confirmation displays');
+
+    await click('button:contains(Ok)');
+    await waitToAppear('.modal-title:contains(Patient Checked Out)');
+    assert.dom('.modal-title').hasText('Patient Checked Out', 'Patient has been checked out confirmation');
+
+    await click('button:contains(Ok)');
+    assert.equal(find('.outpatient-list td:contains(Joe Bagadonuts)').length, 0, 'Checked out patient no longer appears');
   });
 });
 
 test('Check In/Check Out new outpatient', function(assert) {
-  runWithPouchDump('patient', function() {
+  runWithPouchDump('patient', async function() {
     let visitDate = moment('2015-10-01');
     let visitLocation = 'Outpatient Followup';
-    authenticateUser();
-    visit('/patients/outpatient');
-    andThen(function() {
-      assert.equal(currentURL(), '/patients/outpatient', 'Outpatient url is correct');
-      assert.dom('.view-current-title').hasText('Today\'s Outpatients', 'Title is correct');
-      click('button:contains(Patient Check In)');
-    });
-    andThen(function() {
-      assert.equal(currentURL(), '/visits/edit/checkin', 'Check In url is correct');
-      typeAheadFillIn('.patient-name', 'Jane Bagadonuts');
-    });
-    andThen(function() {
-      assert.dom('.new-patient-checkbox input').isChecked('New Patient checkbox is checked');
-      selectDate('.checkin-date input', visitDate.toDate());
-      select('.visit-type', 'Followup');
-      typeAheadFillIn('.visit-location', visitLocation);
-    });
-    andThen(function() {
-      click('button:contains(Check In)');
-      waitToAppear('.modal-title:contains(New Patient)');
-    });
-    andThen(function() {
-      assert.dom('.modal-title').hasText('New Patient', 'New Patient dialog appears');
-      click('.modal-footer button:contains(Add)');
-      waitToAppear('.modal-title:contains(Patient Checked In)');
-    });
-    andThen(function() {
-      assert.dom('.modal-title').hasText('Patient Checked In', 'Patient has been checked in');
-      assert.dom('.modal-body').hasText(
-        'Jane Bagadonuts has been created and checked in.',
-        'Patient has been created and checked in'
-      );
-      click('button:contains(Ok)');
-    });
-    andThen(function() {
-      findWithAssert('button:contains(Check Out)');
-      click('button:contains(Return)');
-    });
-    andThen(function() {
-      assert.equal(currentURL(), '/patients/outpatient', 'Returned to Outpatient');
-      assert.equal(find('.outpatient-list td:contains(Jane Bagadonuts)').length, 0, 'Checked in patient does not appears in list because of date');
-      selectDate('.outpatient-date input', visitDate.toDate());
-      click('button:contains(Search)');
-      waitToAppear(`.view-current-title:contains(Outpatients for ${visitDate.format('l')})`);
-    });
-    andThen(function() {
-      assert.dom('.view-current-title').hasText(
-        `Outpatients for ${visitDate.format('l')}`,
-        'Title updates to specified date'
-      );
-      waitToAppear('.outpatient-list td:contains(Jane Bagadonuts)');
-    });
-    andThen(function() {
-      assert.equal(find('.outpatient-list td:contains(Jane Bagadonuts)').length, 1, 'Checked in patient appears with date filtered.');
-      select('.outpatient-location', 'Hospital');
-      click('button:contains(Search)');
-    });
-    andThen(function() {
-      assert.equal(find('.outpatient-list td:contains(Jane Bagadonuts)').length, 0, 'Checked in patient does not appear because different location.');
-      findWithAssert(`.outpatient-location option:contains(${visitLocation})`);
-      select('.outpatient-location', visitLocation);
-      click('button:contains(Search)');
-    });
-    andThen(function() {
-      assert.equal(find('.outpatient-list td:contains(Jane Bagadonuts)').length, 1, 'Checked in patient appears with date and location filtered.');
-      visit('/patients');
-    });
-    andThen(function() {
-      assert.equal(find('tr:last td:contains(Jane)').length, 1, 'New patient appears in patient listing.');
-      click('tr:last td button:contains(Check Out)');
-      waitToAppear('.view-current-title:contains(Edit Visit)');
-    });
-    andThen(function() {
-      assert.dom('.view-current-title').hasText('Edit Visit', 'Visit displays on checkout from patient listing');
-      assert.dom('.patient-name .ps-info-data').hasText('Jane Bagadonuts', 'Jane Bagadonuts patient record displays');
-      click('button:contains(Check Out)');
-      waitToAppear('.modal-dialog');
-    });
-    andThen(function() {
-      assert.dom('.modal-title').hasText('Patient Checked Out', 'Patient has been checked out confirmation');
-      click('button:contains(Ok)');
-    });
-    andThen(function() {
-      let checkoutDate = moment();
-      assert.dom('.checkout-date input').hasValue(checkoutDate.format('l h:mm A'), 'Check Out date properly set');
-      visit('/patients/outpatient');
-    });
-    andThen(function() {
-      assert.equal(find('.outpatient-list td:contains(Jane Bagadonuts)').length, 0, 'Checked out patient no longer appears');
-    });
+    await authenticateUser();
+    await visit('/patients/outpatient');
+    assert.equal(currentURL(), '/patients/outpatient', 'Outpatient url is correct');
+    assert.dom('.view-current-title').hasText('Today\'s Outpatients', 'Title is correct');
+
+    await click('button:contains(Patient Check In)');
+    assert.equal(currentURL(), '/visits/edit/checkin', 'Check In url is correct');
+
+    await typeAheadFillIn('.patient-name', 'Jane Bagadonuts');
+    assert.dom('.new-patient-checkbox input').isChecked('New Patient checkbox is checked');
+
+    await selectDate('.checkin-date input', visitDate.toDate());
+    await select('.visit-type', 'Followup');
+    await typeAheadFillIn('.visit-location', visitLocation);
+    await click('button:contains(Check In)');
+    await waitToAppear('.modal-title:contains(New Patient)');
+    assert.dom('.modal-title').hasText('New Patient', 'New Patient dialog appears');
+
+    await click('.modal-footer button:contains(Add)');
+    await waitToAppear('.modal-title:contains(Patient Checked In)');
+    assert.dom('.modal-title').hasText('Patient Checked In', 'Patient has been checked in');
+    assert.dom('.modal-body').hasText(
+      'Jane Bagadonuts has been created and checked in.',
+      'Patient has been created and checked in'
+    );
+
+    await click('button:contains(Ok)');
+    findWithAssert('button:contains(Check Out)');
+
+    await click('button:contains(Return)');
+    assert.equal(currentURL(), '/patients/outpatient', 'Returned to Outpatient');
+    assert.equal(find('.outpatient-list td:contains(Jane Bagadonuts)').length, 0, 'Checked in patient does not appears in list because of date');
+
+    await selectDate('.outpatient-date input', visitDate.toDate());
+    await click('button:contains(Search)');
+    await waitToAppear(`.view-current-title:contains(Outpatients for ${visitDate.format('l')})`);
+    assert.dom('.view-current-title').hasText(
+      `Outpatients for ${visitDate.format('l')}`,
+      'Title updates to specified date'
+    );
+
+    await waitToAppear('.outpatient-list td:contains(Jane Bagadonuts)');
+    assert.equal(find('.outpatient-list td:contains(Jane Bagadonuts)').length, 1, 'Checked in patient appears with date filtered.');
+
+    await select('.outpatient-location', 'Hospital');
+    await click('button:contains(Search)');
+    assert.equal(find('.outpatient-list td:contains(Jane Bagadonuts)').length, 0, 'Checked in patient does not appear because different location.');
+    findWithAssert(`.outpatient-location option:contains(${visitLocation})`);
+
+    await select('.outpatient-location', visitLocation);
+    await click('button:contains(Search)');
+    assert.equal(find('.outpatient-list td:contains(Jane Bagadonuts)').length, 1, 'Checked in patient appears with date and location filtered.');
+
+    await visit('/patients');
+    assert.equal(find('tr:last td:contains(Jane)').length, 1, 'New patient appears in patient listing.');
+
+    await click('tr:last td button:contains(Check Out)');
+    await waitToAppear('.view-current-title:contains(Edit Visit)');
+    assert.dom('.view-current-title').hasText('Edit Visit', 'Visit displays on checkout from patient listing');
+    assert.dom('.patient-name .ps-info-data').hasText('Jane Bagadonuts', 'Jane Bagadonuts patient record displays');
+
+    await click('button:contains(Check Out)');
+    await waitToAppear('.modal-dialog');
+    assert.dom('.modal-title').hasText('Patient Checked Out', 'Patient has been checked out confirmation');
+
+    await click('button:contains(Ok)');
+
+    let checkoutDate = moment();
+    assert.dom('.checkout-date input').hasValue(checkoutDate.format('l h:mm A'), 'Check Out date properly set');
+
+    await visit('/patients/outpatient');
+    assert.equal(find('.outpatient-list td:contains(Jane Bagadonuts)').length, 0, 'Checked out patient no longer appears');
   });
 });

--- a/tests/acceptance/patient-notes-test.js
+++ b/tests/acceptance/patient-notes-test.js
@@ -4,82 +4,59 @@ import moduleForAcceptance from 'hospitalrun/tests/helpers/module-for-acceptance
 moduleForAcceptance('Acceptance | patient notes');
 
 test('patient notes crud testing', function(assert) {
-  runWithPouchDump('default', function() {
-    authenticateUser();
-    visit('/patients/edit/new');
-    andThen(function() {
-      assert.equal(currentURL(), '/patients/edit/new');
-      fillIn('.test-first-name input', 'John');
-      fillIn('.test-last-name input', 'Doe');
-    });
-    andThen(function() {
-      click('.panel-footer button:contains(Add)');
-      waitToAppear('.message:contains(The patient record for John Doe has been saved)');
-    });
-    andThen(function() {
-      assert.dom('.message').hasText('The patient record for John Doe has been saved.');
-      waitToAppear('.patient-summary');
-    });
-    andThen(function() {
-      assert.dom('.patient-summary').exists();
-      click('[data-test-selector=visits-tab]');
-    });
-    andThen(function() {
-      assert.dom('#visits').exists();
-      click('button:contains(New Visit)');
-    });
-    andThen(function() {
-      assert.equal(currentURL(), '/visits/edit/new', 'Now in add visiting information route');
-      click('.panel-footer button:contains(Add)');
-      waitToAppear('.modal-dialog');
-    });
-    andThen(() => {
-      assert.dom('.modal-title').hasText('Visit Saved', 'New visit has been saved');
-      click('button:contains(Ok)');
-    });
-    andThen(() => {
-      click('[data-test-selector=notes-tab]');
-    });
-    andThen(() => {
-      assert.equal(find('button:contains(New Note)').length, 1, 'New Note button in visible');
-      click('button:contains(New Note)');
-      waitToAppear('.modal-dialog');
-    });
-    andThen(function() {
-      assert.dom('.modal-title').hasText('New Note for John Doe', 'Notes modal appeared');
-      fillIn('.test-note-content textarea', 'This is a note.');
-      fillIn('.test-note-attribution input', 'Dr. Nick');
-    });
-    andThen(function() {
-      click('.modal-footer button:contains(Add)');
-      waitToDisappear('.modal-dialog');
-      waitToAppear('#visit-notes table tr td:contains(This is a note.)');
-    });
-    andThen(function() {
-      assert.equal(find('#visit-notes table tr td:contains(This is a note.)').length, 1, 'Successfully added note.');
-      click('#visit-notes table tr td button:contains(Edit)');
-      waitToAppear('.modal-dialog');
-    });
-    andThen(function() {
-      fillIn('.test-note-content textarea', 'This is an updated note.');
-    });
-    andThen(function() {
-      click('.modal-footer button:contains(Update)');
-      waitToDisappear('.modal-dialog');
-      waitToAppear('#visit-notes table tr td:contains(This is an updated note.)');
-    });
-    andThen(function() {
-      assert.equal(find('#visit-notes table tr td:contains(This is an updated note.)').length, 1, 'Successfully updated note.');
-      click('#visit-notes table tr td button:contains(Delete)');
-      waitToAppear('.modal-dialog');
-    });
-    andThen(function() {
-      assert.dom('.modal-title').hasText('Delete Note', 'Delete Note modal appeared');
-      click('.modal-footer button:contains(Ok)');
-      waitToDisappear('.modal-dialog');
-    });
-    andThen(function() {
-      assert.equal(find('#visit-notes table tr td:contains(This is an updated note.)').length, 0, 'Successfully deleted note.');
-    });
+  runWithPouchDump('default', async function() {
+    await authenticateUser();
+    await visit('/patients/edit/new');
+    assert.equal(currentURL(), '/patients/edit/new');
+
+    await fillIn('.test-first-name input', 'John');
+    await fillIn('.test-last-name input', 'Doe');
+    await click('.panel-footer button:contains(Add)');
+    await waitToAppear('.message:contains(The patient record for John Doe has been saved)');
+    assert.dom('.message').hasText('The patient record for John Doe has been saved.');
+
+    await waitToAppear('.patient-summary');
+    assert.dom('.patient-summary').exists();
+
+    await click('[data-test-selector=visits-tab]');
+    assert.dom('#visits').exists();
+
+    await click('button:contains(New Visit)');
+    assert.equal(currentURL(), '/visits/edit/new', 'Now in add visiting information route');
+
+    await click('.panel-footer button:contains(Add)');
+    await waitToAppear('.modal-dialog');
+    assert.dom('.modal-title').hasText('Visit Saved', 'New visit has been saved');
+
+    await click('button:contains(Ok)');
+    await click('[data-test-selector=notes-tab]');
+    assert.equal(find('button:contains(New Note)').length, 1, 'New Note button in visible');
+
+    await click('button:contains(New Note)');
+    await waitToAppear('.modal-dialog');
+    assert.dom('.modal-title').hasText('New Note for John Doe', 'Notes modal appeared');
+
+    await fillIn('.test-note-content textarea', 'This is a note.');
+    await fillIn('.test-note-attribution input', 'Dr. Nick');
+    await click('.modal-footer button:contains(Add)');
+    await waitToDisappear('.modal-dialog');
+    await waitToAppear('#visit-notes table tr td:contains(This is a note.)');
+    assert.equal(find('#visit-notes table tr td:contains(This is a note.)').length, 1, 'Successfully added note.');
+
+    await click('#visit-notes table tr td button:contains(Edit)');
+    await waitToAppear('.modal-dialog');
+    await fillIn('.test-note-content textarea', 'This is an updated note.');
+    await click('.modal-footer button:contains(Update)');
+    await waitToDisappear('.modal-dialog');
+    await waitToAppear('#visit-notes table tr td:contains(This is an updated note.)');
+    assert.equal(find('#visit-notes table tr td:contains(This is an updated note.)').length, 1, 'Successfully updated note.');
+
+    await click('#visit-notes table tr td button:contains(Delete)');
+    await waitToAppear('.modal-dialog');
+    assert.dom('.modal-title').hasText('Delete Note', 'Delete Note modal appeared');
+
+    await click('.modal-footer button:contains(Ok)');
+    await waitToDisappear('.modal-dialog');
+    assert.equal(find('#visit-notes table tr td:contains(This is an updated note.)').length, 0, 'Successfully deleted note.');
   });
 });

--- a/tests/acceptance/patients-test.js
+++ b/tests/acceptance/patients-test.js
@@ -4,36 +4,32 @@ import moduleForAcceptance from 'hospitalrun/tests/helpers/module-for-acceptance
 moduleForAcceptance('Acceptance | patients');
 
 test('visiting /patients route', function(assert) {
-  runWithPouchDump('default', function() {
-    authenticateUser();
-    visit('/patients');
-    andThen(function() {
-      assert.equal(currentURL(), '/patients');
-      let noPatientsFound = find('[data-test-selector="no-patients-found"]');
-      assert.equal(noPatientsFound.text().trim(), 'No patients found. Create a new patient record?', 'no records found');
-      let newPatientButton = find('button:contains(+ new patient)');
-      assert.equal(newPatientButton.length, 1, 'Add new patient button is visible');
-    });
-    click('button:contains(+ new patient)');
-    andThen(function() {
-      assert.equal(currentURL(), '/patients/edit/new');
-    });
+  runWithPouchDump('default', async function() {
+    await authenticateUser();
+    await visit('/patients');
+    assert.equal(currentURL(), '/patients');
+
+    let noPatientsFound = find('[data-test-selector="no-patients-found"]');
+    assert.equal(noPatientsFound.text().trim(), 'No patients found. Create a new patient record?', 'no records found');
+    let newPatientButton = find('button:contains(+ new patient)');
+    assert.equal(newPatientButton.length, 1, 'Add new patient button is visible');
+
+    await click('button:contains(+ new patient)');
+    assert.equal(currentURL(), '/patients/edit/new');
   });
 });
 
 test('View reports tab', function(assert) {
-  runWithPouchDump('default', function() {
-    authenticateUser();
-    visit('/patients/reports');
+  runWithPouchDump('default', async function() {
+    await authenticateUser();
+    await visit('/patients/reports');
 
-    andThen(function() {
-      let generateReportButton = find('button:contains(Generate Report)');
-      assert.equal(currentURL(), '/patients/reports');
-      assert.equal(generateReportButton.length, 1, 'Generate Report button is visible');
-      let reportType = find('[data-test-selector="select-report-type"]');
-      assert.equal(reportType.length, 1, 'Report type select is visible');
-      assert.equal(reportType.find(':selected').text().trim(), 'Admissions Detail', 'Default value selected"');
-    });
+    let generateReportButton = find('button:contains(Generate Report)');
+    assert.equal(currentURL(), '/patients/reports');
+    assert.equal(generateReportButton.length, 1, 'Generate Report button is visible');
+    let reportType = find('[data-test-selector="select-report-type"]');
+    assert.equal(reportType.length, 1, 'Report type select is visible');
+    assert.equal(reportType.find(':selected').text().trim(), 'Admissions Detail', 'Default value selected"');
   });
 });
 
@@ -51,174 +47,137 @@ reportNames.forEach((reportName) => {
 });
 
 test('View reports tab | Patient Status', function(assert) {
-  runWithPouchDump('default', function() {
-    authenticateUser();
-    visit('/patients/reports');
-    select('[data-test-selector="select-report-type"] select', 'Patient Status');
+  runWithPouchDump('default', async function() {
+    await authenticateUser();
+    await visit('/patients/reports');
+    await select('[data-test-selector="select-report-type"] select', 'Patient Status');
 
-    andThen(function() {
-      let generateReportButton = find('button:contains(Generate Report)');
-      assert.equal(currentURL(), '/patients/reports');
-      assert.equal(generateReportButton.length, 1, 'Generate Report button is visible');
-      let reportType = find('[data-test-selector="select-report-type"] select');
-      assert.equal(reportType.length, 1, 'Report type select is visible');
-      assert.equal(reportType.find(':selected').text().trim(), 'Patient Status', 'Default value selected"');
-    });
+    let generateReportButton = find('button:contains(Generate Report)');
+    assert.equal(currentURL(), '/patients/reports');
+    assert.equal(generateReportButton.length, 1, 'Generate Report button is visible');
+    let reportType = find('[data-test-selector="select-report-type"] select');
+    assert.equal(reportType.length, 1, 'Report type select is visible');
+    assert.equal(reportType.find(':selected').text().trim(), 'Patient Status', 'Default value selected"');
   });
 });
 
 test('Testing admitted patient', function(assert) {
-  runWithPouchDump('patient', function() {
-    authenticateUser();
-    visit('/patients/admitted');
-    andThen(function() {
-      assert.equal(currentURL(), '/patients/admitted');
-      assert.dom('.clickable').exists({ count: 1 }, 'One patient is listed');
-    });
-    click('button:contains(Discharge)');
-    waitToAppear('.view-current-title:contains(Edit Visit)');
-    andThen(function() {
-      assert.equal(currentURL(), '/visits/edit/03C7BF8B-04E0-DD9E-9469-96A5604F5340', 'should return visits/edit instead');
-    });
-    click('.panel-footer button:contains(Discharge)');
-    waitToAppear('.modal-dialog');
-    andThen(() => {
-      assert.dom('.modal-title').hasText('Patient Discharged', 'Patient has been discharged');
-    });
+  runWithPouchDump('patient', async function() {
+    await authenticateUser();
+    await visit('/patients/admitted');
+    assert.equal(currentURL(), '/patients/admitted');
+    assert.dom('.clickable').exists({ count: 1 }, 'One patient is listed');
 
-    click('button:contains(Ok)');
-    visit('/patients/admitted');
-    waitToAppear('.view-current-title:contains(Admitted Patients)');
-    andThen(() => {
-      assert.dom('.clickable').doesNotExist('No patient is listed');
-    });
+    await click('button:contains(Discharge)');
+    await waitToAppear('.view-current-title:contains(Edit Visit)');
+    assert.equal(currentURL(), '/visits/edit/03C7BF8B-04E0-DD9E-9469-96A5604F5340', 'should return visits/edit instead');
+
+    await click('.panel-footer button:contains(Discharge)');
+    await waitToAppear('.modal-dialog');
+    assert.dom('.modal-title').hasText('Patient Discharged', 'Patient has been discharged');
+
+    await click('button:contains(Ok)');
+    await visit('/patients/admitted');
+    await waitToAppear('.view-current-title:contains(Admitted Patients)');
+    assert.dom('.clickable').doesNotExist('No patient is listed');
   });
 });
 
 test('Adding a new patient record', function(assert) {
-  runWithPouchDump('default', function() {
-    authenticateUser();
-    visit('/patients/edit/new');
-    andThen(function() {
-      assert.equal(currentURL(), '/patients/edit/new');
-    });
+  runWithPouchDump('default', async function() {
+    await authenticateUser();
+    await visit('/patients/edit/new');
+    assert.equal(currentURL(), '/patients/edit/new');
 
-    fillIn('.test-first-name input', 'John');
-    fillIn('.test-last-name input', 'Doe');
-    click('.panel-footer button:contains(Add)');
-    waitToAppear('.message:contains(The patient record for John Doe has been saved)');
-    andThen(function() {
-      assert.dom('.message').hasText('The patient record for John Doe has been saved.');
-    });
+    await fillIn('.test-first-name input', 'John');
+    await fillIn('.test-last-name input', 'Doe');
+    await click('.panel-footer button:contains(Add)');
+    await waitToAppear('.message:contains(The patient record for John Doe has been saved)');
+    assert.dom('.message').hasText('The patient record for John Doe has been saved.');
 
-    waitToAppear('.patient-summary');
-
-    andThen(function() {
-      assert.dom('.patient-summary').exists();
-    });
-    andThen(function() {
-      assert.dom('#general').exists();
-    });
-
+    await waitToAppear('.patient-summary');
+    assert.dom('.patient-summary').exists();
+    assert.dom('#general').exists();
   });
 });
 
 test('Delete a patient record', function(assert) {
-  runWithPouchDump('patient', function() {
-    authenticateUser();
-    visit('/patients');
-    andThen(() =>{
-      assert.equal(currentURL(), '/patients', 'Patient listing url is correct');
-      assert.equal(find('tr.clickable td:contains(Joe)').length, 1, 'One patient exists to delete.');
-      click('tr.clickable button:contains(Delete)');
-      waitToAppear('.modal-dialog');
-    });
-    andThen(() =>{
-      assert.dom('.modal-title').hasText('Delete Patient', 'Delete Patient ');
-      assert.dom('.modal-body').hasText(
-        'Are you sure you wish to delete Joe Bagadonuts?',
-        'Patient information appears in modal'
-      );
-      click('.modal-footer button:contains(Delete)');
-      waitToDisappear('.modal-dialog');
-      waitToDisappear('tr.clickable td:contains(Joe)');
-    });
-    andThen(function() {
-      assert.equal(find('tr.clickable td:contains(Joe)').length, 0, 'Patient has been successfully deleted.');
-    });
+  runWithPouchDump('patient', async function() {
+    await authenticateUser();
+    await visit('/patients');
+    assert.equal(currentURL(), '/patients', 'Patient listing url is correct');
+    assert.equal(find('tr.clickable td:contains(Joe)').length, 1, 'One patient exists to delete.');
+
+    await click('tr.clickable button:contains(Delete)');
+    await waitToAppear('.modal-dialog');
+    assert.dom('.modal-title').hasText('Delete Patient', 'Delete Patient ');
+    assert.dom('.modal-body').hasText(
+      'Are you sure you wish to delete Joe Bagadonuts?',
+      'Patient information appears in modal'
+    );
+
+    await click('.modal-footer button:contains(Delete)');
+    await waitToDisappear('.modal-dialog');
+    await waitToDisappear('tr.clickable td:contains(Joe)');
+    assert.equal(find('tr.clickable td:contains(Joe)').length, 0, 'Patient has been successfully deleted.');
   });
 });
 
 test('Searching patients', function(assert) {
-  runWithPouchDump('patient', function() {
-    authenticateUser();
-    visit('/patients');
+  runWithPouchDump('patient', async function() {
+    await authenticateUser();
+    await visit('/patients');
 
-    fillIn('[role="search"] div input', 'Joe');
-    click('.glyphicon-search');
+    await fillIn('[role="search"] div input', 'Joe');
+    await click('.glyphicon-search');
+    assert.equal(currentURL(), '/patients/search/Joe', 'Searched for Joe');
+    assert.equal(find('button:contains(Delete)').length, 1, 'There is one search item');
 
-    andThen(() => {
-      assert.equal(currentURL(), '/patients/search/Joe', 'Searched for Joe');
-      assert.equal(find('button:contains(Delete)').length, 1, 'There is one search item');
-    });
+    await fillIn('[role="search"] div input', 'joe');
+    await click('.glyphicon-search');
+    assert.equal(currentURL(), '/patients/search/joe', 'Searched for all lower case joe');
+    assert.equal(find('button:contains(Delete)').length, 1, 'There is one search item');
 
-    fillIn('[role="search"] div input', 'joe');
-    click('.glyphicon-search');
-
-    andThen(() => {
-      assert.equal(currentURL(), '/patients/search/joe', 'Searched for all lower case joe');
-      assert.equal(find('button:contains(Delete)').length, 1, 'There is one search item');
-    });
-    fillIn('[role="search"] div input', 'ItemNotFound');
-    click('.glyphicon-search');
-
-    andThen(() => {
-      assert.equal(currentURL(), '/patients/search/ItemNotFound', 'Searched for ItemNotFound');
-      assert.equal(find('button:contains(Delete)').length, 0, 'There is no search result');
-    });
+    await fillIn('[role="search"] div input', 'ItemNotFound');
+    await click('.glyphicon-search');
+    assert.equal(currentURL(), '/patients/search/ItemNotFound', 'Searched for ItemNotFound');
+    assert.equal(find('button:contains(Delete)').length, 0, 'There is no search result');
   });
 });
 
 function testSimpleReportForm(reportName) {
   test(`View reports tab | ${reportName} shows start and end dates`, function(assert) {
-    runWithPouchDump('default', function() {
-      authenticateUser();
-      visit('/patients/reports');
-      select('[data-test-selector="select-report-type"] select', reportName);
+    runWithPouchDump('default', async function() {
+      await authenticateUser();
+      await visit('/patients/reports');
+      await select('[data-test-selector="select-report-type"] select', reportName);
 
-      andThen(function() {
-        let reportStartDate = find('[data-test-selector="select-report-start-date"]');
-        let reportEndDate = find('[data-test-selector="select-report-end-date"]');
-        assert.equal(reportStartDate.length, 1, 'Report start date select is visible');
-        assert.equal(reportEndDate.length, 1, 'Report end date select is visible');
-        let reportType = find('[data-test-selector="select-report-type"] select');
-        assert.equal(reportType.find(':selected').text().trim(), reportName, `${reportName} option selected`);
-      });
+      let reportStartDate = find('[data-test-selector="select-report-start-date"]');
+      let reportEndDate = find('[data-test-selector="select-report-end-date"]');
+      assert.equal(reportStartDate.length, 1, 'Report start date select is visible');
+      assert.equal(reportEndDate.length, 1, 'Report end date select is visible');
+      let reportType = find('[data-test-selector="select-report-type"] select');
+      assert.equal(reportType.find(':selected').text().trim(), reportName, `${reportName} option selected`);
     });
   });
 }
 
 function testExportReportName(reportName) {
   test(`View reports tab | Export reports name for ${reportName} shows report name, start and end dates`, (assert) => {
-    runWithPouchDump('default', () => {
-      authenticateUser();
-      visit('/patients/reports');
-      select('[data-test-selector="select-report-type"] select', reportName);
+    runWithPouchDump('default', async function() {
+      await authenticateUser();
+      await visit('/patients/reports');
+      await select('[data-test-selector="select-report-type"] select', reportName);
+      assert.equal(currentURL(), '/patients/reports');
 
-      andThen(() => {
-        assert.equal(currentURL(), '/patients/reports');
-      });
+      await fillIn('[data-test-selector="select-report-start-date"] input', '12/11/2016');
+      await fillIn('[data-test-selector="select-report-end-date"] input', '12/31/2016');
 
-      fillIn('[data-test-selector="select-report-start-date"] input', '12/11/2016');
-      fillIn('[data-test-selector="select-report-end-date"] input', '12/31/2016');
+      await click('button:contains(Generate Report)');
+      await waitToAppear('.panel-title');
 
-      click('button:contains(Generate Report)');
-      waitToAppear('.panel-title');
-
-      andThen(() => {
-        let exportReportButton = findWithAssert('a:contains(Export Report)');
-        assert.equal($(exportReportButton).attr('download'), `${reportName} Report 12/11/2016 - 12/31/2016.csv`);
-      });
+      let exportReportButton = findWithAssert('a:contains(Export Report)');
+      assert.equal($(exportReportButton).attr('download'), `${reportName} Report 12/11/2016 - 12/31/2016.csv`);
     });
   });
 }

--- a/tests/acceptance/pricing-test.js
+++ b/tests/acceptance/pricing-test.js
@@ -2,18 +2,15 @@ import { test } from 'qunit';
 import moduleForAcceptance from 'hospitalrun/tests/helpers/module-for-acceptance';
 
 function verifyPricingLists(path, includesPrices, excludesPrices, assert) {
-  runWithPouchDump('billing', function() {
-    authenticateUser();
-    visit(path);
-    andThen(function() {
-      assert.equal(currentURL(), path);
-      includesPrices.forEach(function(priceName) {
-        assert.equal(find(`.price-name:contains(${priceName})`).length, 1, `${priceName} displays`);
-      });
-      excludesPrices.forEach(function(priceName) {
-        assert.equal(find(`.price-name:contains(${priceName})`).length, 0, `${priceName} is not present`);
-      });
-
+  runWithPouchDump('billing', async function() {
+    await authenticateUser();
+    await visit(path);
+    assert.equal(currentURL(), path);
+    includesPrices.forEach(function(priceName) {
+      assert.equal(find(`.price-name:contains(${priceName})`).length, 1, `${priceName} displays`);
+    });
+    excludesPrices.forEach(function(priceName) {
+      assert.equal(find(`.price-name:contains(${priceName})`).length, 0, `${priceName} is not present`);
     });
   });
 }
@@ -80,165 +77,124 @@ test('visiting /pricing/ward', function(assert) {
 });
 
 test('create new price', function(assert) {
-  runWithPouchDump('billing', function() {
-    authenticateUser();
-    visit('/pricing');
-    click('button:contains(+ new item)');
-    andThen(function() {
-      assert.equal(currentURL(), '/pricing/edit/new');
-    });
-    fillIn('.price-name input', 'Xray Foot');
-    fillIn('.price-amount input', 100);
-    fillIn('.price-department input', 'Imaging');
-    select('.price-category', 'Imaging');
-    click('button:contains(Add):last');
-    waitToAppear('.modal-dialog');
-    andThen(() => {
-      assert.dom('.modal-title').hasText('Pricing Item Saved', 'Pricing Item saved');
-      click('button:contains(Ok)');
-    });
-    andThen(() => {
-      click('button:contains(Add Override)');
-      waitToAppear('.modal-dialog');
-    });
-    andThen(() => {
-      assert.dom('.modal-title').hasText('Add Override', 'Add Override Dialog displays');
-      select('.pricing-profile', 'Half off');
-      fillIn('.pricing-override-price input', 20);
-    });
-    andThen(() => {
-      click('button:contains(Add):last');
-      waitToAppear('.override-profile');
-    });
-    andThen(() => {
-      assert.dom('.override-profile').hasText('Half off', 'Pricing override saved');
-    });
+  runWithPouchDump('billing', async function() {
+    await authenticateUser();
+    await visit('/pricing');
+    await click('button:contains(+ new item)');
+    assert.equal(currentURL(), '/pricing/edit/new');
+
+    await fillIn('.price-name input', 'Xray Foot');
+    await fillIn('.price-amount input', 100);
+    await fillIn('.price-department input', 'Imaging');
+    await select('.price-category', 'Imaging');
+    await click('button:contains(Add):last');
+    await waitToAppear('.modal-dialog');
+    assert.dom('.modal-title').hasText('Pricing Item Saved', 'Pricing Item saved');
+
+    await click('button:contains(Ok)');
+    await click('button:contains(Add Override)');
+    await waitToAppear('.modal-dialog');
+    assert.dom('.modal-title').hasText('Add Override', 'Add Override Dialog displays');
+
+    await select('.pricing-profile', 'Half off');
+    await fillIn('.pricing-override-price input', 20);
+    await click('button:contains(Add):last');
+    await waitToAppear('.override-profile');
+    assert.dom('.override-profile').hasText('Half off', 'Pricing override saved');
   });
 });
 
 test('delete price', function(assert) {
-  runWithPouchDump('billing', function() {
-    authenticateUser();
-    visit('/pricing/lab');
-    andThen(function() {
-      assert.equal(currentURL(), '/pricing/lab');
-      assert.equal(find('.price-name:contains(Blood test)').length, 1, 'Price exists to delete');
-      click('button:contains(Delete)');
-    });
-    waitToAppear('.modal-dialog');
-    andThen(() => {
-      assert.dom('.alert').hasText(
-        'Are you sure you wish to delete Blood test?',
-        'Pricing item is displayed for deletion'
-      );
-    });
-    click('button:contains(Delete):last');
-    waitToDisappear('.price-name:contains(Blood test)');
-    andThen(() => {
-      assert.equal(find('.price-name:contains(Blood test)').length, 0, 'Price disappears from price list');
-    });
+  runWithPouchDump('billing', async function() {
+    await authenticateUser();
+    await visit('/pricing/lab');
+    assert.equal(currentURL(), '/pricing/lab');
+    assert.equal(find('.price-name:contains(Blood test)').length, 1, 'Price exists to delete');
+
+    await click('button:contains(Delete)');
+    await waitToAppear('.modal-dialog');
+    assert.dom('.alert').hasText(
+      'Are you sure you wish to delete Blood test?',
+      'Pricing item is displayed for deletion'
+    );
+
+    await click('button:contains(Delete):last');
+    await waitToDisappear('.price-name:contains(Blood test)');
+    assert.equal(find('.price-name:contains(Blood test)').length, 0, 'Price disappears from price list');
   });
 });
 
 test('create new pricing profile', function(assert) {
-  runWithPouchDump('billing', function() {
-    authenticateUser();
-    visit('/pricing/profiles');
-    andThen(function() {
-      assert.equal(currentURL(), '/pricing/profiles');
-      click('button:contains(+ new item)');
-      waitToAppear('.modal-dialog');
-      andThen(() => {
-        assert.dom('.modal-title').hasText('New Pricing Profile', 'New Pricing Profile modal appears');
-      });
-      fillIn('.pricing-profile-name input', 'Quarter Off');
-      fillIn('.pricing-profile-percentage input', 25);
-      fillIn('.pricing-profile-discount input', 10);
-      andThen(() => {
-        click('button:contains(Add)');
-      });
-      waitToAppear('.modal-title:contains(Pricing Profile Saved)');
-      click('button:contains(Ok)');
-      waitToAppear('.pricing-profile-name:contains(Quarter Off)');
-      andThen(() => {
-        assert.equal(find('.pricing-profile-name:contains(Quarter Off)').text(), 'Quarter Off', 'New price profile displays');
-      });
-    });
+  runWithPouchDump('billing', async function() {
+    await authenticateUser();
+    await visit('/pricing/profiles');
+    assert.equal(currentURL(), '/pricing/profiles');
+
+    await click('button:contains(+ new item)');
+    await waitToAppear('.modal-dialog');
+    assert.dom('.modal-title').hasText('New Pricing Profile', 'New Pricing Profile modal appears');
+
+    await fillIn('.pricing-profile-name input', 'Quarter Off');
+    await fillIn('.pricing-profile-percentage input', 25);
+    await fillIn('.pricing-profile-discount input', 10);
+    await click('button:contains(Add)');
+    await waitToAppear('.modal-title:contains(Pricing Profile Saved)');
+    await click('button:contains(Ok)');
+    await waitToAppear('.pricing-profile-name:contains(Quarter Off)');
+    assert.equal(find('.pricing-profile-name:contains(Quarter Off)').text(), 'Quarter Off', 'New price profile displays');
   });
 });
 
 test('delete pricing profile', function(assert) {
-  runWithPouchDump('billing', function() {
-    authenticateUser();
-    visit('/pricing/profiles');
-    andThen(function() {
-      assert.equal(currentURL(), '/pricing/profiles');
-      assert.equal(find('.pricing-profile-name:contains(Half off)').length, 1, 'Pricing profile exists to delete');
-      click('button:contains(Delete)');
-    });
-    waitToAppear('.modal-dialog');
-    andThen(() => {
-      assert.dom('.modal-title').hasText('Delete Profile', 'Pricing Profile delete confirmation is displayed');
-    });
-    click('button:contains(Ok)');
-    waitToDisappear('.pricing-profile-name:contains(Half off)');
-    andThen(() => {
-      assert.equal(find('.pricing-profile-name:contains(Half off)').length, 0, 'Pricing profile disappears from list');
-    });
+  runWithPouchDump('billing', async function() {
+    await authenticateUser();
+    await visit('/pricing/profiles');
+    assert.equal(currentURL(), '/pricing/profiles');
+    assert.equal(find('.pricing-profile-name:contains(Half off)').length, 1, 'Pricing profile exists to delete');
+
+    await click('button:contains(Delete)');
+    await waitToAppear('.modal-dialog');
+    assert.dom('.modal-title').hasText('Delete Profile', 'Pricing Profile delete confirmation is displayed');
+
+    await click('button:contains(Ok)');
+    await waitToDisappear('.pricing-profile-name:contains(Half off)');
+    assert.equal(find('.pricing-profile-name:contains(Half off)').length, 0, 'Pricing profile disappears from list');
   });
 });
 
 test('Searching pricing', function(assert) {
-  runWithPouchDump('billing', function() {
-    authenticateUser();
-    visit('/pricing');
+  runWithPouchDump('billing', async function() {
+    await authenticateUser();
+    await visit('/pricing');
 
-    fillIn('[role="search"] div input', 'Xray Hand');
-    click('.glyphicon-search');
+    await fillIn('[role="search"] div input', 'Xray Hand');
+    await click('.glyphicon-search');
+    assert.equal(currentURL(), '/pricing/search/Xray%20Hand', 'Searched for Name: Xray Hand');
+    assert.equal(find('button:contains(Delete)').length, 3, 'There are 3 search items');
 
-    andThen(() => {
-      assert.equal(currentURL(), '/pricing/search/Xray%20Hand', 'Searched for Name: Xray Hand');
-      assert.equal(find('button:contains(Delete)').length, 3, 'There are 3 search items');
-    });
+    await fillIn('[role="search"] div input', 'Blood');
+    await click('.glyphicon-search');
+    assert.equal(currentURL(), '/pricing/search/Blood', 'Searched for Name: Blood');
+    assert.equal(find('button:contains(Delete)').length, 1, 'There is one search item');
 
-    fillIn('[role="search"] div input', 'Blood');
-    click('.glyphicon-search');
+    await fillIn('[role="search"] div input', 'Leg');
+    await click('.glyphicon-search');
+    assert.equal(currentURL(), '/pricing/search/Leg', 'Searched for Name: Leg');
+    assert.equal(find('button:contains(Delete)').length, 2, 'There are 2 search items');
 
-    andThen(() => {
-      assert.equal(currentURL(), '/pricing/search/Blood', 'Searched for Name: Blood');
-      assert.equal(find('button:contains(Delete)').length, 1, 'There is one search item');
-    });
+    await fillIn('[role="search"] div input', 'Gauze');
+    await click('.glyphicon-search');
+    assert.equal(currentURL(), '/pricing/search/Gauze', 'Searched for Name: Gauze');
+    assert.equal(find('button:contains(Delete)').length, 2, 'There are 2 search items');
 
-    fillIn('[role="search"] div input', 'Leg');
-    click('.glyphicon-search');
+    await fillIn('[role="search"] div input', 'xray');
+    await click('.glyphicon-search');
+    assert.equal(currentURL(), '/pricing/search/xray', 'Searched for all lower case xray');
+    assert.equal(find('button:contains(Delete)').length, 3, 'There is one search item');
 
-    andThen(() => {
-      assert.equal(currentURL(), '/pricing/search/Leg', 'Searched for Name: Leg');
-      assert.equal(find('button:contains(Delete)').length, 2, 'There are 2 search items');
-    });
-
-    fillIn('[role="search"] div input', 'Gauze');
-    click('.glyphicon-search');
-
-    andThen(() => {
-      assert.equal(currentURL(), '/pricing/search/Gauze', 'Searched for Name: Gauze');
-      assert.equal(find('button:contains(Delete)').length, 2, 'There are 2 search items');
-    });
-
-    fillIn('[role="search"] div input', 'xray');
-    click('.glyphicon-search');
-
-    andThen(() => {
-      assert.equal(currentURL(), '/pricing/search/xray', 'Searched for all lower case xray');
-      assert.equal(find('button:contains(Delete)').length, 3, 'There is one search item');
-    });
-
-    fillIn('[role="search"] div input', 'ItemNotFound');
-    click('.glyphicon-search');
-
-    andThen(() => {
-      assert.equal(currentURL(), '/pricing/search/ItemNotFound', 'Searched for ItemNotFound');
-      assert.dom('.clickable').doesNotExist('There is no search result');
-    });
+    await fillIn('[role="search"] div input', 'ItemNotFound');
+    await click('.glyphicon-search');
+    assert.equal(currentURL(), '/pricing/search/ItemNotFound', 'Searched for ItemNotFound');
+    assert.dom('.clickable').doesNotExist('There is no search result');
   });
 });

--- a/tests/acceptance/procedure-test.js
+++ b/tests/acceptance/procedure-test.js
@@ -3,189 +3,126 @@ import moduleForAcceptance from 'hospitalrun/tests/helpers/module-for-acceptance
 
 moduleForAcceptance('Acceptance | procedures');
 
-testWithVisit('Add procedure', function(assert) {
+testWithVisit('Add procedure', async function(assert) {
   let procedureDesc = 'Release Left Elbow Bursa and Ligament, Percutaneous Approach';
   assert.dom('#visit-procedures tr').exists({ count: 2 }, 'One procedure is listed for the visit');
-  click('button:contains(New Procedure)');
-  andThen(function() {
-    typeAheadFillIn('.procedure-description', procedureDesc);
-    typeAheadFillIn('.procedure-physician', 'Dr Jones');
-    updateProcedure(assert, 'Add');
-  });
-  andThen(function() {
-    click('button:contains(Return)');
-  });
-  andThen(function() {
-    assert.equal(find('#visit-procedures tr').length, 3, 'Two procedure are listed for the visit');
-    assert.equal(find(`#visit-procedures td:contains(${procedureDesc})`).length, 1, 'New procedure description is listed for the visit');
-  });
+
+  await click('button:contains(New Procedure)');
+  await typeAheadFillIn('.procedure-description', procedureDesc);
+  await typeAheadFillIn('.procedure-physician', 'Dr Jones');
+  await updateProcedure(assert, 'Add');
+  await click('button:contains(Return)');
+  assert.equal(find('#visit-procedures tr').length, 3, 'Two procedure are listed for the visit');
+  assert.equal(find(`#visit-procedures td:contains(${procedureDesc})`).length, 1, 'New procedure description is listed for the visit');
 });
 
-testWithVisit('Edit procedure', function(assert) {
-  click('#visit-procedures button:contains(Edit)');
-  andThen(function() {
-    assert.equal(currentURL(), '/visits/procedures/edit/398B4F58-152F-1476-8ED1-329C4D85E25F', 'Procedure url is correct');
-    fillIn('.procedure-notes', 'Abdominals blood glucose level blood pressure carbohydrate medications');
-  });
-  andThen(function() {
-    click('button:contains(Add Item)');
-    waitToAppear('.modal-dialog');
-  });
-  andThen(function() {
-    assert.dom('.modal-title').hasText('Add Charge Item', 'Add Charge Item modal appears');
-    typeAheadFillIn('.charge-item-name', 'Gauze pad');
-    click('.modal-footer button:contains(Add)');
-  });
-  andThen(function() {
-    waitToDisappear('.modal-dialog');
-    waitToAppear('td.charge-item-name:contains(Gauze pad)');
-  });
-  andThen(function() {
-    assert.equal(find('td.charge-item-name:contains(Gauze pad)').length, 1, 'New charge item appears');
-    click('.charge-items tr:last button:contains(Edit)');
-    waitToAppear('.modal-dialog');
-  });
-  andThen(function() {
-    assert.dom('.modal-title').hasText('Edit Charge Item', 'Edit Charge Item modal appears');
-    typeAheadFillIn('.charge-item-name', 'Gauze padding');
-  });
-  andThen(function() {
-    click('.modal-footer button:contains(Update)');
-  });
-  andThen(function() {
-    waitToAppear('td.charge-item-name:contains(Gauze padding)');
-    waitToDisappear('.modal-dialog');
-  });
-  andThen(function() {
-    assert.equal(find('td.charge-item-name:contains(Gauze padding)').length, 1, 'Updated charge item appears');
-    assert.dom('.medication-charges tr').exists({ count: 2 }, 'One medication charge exists');
-    assert.equal(find('.medication-charges button:contains(Add Medication)').length, 1, 'Add medication button exists');
-    click('button:contains(Add Medication)');
-    waitToAppear('.modal-dialog');
-  });
-  andThen(function() {
-    assert.dom('.modal-title').hasText('Add Medication Used', 'Add Medication Used modal appears');
-    typeAheadFillIn('.medication-used', 'Cefazolin 500mg vial (Hazolin) - m00001 (999998 available)');
-    waitToDisappear('.disabled-btn:contains(Add)');
-  });
-  andThen(function() {
-    click('.modal-footer button:contains(Add)');
-  });
-  andThen(function() {
-    waitToDisappear('.modal-dialog');
-  });
-  andThen(function() {
-    updateProcedure(assert, 'Update');
-  });
-  andThen(function() {
-    assert.equal(find('.medication-charges td:contains(Cefazolin 500mg vial)').length, 2, 'Two medication charges exists');
-    click('.medication-charges button:contains(Edit):first');
-    waitToAppear('.modal-dialog');
-  });
-  andThen(function() {
-    assert.dom('.modal-title').hasText('Edit Medication Used', 'Edit Medication Used modal appears here');
-    fillIn('.medication-quantity input', 2);
-    click('.modal-footer button:contains(Update)');
-  });
-  andThen(function() {
-    waitToDisappear('.modal-dialog');
-    waitToAppear('.medication-charge-quantity:contains(2)');
-  });
-  andThen(function() {
-    assert.equal(find('.medication-charge-quantity:first').text(), '2', 'Updated medication quantity appears');
-    updateProcedure(assert, 'Update');
-  });
-  andThen(function() {
-    click('.charge-items tr:last button:contains(Delete)');
-    waitToAppear('.modal-dialog');
-  });
-  andThen(function() {
-    assert.dom('.modal-title').hasText('Delete Charge Item', 'Delete Charge Item dialog displays');
-    click('.modal-footer button:contains(Ok)');
-  });
-  andThen(function() {
-    waitToDisappear('.modal-dialog');
-    waitToDisappear('.charge-items tr:last button:contains(Delete)');
-  });
-  andThen(function() {
-    click('.medication-charges tr:last button:contains(Delete)');
-    waitToAppear('.modal-dialog');
-  });
-  andThen(function() {
-    assert.dom('.modal-title').hasText('Delete Medication Used', 'Delete Medication Used dialog displays');
-    click('.modal-footer button:contains(Ok)');
-  });
-  andThen(function() {
-    waitToDisappear('.modal-dialog');
-  });
-  andThen(function() {
-    updateProcedure(assert, 'Update');
-  });
-  andThen(function() {
-    waitToAppear('button:contains(Return)');
-  });
-  andThen(function() {
-    click('button:contains(Return)');
-  });
-  andThen(function() {
-    click('#visit-procedures button:contains(Edit)');
-  });
-  andThen(function() {
-    assert.equal(currentURL(), '/visits/procedures/edit/398B4F58-152F-1476-8ED1-329C4D85E25F', 'Returned back to procedure');
-    assert.dom('td.charge-item-name').doesNotExist('Charge item is deleted');
-    assert.dom('.medication-charges tr').exists({ count: 2 }, 'Medication used is deleted');
-  });
+testWithVisit('Edit procedure', async function(assert) {
+  await click('#visit-procedures button:contains(Edit)');
+  assert.equal(currentURL(), '/visits/procedures/edit/398B4F58-152F-1476-8ED1-329C4D85E25F', 'Procedure url is correct');
+
+  await fillIn('.procedure-notes', 'Abdominals blood glucose level blood pressure carbohydrate medications');
+  await click('button:contains(Add Item)');
+  await waitToAppear('.modal-dialog');
+  assert.dom('.modal-title').hasText('Add Charge Item', 'Add Charge Item modal appears');
+
+  await typeAheadFillIn('.charge-item-name', 'Gauze pad');
+  await click('.modal-footer button:contains(Add)');
+  await waitToDisappear('.modal-dialog');
+  await waitToAppear('td.charge-item-name:contains(Gauze pad)');
+  assert.equal(find('td.charge-item-name:contains(Gauze pad)').length, 1, 'New charge item appears');
+
+  await click('.charge-items tr:last button:contains(Edit)');
+  await waitToAppear('.modal-dialog');
+  assert.dom('.modal-title').hasText('Edit Charge Item', 'Edit Charge Item modal appears');
+
+  await typeAheadFillIn('.charge-item-name', 'Gauze padding');
+  await click('.modal-footer button:contains(Update)');
+  await waitToAppear('td.charge-item-name:contains(Gauze padding)');
+  await waitToDisappear('.modal-dialog');
+  assert.equal(find('td.charge-item-name:contains(Gauze padding)').length, 1, 'Updated charge item appears');
+  assert.dom('.medication-charges tr').exists({ count: 2 }, 'One medication charge exists');
+  assert.equal(find('.medication-charges button:contains(Add Medication)').length, 1, 'Add medication button exists');
+
+  await click('button:contains(Add Medication)');
+  await waitToAppear('.modal-dialog');
+  assert.dom('.modal-title').hasText('Add Medication Used', 'Add Medication Used modal appears');
+
+  await typeAheadFillIn('.medication-used', 'Cefazolin 500mg vial (Hazolin) - m00001 (999998 available)');
+  await waitToDisappear('.disabled-btn:contains(Add)');
+  await click('.modal-footer button:contains(Add)');
+  await waitToDisappear('.modal-dialog');
+  await updateProcedure(assert, 'Update');
+  assert.equal(find('.medication-charges td:contains(Cefazolin 500mg vial)').length, 2, 'Two medication charges exists');
+
+  await click('.medication-charges button:contains(Edit):first');
+  await waitToAppear('.modal-dialog');
+  assert.dom('.modal-title').hasText('Edit Medication Used', 'Edit Medication Used modal appears here');
+
+  await fillIn('.medication-quantity input', 2);
+  await click('.modal-footer button:contains(Update)');
+  await waitToDisappear('.modal-dialog');
+  await waitToAppear('.medication-charge-quantity:contains(2)');
+  assert.equal(find('.medication-charge-quantity:first').text(), '2', 'Updated medication quantity appears');
+
+  await updateProcedure(assert, 'Update');
+  await click('.charge-items tr:last button:contains(Delete)');
+  await waitToAppear('.modal-dialog');
+  assert.dom('.modal-title').hasText('Delete Charge Item', 'Delete Charge Item dialog displays');
+
+  await click('.modal-footer button:contains(Ok)');
+  await waitToDisappear('.modal-dialog');
+  await waitToDisappear('.charge-items tr:last button:contains(Delete)');
+  await click('.medication-charges tr:last button:contains(Delete)');
+  await waitToAppear('.modal-dialog');
+  assert.dom('.modal-title').hasText('Delete Medication Used', 'Delete Medication Used dialog displays');
+
+  await click('.modal-footer button:contains(Ok)');
+  await waitToDisappear('.modal-dialog');
+  await updateProcedure(assert, 'Update');
+  await waitToAppear('button:contains(Return)');
+  await click('button:contains(Return)');
+  await click('#visit-procedures button:contains(Edit)');
+  assert.equal(currentURL(), '/visits/procedures/edit/398B4F58-152F-1476-8ED1-329C4D85E25F', 'Returned back to procedure');
+  assert.dom('td.charge-item-name').doesNotExist('Charge item is deleted');
+  assert.dom('.medication-charges tr').exists({ count: 2 }, 'Medication used is deleted');
 });
 
-testWithVisit('Delete procedure', function(assert) {
+testWithVisit('Delete procedure', async function(assert) {
   assert.dom('#visit-procedures tr').exists({ count: 2 }, 'One procedure is displayed to delete');
-  click('#visit-procedures button:contains(Delete)');
-  waitToAppear('.modal-dialog');
-  andThen(function() {
 
-  });
-  andThen(function() {
-    assert.dom('.modal-title').hasText('Delete Procedure', 'Delete Procedure confirmation displays');
-    click('.modal-footer button:contains(Delete)');
-    waitToDisappear('.modal-dialog');
-  });
-  andThen(function() {
-    assert.dom('#visit-procedures tr').exists({ count: 1 }, 'Procedure is deleted');
-  });
+  await click('#visit-procedures button:contains(Delete)');
+  await waitToAppear('.modal-dialog');
+  assert.dom('.modal-title').hasText('Delete Procedure', 'Delete Procedure confirmation displays');
+
+  await click('.modal-footer button:contains(Delete)');
+  await waitToDisappear('.modal-dialog');
+  assert.dom('#visit-procedures tr').exists({ count: 1 }, 'Procedure is deleted');
 });
 
 function testWithVisit(testLabel, testFunction) {
   test(testLabel, function(assert) {
-    runWithPouchDump('patient', function() {
-      authenticateUser();
-      visit('/patients');
-      andThen(function() {
-        assert.equal(currentURL(), '/patients', 'Patient url is correct');
-        click('button:contains(Edit)');
-      });
-      andThen(function() {
-        assert.dom('.patient-name .ps-info-data').hasText('Joe Bagadonuts', 'Joe Bagadonuts patient record displays');
-        click('[data-test-selector=visits-tab]');
-        waitToAppear('#visits button:contains(Edit)');
-      });
-      andThen(function() {
-        click('#visits button:contains(Edit)');
-      });
-      andThen(function() {
-        assert.equal(currentURL(), '/visits/edit/03C7BF8B-04E0-DD9E-9469-96A5604F5340', 'Visit url is correct');
-        testFunction(assert);
-      });
+    runWithPouchDump('patient', async function() {
+      await authenticateUser();
+      await visit('/patients');
+      assert.equal(currentURL(), '/patients', 'Patient url is correct');
+
+      await click('button:contains(Edit)');
+      assert.dom('.patient-name .ps-info-data').hasText('Joe Bagadonuts', 'Joe Bagadonuts patient record displays');
+
+      await click('[data-test-selector=visits-tab]');
+      await waitToAppear('#visits button:contains(Edit)');
+      await click('#visits button:contains(Edit)');
+      assert.equal(currentURL(), '/visits/edit/03C7BF8B-04E0-DD9E-9469-96A5604F5340', 'Visit url is correct');
+
+      await testFunction(assert);
     });
   });
 }
 
-function updateProcedure(assert, buttonText) {
-  andThen(function() {
-    click(`.panel-footer button:contains(${buttonText})`);
-    waitToAppear('.modal-dialog');
-  });
-  andThen(function() {
-    assert.dom('.modal-title').hasText('Procedure Saved', 'Procedure Saved dialog displays');
-    click('button:contains(Ok)');
-  });
+async function updateProcedure(assert, buttonText) {
+  await click(`.panel-footer button:contains(${buttonText})`);
+  await waitToAppear('.modal-dialog');
+  assert.dom('.modal-title').hasText('Procedure Saved', 'Procedure Saved dialog displays');
+
+  await click('button:contains(Ok)');
 }

--- a/tests/acceptance/role-test.js
+++ b/tests/acceptance/role-test.js
@@ -5,69 +5,64 @@ import { PREDEFINED_USER_ROLES } from 'hospitalrun/mixins/user-roles';
 moduleForAcceptance('Acceptance | roles');
 
 test('visiting /admin/roles', function(assert) {
-  runWithPouchDump('admin', function() {
-    authenticateUser();
-    visit('/admin/roles');
-    andThen(function() {
-      assert.equal(currentURL(), '/admin/roles');
-      select('.role-select', 'Doctor');
+  runWithPouchDump('admin', async function() {
+    await authenticateUser();
+    await visit('/admin/roles');
+    assert.equal(currentURL(), '/admin/roles');
+
+    await select('.role-select', 'Doctor');
+    assert.dom('.checkbox-appointments input').isNotChecked('Appointments checkbox is not checked');
+    assert.dom('.checkbox-addAppointment input').isNotChecked('Add appointments checkbox is not checked');
+
+    await click('.checkbox-appointments input');
+    await click('.checkbox-addAppointment input');
+    assert.dom('.checkbox-appointments input').isChecked('Appointments checkbox is checked');
+    assert.dom('.checkbox-addAppointment input').isChecked('Add appointments checkbox is checked');
+
+    await click('button:contains(Update)');
+    await waitToAppear('.modal-dialog');
+    assert.dom('.modal-title').hasText('Role Saved', 'Role has been saved');
+    assert.dom('.modal-body').hasText('The Doctor role has been saved.', 'Doctor role has been saved');
+
+    await click('button:contains(Ok)');
+    await invalidateSession();
+    await visit('/login');
+
+    await authenticateUser({
+      name: 'doctor@hospitalrun.io',
+      roles: ['Doctor', 'user'],
+      role: 'Doctor',
+      prefix: 'p1'
     });
-    andThen(() => {
-      assert.dom('.checkbox-appointments input').isNotChecked('Appointments checkbox is not checked');
-      assert.dom('.checkbox-addAppointment input').isNotChecked('Add appointments checkbox is not checked');
-    });
-    click('.checkbox-appointments input');
-    click('.checkbox-addAppointment input');
-    andThen(() => {
-      assert.dom('.checkbox-appointments input').isChecked('Appointments checkbox is checked');
-      assert.dom('.checkbox-addAppointment input').isChecked('Add appointments checkbox is checked');
-      click('button:contains(Update)');
-      waitToAppear('.modal-dialog');
-    });
-    andThen(() => {
-      assert.dom('.modal-title').hasText('Role Saved', 'Role has been saved');
-      assert.dom('.modal-body').hasText('The Doctor role has been saved.', 'Doctor role has been saved');
-      click('button:contains(Ok)');
-      invalidateSession();
-      visit('/login');
-    });
-    andThen(() => {
-      authenticateUser({
-        name: 'doctor@hospitalrun.io',
-        roles: ['Doctor', 'user'],
-        role: 'Doctor',
-        prefix: 'p1'
-      });
-    });
-    visit('/appointments/edit/new');
-    andThen(function() {
-      assert.equal(currentURL(), '/appointments/edit/new', 'Doctor can now navigate to new appointments');
-      assert.dom('.view-current-title').hasText('New Appointment', 'New appointment screen displays');
-    });
+
+    await visit('/appointments/edit/new');
+    assert.equal(currentURL(), '/appointments/edit/new', 'Doctor can now navigate to new appointments');
+    assert.dom('.view-current-title').hasText('New Appointment', 'New appointment screen displays');
   });
 });
 
 PREDEFINED_USER_ROLES.forEach((role) => {
   if (role.defaultRoute && role.name !== 'User Administrator') {
     test(`Testing User Role homescreen for ${role.name}`, (assert) =>{
-      runWithPouchDump('default', () => {
-        authenticateUser({
+      runWithPouchDump('default', async function() {
+        await authenticateUser({
           roles: role.roles,
           role: role.name,
           authenticated: {
             role: role.name
           }
         });
-        visit('/');
-        waitToAppear('.view-current-title');
-        andThen(() => {
-          let defaultURL = role.defaultRoute.replace('.index', '');
-          if (defaultURL === 'users') {
-            defaultURL = 'admin/users';
-          }
-          assert.equal(currentURL(), `/${defaultURL}`, `Correct homepage displays for role ${role.name}`);
-          invalidateSession();
-        });
+
+        await visit('/');
+        await waitToAppear('.view-current-title');
+
+        let defaultURL = role.defaultRoute.replace('.index', '');
+        if (defaultURL === 'users') {
+          defaultURL = 'admin/users';
+        }
+        assert.equal(currentURL(), `/${defaultURL}`, `Correct homepage displays for role ${role.name}`);
+
+        await invalidateSession();
       });
     });
   }

--- a/tests/acceptance/users-test.js
+++ b/tests/acceptance/users-test.js
@@ -77,114 +77,100 @@ module('Acceptance | users', {
 });
 
 test('visiting /admin/users', function(assert) {
-  runWithPouchDump('default', function() {
+  runWithPouchDump('default', async function() {
     let role = PREDEFINED_USER_ROLES.findBy('name', 'User Administrator');
-    authenticateUser({
+    await authenticateUser({
       roles: role.roles,
       role: role.name,
       authenticated: {
         role: role.name
       }
     });
-    addAllUsers(assert);
-    andThen(() => {
-      visit('/'); // Default home page for User Administrator is admin/users
-      andThen(function() {
-        assert.equal(currentURL(), '/admin/users', 'User Administrator initial page displays');
-        assert.equal(find('td.user-display-name:first').text(), 'HospitalRun Administrator');
-        assert.equal(find('td.user-name:first').text(), 'hradmin');
-        assert.equal(find('td.user-email:first').text(), 'hradmin@hospitalrun.io');
-        assert.equal(find('td.user-role:first').text(), 'System Administrator');
-      });
-    });
+    await addAllUsers(assert);
+    await visit('/'); // Default home page for User Administrator is admin/users
+    assert.equal(currentURL(), '/admin/users', 'User Administrator initial page displays');
+    assert.equal(find('td.user-display-name:first').text(), 'HospitalRun Administrator');
+    assert.equal(find('td.user-name:first').text(), 'hradmin');
+    assert.equal(find('td.user-email:first').text(), 'hradmin@hospitalrun.io');
+    assert.equal(find('td.user-role:first').text(), 'System Administrator');
   });
 });
 
 test('create new user', function(assert) {
-  runWithPouchDump('default', function() {
-    authenticateUser();
-    addAllUsers(assert);
-    andThen(() => {
-      visit('/admin/users');
-      stubRequest('put', '/db/_users/org.couchdb.user:jane@donuts.com', function(request) {
-        let expectedBody = {
-          _id: 'org.couchdb.user:jane@donuts.com',
-          deleted: false,
-          displayName: 'Jane Bagadonuts',
-          email: 'jane@donuts.com',
-          name: 'jane@donuts.com',
-          password: 'password',
-          roles: ['Hospital Administrator', 'user'],
-          userPrefix: 'p02',
-          type: 'user'
-        };
-        assert.equal(request.requestBody, JSON.stringify(expectedBody), 'New user data sent to the server');
-        request.ok({
-          'ok': true,
-          'id': 'org.couchdb.user:jane@donuts.com',
-          'rev': '1-ef3d54502f2cc8e8f73d8547881f0836'
-        });
-      });
+  runWithPouchDump('default', async function() {
+    await authenticateUser();
+    await addAllUsers(assert);
 
-      visit('/admin/users/edit/new');
-      andThen(function() {
-        select('.user-role', 'Hospital Administrator');
-        fillIn('.user-display-name input', 'Jane Bagadonuts');
-        fillIn('.user-email input', 'jane@donuts.com');
-        fillIn('.user-password input', 'password');
-        click('button:contains(Add)');
-        waitToAppear('.modal-dialog');
-        andThen(() => {
-          assert.dom('.modal-title').hasText('User Saved', 'User was saved successfully');
-          assert.dom('.view-current-title').hasText('Edit User', 'Page title changed to Edit User');
-        });
-        click('button:contains(Ok)');
+    await visit('/admin/users');
+    stubRequest('put', '/db/_users/org.couchdb.user:jane@donuts.com', function(request) {
+      let expectedBody = {
+        _id: 'org.couchdb.user:jane@donuts.com',
+        deleted: false,
+        displayName: 'Jane Bagadonuts',
+        email: 'jane@donuts.com',
+        name: 'jane@donuts.com',
+        password: 'password',
+        roles: ['Hospital Administrator', 'user'],
+        userPrefix: 'p02',
+        type: 'user'
+      };
+      assert.equal(request.requestBody, JSON.stringify(expectedBody), 'New user data sent to the server');
+      request.ok({
+        'ok': true,
+        'id': 'org.couchdb.user:jane@donuts.com',
+        'rev': '1-ef3d54502f2cc8e8f73d8547881f0836'
       });
     });
+
+    await visit('/admin/users/edit/new');
+    await select('.user-role', 'Hospital Administrator');
+    await fillIn('.user-display-name input', 'Jane Bagadonuts');
+    await fillIn('.user-email input', 'jane@donuts.com');
+    await fillIn('.user-password input', 'password');
+    await click('button:contains(Add)');
+    await waitToAppear('.modal-dialog');
+    assert.dom('.modal-title').hasText('User Saved', 'User was saved successfully');
+    assert.dom('.view-current-title').hasText('Edit User', 'Page title changed to Edit User');
+
+    await click('button:contains(Ok)');
   });
 });
 
 test('delete user', function(assert) {
-  runWithPouchDump('default', function() {
-    authenticateUser();
-    addAllUsers(assert);
-    andThen(() => {
-      stubRequest('put', '/db/_users/org.couchdb.user:joe@donuts.com', function(request) {
-        let expectedBody = {
-          _id: 'org.couchdb.user:joe@donuts.com',
-          derived_key: 'derivedkeyhere',
-          deleted: true,
-          displayName: 'Joe Bagadonuts',
-          email: 'joe@donuts.com',
-          iterations: 10,
-          name: 'joe@donuts.com',
-          password_scheme: 'pbkdf2',
-          _rev: '1-ef3d54502f2cc8e8f73d8547881f0836',
-          roles: ['deleted'],
-          salt: 'saltgoeshere',
-          userPrefix: 'p01',
-          type: 'user'
-        };
-        assert.equal(request.requestBody, JSON.stringify(expectedBody), 'Delete user request sent to the server');
-        request.ok({
-          'ok': true,
-          'id': 'org.couchdb.user:joe@donuts.com',
-          'rev': '1-ef3d54502f2cc8e8f73d8547881f0836'
-        });
-      });
+  runWithPouchDump('default', async function() {
+    await authenticateUser();
+    await addAllUsers(assert);
 
-      visit('/admin/users');
-      andThen(function() {
-        click('button:contains(Delete):last');
-        waitToAppear('.modal-dialog');
-        andThen(() => {
-          assert.dom('.alert').hasText('Are you sure you wish to delete ?', 'User is displayed for deletion');
-        });
-        click('button:contains(Delete):last');
-        andThen(() => {
-          assert.equal(find('.user-email:contains(joe@donuts.com)').length, 0, 'User disappears from user list');
-        });
+    stubRequest('put', '/db/_users/org.couchdb.user:joe@donuts.com', function(request) {
+      let expectedBody = {
+        _id: 'org.couchdb.user:joe@donuts.com',
+        derived_key: 'derivedkeyhere',
+        deleted: true,
+        displayName: 'Joe Bagadonuts',
+        email: 'joe@donuts.com',
+        iterations: 10,
+        name: 'joe@donuts.com',
+        password_scheme: 'pbkdf2',
+        _rev: '1-ef3d54502f2cc8e8f73d8547881f0836',
+        roles: ['deleted'],
+        salt: 'saltgoeshere',
+        userPrefix: 'p01',
+        type: 'user'
+      };
+      assert.equal(request.requestBody, JSON.stringify(expectedBody), 'Delete user request sent to the server');
+      request.ok({
+        'ok': true,
+        'id': 'org.couchdb.user:joe@donuts.com',
+        'rev': '1-ef3d54502f2cc8e8f73d8547881f0836'
       });
     });
+
+    await visit('/admin/users');
+    await click('button:contains(Delete):last');
+    await waitToAppear('.modal-dialog');
+    assert.dom('.alert').hasText('Are you sure you wish to delete ?', 'User is displayed for deletion');
+
+    await click('button:contains(Delete):last');
+    assert.equal(find('.user-email:contains(joe@donuts.com)').length, 0, 'User disappears from user list');
   });
 });

--- a/tests/acceptance/visit-test.js
+++ b/tests/acceptance/visit-test.js
@@ -39,502 +39,360 @@ const opdReportTestCases = {
 moduleForAcceptance('Acceptance | visits');
 
 test('Add admission visit', function(assert) {
-  runWithPouchDump('patient', function() {
-    authenticateUser();
-    addVisit(assert);
-    andThen(() => {
-      addAdmissionData(assert);
-    });
-    andThen(() => {
-      newReport(assert, 'Discharge');
-    });
-    andThen(() => {
-      checkDischargeReport(assert);
-    });
-    andThen(() => {
-      saveReport(assert, 'Discharge');
-    });
-    andThen(() => {
-      viewReport(assert, 'Discharge');
-    });
+  runWithPouchDump('patient', async function() {
+    await authenticateUser();
+    await addVisit(assert);
+    await addAdmissionData(assert);
+    await newReport(assert, 'Discharge');
+    await checkDischargeReport(assert);
+    await saveReport(assert, 'Discharge');
+    await viewReport(assert, 'Discharge');
   });
 });
 
 for (let testCase in opdReportTestCases) {
   test(testCase, function(assert) {
-    runWithPouchDump('patient', function() {
-      authenticateUser();
+    runWithPouchDump('patient', async function() {
+      await authenticateUser();
 
-      (opdReportTestCases[testCase].customForms || []).forEach((f) => {
-        createCustomFormForType(f.type, f.alwaysIncluded);
-      });
+      for (let f of (opdReportTestCases[testCase].customForms || [])) {
+        await createCustomFormForType(f.type, f.alwaysIncluded);
+      }
 
-      addVisit(assert, 'Clinic');
-      andThen(() => {
-        addOutpatientData(assert, opdReportTestCases[testCase]);
-      });
-      andThen(() => {
-        newReport(assert, 'OPD');
-      });
-      andThen(() => {
-        checkOPDReport(assert);
-      });
-      andThen(() => {
-        saveReport(assert, 'OPD');
-      });
-      andThen(() => {
-        viewReport(assert, 'OPD', opdReportTestCases[testCase]);
-      });
+      await addVisit(assert, 'Clinic');
+      await addOutpatientData(assert, opdReportTestCases[testCase]);
+      await newReport(assert, 'OPD');
+      await checkOPDReport(assert);
+      await saveReport(assert, 'OPD');
+      await viewReport(assert, 'OPD', opdReportTestCases[testCase]);
     });
   });
 }
 
 test('Edit visit', function(assert) {
-  runWithPouchDump('patient', function() {
-    authenticateUser();
-    visit('/patients');
-    andThen(function() {
-      assert.equal(currentURL(), '/patients', 'Patient url is correct');
-      click('button:contains(Edit)');
-    });
-    andThen(function() {
-      assert.dom('.patient-name .ps-info-data').hasText('Joe Bagadonuts', 'Joe Bagadonuts patient record displays');
-      click('[data-test-selector=visits-tab]');
-      waitToAppear('#visits button:contains(Edit)');
-    });
-    andThen(function() {
-      click('#visits button:contains(Edit)');
-    });
-    andThen(function() {
-      assert.equal(currentURL(), '/visits/edit/03C7BF8B-04E0-DD9E-9469-96A5604F5340', 'Visit url is correct');
-      click('a:contains(Add Allergy)');
-      waitToAppear('.modal-dialog');
-    });
-    andThen(function() {
-      assert.dom('.modal-title').hasText('Add Allergy', 'Add Allergy dialog displays');
-      fillIn('.test-allergy input', 'Oatmeal');
-      click('.modal-footer button:contains(Add)');
-      waitToDisappear('.modal-dialog');
-    });
-    andThen(function() {
-      assert.equal(find('a.allergy-button:contains(Oatmeal)').length, 1, 'New allergy appears');
-      click('a:contains(Add Diagnosis)');
-      waitToAppear('.modal-dialog');
-    });
-    andThen(function() {
-      assert.dom('.modal-title').hasText('Add Diagnosis', 'Add Diagnosis dialog displays');
-      fillIn('.diagnosis-text input', 'Broken Arm');
-      click('.modal-footer button:contains(Add)');
-      waitToAppear('a.primary-diagnosis');
-    });
-    andThen(function() {
-      assert.equal(find('a.primary-diagnosis:contains(Broken Arm)').length, 1, 'New primary diagnosis appears');
-      click('button:contains(New Medication)');
-    });
-    andThen(function() {
-      assert.equal(currentURL(), '/medication/edit/new?forVisitId=03C7BF8B-04E0-DD9E-9469-96A5604F5340', 'New medication url is correct');
-      assert.dom('.patient-name .ps-info-data').hasText('Joe Bagadonuts', 'New medication prepopulates with patient');
-      click('button:contains(Cancel)');
-    });
-    andThen(function() {
-      click('button:contains(New Lab)');
-    });
-    andThen(function() {
-      assert.equal(currentURL(), '/labs/edit/new?forVisitId=03C7BF8B-04E0-DD9E-9469-96A5604F5340', 'New lab url is correct');
-      assert.dom('.patient-name .ps-info-data').hasText('Joe Bagadonuts', 'New lab prepopulates with patient');
-      click('button:contains(Cancel)');
-    });
-    andThen(function() {
-      click('button:contains(New Imaging)');
-    });
-    andThen(function() {
-      assert.equal(currentURL(), '/imaging/edit/new?forVisitId=03C7BF8B-04E0-DD9E-9469-96A5604F5340', 'New imaging url is correct');
-      assert.dom('.patient-name .ps-info-data').hasText('Joe Bagadonuts', 'New imaging prepopulates with patient');
-      click('button:contains(Cancel)');
-    });
-    andThen(function() {
-      click('button:contains(New Vitals)');
-      waitToAppear('.modal-dialog');
-    });
-    andThen(function() {
-      fillIn('.temperature-text input', '34.56');
-      fillIn('.weight-text input', '34.56');
-      fillIn('.height-text input', '34.56');
-      fillIn('.sbp-text input', '34.56');
-      fillIn('.dbp-text input', '34.56');
-      fillIn('.heart-rate-text input', '34.56');
-      fillIn('.respiratory-rate-text input', '34.56');
-      click('.modal-footer button:contains(Add)');
-      waitToAppear('#visit-vitals tr:last td:contains(34.56)');
-    });
-    andThen(function() {
-      assert.equal(find('#visit-vitals tr:last td:contains(34.56)').length, 7, 'New vitals appears');
-      click('button:contains(Add Item)');
-      waitToAppear('.modal-dialog');
-    });
-    andThen(function() {
-      typeAheadFillIn('.charge-item-name', 'Gauze pad');
-      click('.modal-footer button:contains(Add)');
-    });
-    andThen(function() {
-      waitToDisappear('.modal-dialog');
-      waitToAppear('td.charge-item-name');
-    });
-    andThen(function() {
-      assert.dom('td.charge-item-name').hasText('Gauze pad', 'New charge item appears');
-    });
-    andThen(function() {
-      updateVisit(assert, 'Update');
-    });
-    andThen(function() {
-      click('a.primary-diagnosis:contains(Broken Arm)');
-      waitToAppear('.modal-dialog');
-    });
-    andThen(function() {
-      assert.dom('.modal-title').hasText('Edit Diagnosis', 'Edit Diagnosis modal appears');
-      assert.equal(find('.modal-footer button:contains(Delete)').length, 1, 'Delete button appears');
-    });
-    andThen(function() {
-      click('.modal-footer button:contains(Delete)');
-    });
-    andThen(function() {
-      waitToDisappear('.modal-dialog');
-    });
-    andThen(function() {
-      click('#visit-vitals tr:last button:contains(Delete)');
-      waitToAppear('.modal-dialog');
-    });
-    andThen(function() {
-      assert.dom('.modal-title').hasText('Delete Vitals', 'Delete Vitals dialog displays');
-      click('.modal-footer button:contains(Delete)');
-      click('[data-test-selector=charges-tab]');
-    });
-    andThen(function() {
-      click('.charge-items tr:last button:contains(Delete)');
-      waitToAppear('.modal-dialog');
-    });
-    andThen(function() {
-      assert.dom('.modal-title').hasText('Delete Charge Item', 'Delete Charge Item dialog displays');
-      click('.modal-footer button:contains(Ok)');
-    });
-    andThen(function() {
-      waitToDisappear('.modal-dialog');
-    });
-    andThen(function() {
-      assert.equal(find('a.primary-diagnosis:contains(Broken Arm)').length, 0, 'New primary diagnosis is deleted');
-      assert.equal(find('#visit-vitals tr:last td:contains(34.56)').length, 0, 'Vital is deleted');
-      assert.dom('td.charge-item-name').doesNotExist('Charge item is deleted');
-    });
+  runWithPouchDump('patient', async function() {
+    await authenticateUser();
+    await visit('/patients');
+    assert.equal(currentURL(), '/patients', 'Patient url is correct');
+
+    await click('button:contains(Edit)');
+    assert.dom('.patient-name .ps-info-data').hasText('Joe Bagadonuts', 'Joe Bagadonuts patient record displays');
+
+    await click('[data-test-selector=visits-tab]');
+    await waitToAppear('#visits button:contains(Edit)');
+    await click('#visits button:contains(Edit)');
+    assert.equal(currentURL(), '/visits/edit/03C7BF8B-04E0-DD9E-9469-96A5604F5340', 'Visit url is correct');
+
+    await click('a:contains(Add Allergy)');
+    await waitToAppear('.modal-dialog');
+    assert.dom('.modal-title').hasText('Add Allergy', 'Add Allergy dialog displays');
+
+    await fillIn('.test-allergy input', 'Oatmeal');
+    await click('.modal-footer button:contains(Add)');
+    await waitToDisappear('.modal-dialog');
+    assert.equal(find('a.allergy-button:contains(Oatmeal)').length, 1, 'New allergy appears');
+
+    await click('a:contains(Add Diagnosis)');
+    await waitToAppear('.modal-dialog');
+    assert.dom('.modal-title').hasText('Add Diagnosis', 'Add Diagnosis dialog displays');
+
+    await fillIn('.diagnosis-text input', 'Broken Arm');
+    await click('.modal-footer button:contains(Add)');
+    await waitToAppear('a.primary-diagnosis');
+    assert.equal(find('a.primary-diagnosis:contains(Broken Arm)').length, 1, 'New primary diagnosis appears');
+
+    await click('button:contains(New Medication)');
+    assert.equal(currentURL(), '/medication/edit/new?forVisitId=03C7BF8B-04E0-DD9E-9469-96A5604F5340', 'New medication url is correct');
+    assert.dom('.patient-name .ps-info-data').hasText('Joe Bagadonuts', 'New medication prepopulates with patient');
+
+    await click('button:contains(Cancel)');
+    await click('button:contains(New Lab)');
+    assert.equal(currentURL(), '/labs/edit/new?forVisitId=03C7BF8B-04E0-DD9E-9469-96A5604F5340', 'New lab url is correct');
+    assert.dom('.patient-name .ps-info-data').hasText('Joe Bagadonuts', 'New lab prepopulates with patient');
+
+    await click('button:contains(Cancel)');
+    await click('button:contains(New Imaging)');
+    assert.equal(currentURL(), '/imaging/edit/new?forVisitId=03C7BF8B-04E0-DD9E-9469-96A5604F5340', 'New imaging url is correct');
+    assert.dom('.patient-name .ps-info-data').hasText('Joe Bagadonuts', 'New imaging prepopulates with patient');
+
+    await click('button:contains(Cancel)');
+    await click('button:contains(New Vitals)');
+    waitToAppear('.modal-dialog');
+
+    await fillIn('.temperature-text input', '34.56');
+    await fillIn('.weight-text input', '34.56');
+    await fillIn('.height-text input', '34.56');
+    await fillIn('.sbp-text input', '34.56');
+    await fillIn('.dbp-text input', '34.56');
+    await fillIn('.heart-rate-text input', '34.56');
+    await fillIn('.respiratory-rate-text input', '34.56');
+    await click('.modal-footer button:contains(Add)');
+    await waitToAppear('#visit-vitals tr:last td:contains(34.56)');
+    assert.equal(find('#visit-vitals tr:last td:contains(34.56)').length, 7, 'New vitals appears');
+
+    await click('button:contains(Add Item)');
+    await waitToAppear('.modal-dialog');
+    await typeAheadFillIn('.charge-item-name', 'Gauze pad');
+    await click('.modal-footer button:contains(Add)');
+    await waitToDisappear('.modal-dialog');
+    await waitToAppear('td.charge-item-name');
+    assert.dom('td.charge-item-name').hasText('Gauze pad', 'New charge item appears');
+
+    await updateVisit(assert, 'Update');
+    await click('a.primary-diagnosis:contains(Broken Arm)');
+    await waitToAppear('.modal-dialog');
+    assert.dom('.modal-title').hasText('Edit Diagnosis', 'Edit Diagnosis modal appears');
+    assert.equal(find('.modal-footer button:contains(Delete)').length, 1, 'Delete button appears');
+
+    await click('.modal-footer button:contains(Delete)');
+    await waitToDisappear('.modal-dialog');
+    await click('#visit-vitals tr:last button:contains(Delete)');
+    await waitToAppear('.modal-dialog');
+    assert.dom('.modal-title').hasText('Delete Vitals', 'Delete Vitals dialog displays');
+
+    await click('.modal-footer button:contains(Delete)');
+    await click('[data-test-selector=charges-tab]');
+    await click('.charge-items tr:last button:contains(Delete)');
+    await waitToAppear('.modal-dialog');
+    assert.dom('.modal-title').hasText('Delete Charge Item', 'Delete Charge Item dialog displays');
+
+    await click('.modal-footer button:contains(Ok)');
+    await waitToDisappear('.modal-dialog');
+    assert.equal(find('a.primary-diagnosis:contains(Broken Arm)').length, 0, 'New primary diagnosis is deleted');
+    assert.equal(find('#visit-vitals tr:last td:contains(34.56)').length, 0, 'Vital is deleted');
+    assert.dom('td.charge-item-name').doesNotExist('Charge item is deleted');
   });
 });
 
 test('Delete visit', function(assert) {
-  runWithPouchDump('patient', function() {
-    authenticateUser();
-    visit('/patients');
-    andThen(function() {
-      assert.equal(currentURL(), '/patients', 'Patient url is correct');
-      click('button:contains(Edit)');
-    });
-    andThen(function() {
-      assert.dom('.patient-name .ps-info-data').hasText('Joe Bagadonuts', 'Joe Bagadonuts patient record displays');
-      click('[data-test-selector=visits-tab]');
-      waitToAppear('#visits button:contains(Delete)'); // Make sure visits have been retrieved.
-    });
-    andThen(function() {
-      assert.dom('#visits tr').exists({ count: 2 }, 'One visit is displayed to delete');
-      click('#visits button:contains(Delete)');
-      waitToAppear('.modal-dialog');
-    });
-    andThen(function() {
-      assert.dom('.modal-title').hasText('Delete Visit', 'Delete Visit confirmation displays');
-      click('.modal-footer button:contains(Delete)');
-    });
-    andThen(function() {
-      waitToDisappear('.modal-dialog');
-      waitToDisappear('#visits td:contains(Fall from in-line roller-skates, initial encounter)');
-    });
-    andThen(function() {
-      assert.dom('#visits tr').exists({ count: 1 }, 'Visit is deleted');
-    });
+  runWithPouchDump('patient', async function() {
+    await authenticateUser();
+    await visit('/patients');
+    assert.equal(currentURL(), '/patients', 'Patient url is correct');
+
+    await click('button:contains(Edit)');
+    assert.dom('.patient-name .ps-info-data').hasText('Joe Bagadonuts', 'Joe Bagadonuts patient record displays');
+
+    await click('[data-test-selector=visits-tab]');
+    await waitToAppear('#visits button:contains(Delete)'); // Make sure visits have been retrieved.
+    assert.dom('#visits tr').exists({ count: 2 }, 'One visit is displayed to delete');
+
+    await click('#visits button:contains(Delete)');
+    await waitToAppear('.modal-dialog');
+    assert.dom('.modal-title').hasText('Delete Visit', 'Delete Visit confirmation displays');
+
+    await click('.modal-footer button:contains(Delete)');
+    await waitToDisappear('.modal-dialog');
+    await waitToDisappear('#visits td:contains(Fall from in-line roller-skates, initial encounter)');
+    assert.dom('#visits tr').exists({ count: 1 }, 'Visit is deleted');
   });
 });
 
-function addVisit(assert, type) {
-  visit('/patients');
-  andThen(function() {
-    assert.equal(currentURL(), '/patients', 'Patient url is correct');
-    click('button:contains(Edit)');
-  });
-  andThen(function() {
-    assert.dom('.patient-name .ps-info-data').hasText(PATIENT, `${PATIENT} patient record displays`);
-    click('[data-test-selector=visits-tab]');
-    waitToAppear('#visits button:contains(Edit)');
-  });
-  andThen(function() {
-    click('#visits button:contains(New Visit)');
-    waitToAppear('#visit-info');
-  });
-  andThen(function() {
-    assert.dom('.patient-name .ps-info-data').hasText(PATIENT, `${PATIENT} displays as patient for visit`);
-    updateVisit(assert, 'Add', type);
-  });
+async function addVisit(assert, type) {
+  await visit('/patients');
+  assert.equal(currentURL(), '/patients', 'Patient url is correct');
+
+  await click('button:contains(Edit)');
+  assert.dom('.patient-name .ps-info-data').hasText(PATIENT, `${PATIENT} patient record displays`);
+
+  await click('[data-test-selector=visits-tab]');
+  await waitToAppear('#visits button:contains(Edit)');
+
+  await click('#visits button:contains(New Visit)');
+  await waitToAppear('#visit-info');
+  assert.dom('.patient-name .ps-info-data').hasText(PATIENT, `${PATIENT} displays as patient for visit`);
+
+  await updateVisit(assert, 'Add', type);
 }
 
-function addOutpatientData(assert, testCase) {
-  typeAheadFillIn('.visit-location', LOCATION);
-  typeAheadFillIn('.visit-examiner', EXAMINER);
-  andThen(() => {
-    click('a:contains(Add Diagnosis)');
-    waitToAppear('.modal-dialog');
-  });
-  andThen(() => {
-    assert.dom('.modal-title').hasText('Add Diagnosis', 'Add Diagnosis dialog displays');
-    fillIn('.diagnosis-text input', PRIMARY_DIAGNOSIS);
-    click('.modal-footer button:contains(Add)');
-  });
-  andThen(function() {
-    waitToDisappear('.modal-dialog');
-  });
-  andThen(() => {
-    click('a:contains(Add Diagnosis)');
-    waitToAppear('.modal-dialog');
-  });
-  andThen(() => {
-    assert.dom('.modal-title').hasText('Add Diagnosis', 'Add Diagnosis dialog displays');
-    fillIn('.diagnosis-text input', SECONDARY_DIAGNOSIS);
-    click('.secondary-diagnosis input');
-  });
-  andThen(() => {
-    click('.modal-footer button:contains(Add)');
-  });
-  andThen(function() {
-    waitToDisappear('.modal-dialog');
-    waitToAppear(`a.secondary-diagnosis:contains(${SECONDARY_DIAGNOSIS})`);
-  });
-  andThen(() => {
-    click('a:contains(Add Operative Plan)');
-  });
-  andThen(() => {
-    assert.ok(currentURL().indexOf('/patients/operative-plan/new?forVisitId') > -1, 'New operative plan URL is visited');
-    assert.dom('.patient-name .ps-info-data').hasText(PATIENT, `${PATIENT} patient header displays`);
-    assert.dom('.view-current-title').hasText('New Operative Plan', 'New operative plan title is correct');
-    fillIn('.operation-description textarea', OPERATION_DESCRIPTION);
-    typeAheadFillIn('.procedure-description', PROCEDURE_SPLINT);
-    click('button:contains(Add Procedure)');
-    waitToAppear('.procedure-listing td.procedure-description');
-    fillIn('.admission-instructions textarea', ADMISSION_INSTRUCTIONS);
-  });
-  updateVisitData(assert, 'Plan Saved');
-  andThen(() => {
-    click('[data-test-selector=procedures-tab]');
-    waitToAppear('[data-test-selector=new-procedure-btn]');
-    assert.dom('[data-test-selector=new-procedure-btn]').hasText('New Procedure', 'New Procedure button displayed');
-    click('[data-test-selector=new-procedure-btn]');
-  });
-  andThen(() => {
-    assert.ok(currentURL().indexOf('visits/procedures/edit/new?forVisitId') > -1, 'New Procedures URL is visited');
-    typeAheadFillIn('.procedure-description', OPD_PROCEDURE_DESCRIPTION);
-    typeAheadFillIn('.procedure-physician', OPD_PROCEDURE_PHYSICIAN);
-  });
-  updateVisitData(assert, 'Procedure Saved');
-  andThen(() => {
-    click('button:contains(New Lab)');
-  });
-  andThen(() => {
-    assert.ok(currentURL().indexOf('/labs/edit/new?forVisitId') > -1, 'New Lab URL is visited');
-    typeAheadFillIn('.test-lab-type', LAB_TYPE);
-    (testCase.customForms || []).forEach((f) => {
-      if (!f.alwaysIncluded) {
-        attachCustomForm(f.name);
-      }
-      fillCustomForm(f.name);
-    });
-  });
-  updateVisitData(assert, 'Lab Request Saved');
-  andThen(() => {
-    click('button:contains(New Imaging)');
-  });
-  andThen(() => {
-    assert.ok(currentURL().indexOf('/imaging/edit/new?forVisitId') > -1, 'New Imaging URL is visited');
-    typeAheadFillIn('.imaging-type-input', IMAGING_TYPE);
-  });
-  updateVisitData(assert, 'Imaging Request Saved');
-  andThen(() => {
-    click('button:contains(New Appointment)');
-  });
-  andThen(() => {
-    assert.ok(currentURL().indexOf('/appointments/edit/new?forVisitId') > -1, 'New Appointment URL is visited');
-    click('.appointment-all-day input');
-    fillIn('.test-appointment-start input', APPOINTMENT_START_DATE);
-    fillIn('.test-appointment-end input', APPOINTMENT_END_DATE);
-  });
-  updateVisitData(assert, 'Appointment Saved');
-  andThen(function() {
-    click('[data-test-selector=notes-tab]');
-    waitToAppear('[data-test-selector=new-note-btn]');
-    click('[data-test-selector=new-note-btn]');
-  });
-  andThen(() => {
-    assert.dom('.modal-title').hasText(`New Note for ${PATIENT}`, 'New Note dialog displays');
-    fillIn('.test-note-content textarea', NOTE_CONTENT);
-    click('.modal-footer button:contains(Add)');
-  });
-  andThen(function() {
-    waitToDisappear('.modal-dialog');
-  });
-  andThen(() => {
-    assert.ok(currentURL().indexOf('visits/edit/') > -1, 'Returns back to visit URL');
-  });
+async function addOutpatientData(assert, testCase) {
+  await typeAheadFillIn('.visit-location', LOCATION);
+  await typeAheadFillIn('.visit-examiner', EXAMINER);
+  await click('a:contains(Add Diagnosis)');
+  await waitToAppear('.modal-dialog');
+  assert.dom('.modal-title').hasText('Add Diagnosis', 'Add Diagnosis dialog displays');
+
+  await fillIn('.diagnosis-text input', PRIMARY_DIAGNOSIS);
+  await click('.modal-footer button:contains(Add)');
+  await waitToDisappear('.modal-dialog');
+  await click('a:contains(Add Diagnosis)');
+  await waitToAppear('.modal-dialog');
+  assert.dom('.modal-title').hasText('Add Diagnosis', 'Add Diagnosis dialog displays');
+
+  await fillIn('.diagnosis-text input', SECONDARY_DIAGNOSIS);
+  await click('.secondary-diagnosis input');
+  await click('.modal-footer button:contains(Add)');
+  await waitToDisappear('.modal-dialog');
+  await waitToAppear(`a.secondary-diagnosis:contains(${SECONDARY_DIAGNOSIS})`);
+  await click('a:contains(Add Operative Plan)');
+  assert.ok(currentURL().indexOf('/patients/operative-plan/new?forVisitId') > -1, 'New operative plan URL is visited');
+  assert.dom('.patient-name .ps-info-data').hasText(PATIENT, `${PATIENT} patient header displays`);
+  assert.dom('.view-current-title').hasText('New Operative Plan', 'New operative plan title is correct');
+
+  await fillIn('.operation-description textarea', OPERATION_DESCRIPTION);
+  await typeAheadFillIn('.procedure-description', PROCEDURE_SPLINT);
+  await click('button:contains(Add Procedure)');
+  await waitToAppear('.procedure-listing td.procedure-description');
+  await fillIn('.admission-instructions textarea', ADMISSION_INSTRUCTIONS);
+  await updateVisitData(assert, 'Plan Saved');
+  await click('[data-test-selector=procedures-tab]');
+  await waitToAppear('[data-test-selector=new-procedure-btn]');
+  assert.dom('[data-test-selector=new-procedure-btn]').hasText('New Procedure', 'New Procedure button displayed');
+
+  await click('[data-test-selector=new-procedure-btn]');
+  assert.ok(currentURL().indexOf('visits/procedures/edit/new?forVisitId') > -1, 'New Procedures URL is visited');
+
+  await typeAheadFillIn('.procedure-description', OPD_PROCEDURE_DESCRIPTION);
+  await typeAheadFillIn('.procedure-physician', OPD_PROCEDURE_PHYSICIAN);
+  await updateVisitData(assert, 'Procedure Saved');
+  await click('button:contains(New Lab)');
+  assert.ok(currentURL().indexOf('/labs/edit/new?forVisitId') > -1, 'New Lab URL is visited');
+
+  await typeAheadFillIn('.test-lab-type', LAB_TYPE);
+
+  for (let f of (testCase.customForms || [])) {
+    if (!f.alwaysIncluded) {
+      await attachCustomForm(f.name);
+    }
+    await fillCustomForm(f.name);
+  }
+
+  await updateVisitData(assert, 'Lab Request Saved');
+  await click('button:contains(New Imaging)');
+  assert.ok(currentURL().indexOf('/imaging/edit/new?forVisitId') > -1, 'New Imaging URL is visited');
+
+  await typeAheadFillIn('.imaging-type-input', IMAGING_TYPE);
+  await updateVisitData(assert, 'Imaging Request Saved');
+  await click('button:contains(New Appointment)');
+  assert.ok(currentURL().indexOf('/appointments/edit/new?forVisitId') > -1, 'New Appointment URL is visited');
+
+  await click('.appointment-all-day input');
+  await fillIn('.test-appointment-start input', APPOINTMENT_START_DATE);
+  await fillIn('.test-appointment-end input', APPOINTMENT_END_DATE);
+  await updateVisitData(assert, 'Appointment Saved');
+  await click('[data-test-selector=notes-tab]');
+  await waitToAppear('[data-test-selector=new-note-btn]');
+  await click('[data-test-selector=new-note-btn]');
+  assert.dom('.modal-title').hasText(`New Note for ${PATIENT}`, 'New Note dialog displays');
+
+  await fillIn('.test-note-content textarea', NOTE_CONTENT);
+  await click('.modal-footer button:contains(Add)');
+  await waitToDisappear('.modal-dialog');
+  assert.ok(currentURL().indexOf('visits/edit/') > -1, 'Returns back to visit URL');
 }
 
-function addAdmissionData(assert) {
-  typeAheadFillIn('.visit-examiner', EXAMINER);
-  andThen(function() {
-    click('[data-test-selector=notes-tab]');
-    waitToAppear('[data-test-selector=new-note-btn]');
-    click('[data-test-selector=new-note-btn]');
-  });
-  andThen(() => {
-    assert.dom('.modal-title').hasText('New Note for Joe Bagadonuts', 'New Note dialog displays');
-    fillIn('.test-note-content textarea', NOTE_CONTENT);
-    click('.modal-footer button:contains(Add)');
-  });
-  andThen(function() {
-    waitToDisappear('.modal-dialog');
-  });
-  andThen(() => {
-    assert.ok(currentURL().indexOf('visits/edit/') > -1, 'Returns back to visit URL');
-  });
+async function addAdmissionData(assert) {
+  await typeAheadFillIn('.visit-examiner', EXAMINER);
+  await click('[data-test-selector=notes-tab]');
+  await waitToAppear('[data-test-selector=new-note-btn]');
+  await click('[data-test-selector=new-note-btn]');
+  assert.dom('.modal-title').hasText('New Note for Joe Bagadonuts', 'New Note dialog displays');
+
+  await fillIn('.test-note-content textarea', NOTE_CONTENT);
+  await click('.modal-footer button:contains(Add)');
+  await waitToDisappear('.modal-dialog');
+  assert.ok(currentURL().indexOf('visits/edit/') > -1, 'Returns back to visit URL');
 }
 
-function newReport(assert, type) {
-  andThen(function() {
-    click('[data-test-selector=reports-tab]');
-    waitToAppear('[data-test-selector=report-btn]');
-    assert.dom('[data-test-selector=report-btn]').hasText(
-      `New ${type} Report`,
-      'Discharge report can be created for this type of visit'
-    );
-    click('[data-test-selector=report-btn]');
-  });
-  andThen(function() {
-    assert.ok(currentURL().indexOf('visits/reports/edit/new') > -1, 'Report url is correct');
-    assert.dom('.view-current-title').hasText(`New ${type} Report`, `${type} report title displayed correctly`);
-    assert.dom('.patient-name .ps-info-data').hasText(PATIENT, 'Patient record displays');
-  });
+async function newReport(assert, type) {
+  await click('[data-test-selector=reports-tab]');
+  await waitToAppear('[data-test-selector=report-btn]');
+  assert.dom('[data-test-selector=report-btn]').hasText(
+    `New ${type} Report`,
+    'Discharge report can be created for this type of visit'
+  );
+
+  await click('[data-test-selector=report-btn]');
+  assert.ok(currentURL().indexOf('visits/reports/edit/new') > -1, 'Report url is correct');
+  assert.dom('.view-current-title').hasText(`New ${type} Report`, `${type} report title displayed correctly`);
+  assert.dom('.patient-name .ps-info-data').hasText(PATIENT, 'Patient record displays');
 }
 
 function checkOPDReport(assert) {
-  andThen(() => {
-    assert.dom('.patient-id .ps-info-data').hasText(PATIENT_ID, 'Patient ID is displayed');
-    assert.dom('.patient-name .ps-info-data').hasText(PATIENT, 'Patient First Name & Last Name is displayed');
-    assert.dom('.test-visit-date .test-visit-date-label').hasText('Date of Visit:', 'Visit date label displayed');
-    assert.ok(!isEmpty(find('.test-visit-date .test-visit-date-data').text()), 'Visit date is displayed');
-    findWithAssert('.test-visit-type .test-visit-type-label:contains(Visit Type)');
-    assert.dom('.test-visit-type .test-visit-type-data').hasText('Clinic', 'Visit Type is displayed');
-    findWithAssert('.test-examiner .test-examiner-label:contains(Examiner)');
-    assert.dom('.test-examiner .test-examiner-data').hasText(EXAMINER, 'Visit Examiner is displayed');
-    findWithAssert('.test-location .test-location-label:contains(Visit Location)');
-    assert.dom('.test-location .test-location-data').hasText(LOCATION, 'Visit Location is displayed');
-    findWithAssert(`.primary-diagnosis:contains(${PRIMARY_DIAGNOSIS})`);
-    findWithAssert(`.secondary-diagnosis:contains(${SECONDARY_DIAGNOSIS})`);
-    findWithAssert('.test-opd-procedure .test-opd-procedure-label:contains(Procedures)');
-    assert.ok(find('.test-opd-procedure .test-opd-procedure-data').text().indexOf(OPD_PROCEDURE_DESCRIPTION) > -1, 'OPD Procedure is displayed');
-    findWithAssert('.test-labs .test-labs-label:contains(Labs)');
-    assert.ok(find('.test-labs .test-labs-data').text().indexOf(LAB_TYPE) > -1, 'Lab request is displayed');
-    findWithAssert('.test-images .test-images-label:contains(Images)');
-    assert.ok(find('.test-images .test-images-data').text().indexOf(IMAGING_TYPE) > -1, 'Image request is displayed');
-    findWithAssert('.test-operative-plan .test-operative-plan-label:contains(Operative Plan)');
-    findWithAssert('.test-operative-plan .test-operative-plan-description-label:contains(Operation Description:)');
-    assert.dom('.test-operative-plan .test-operative-plan-description-data').hasText(OPERATION_DESCRIPTION);
-    findWithAssert('.test-operative-plan .test-operative-plan-procedures-label:contains(Planned Procedures:)');
-    assert.dom('.test-operative-plan .test-operative-plan-procedures-description').hasText(PROCEDURE_SPLINT);
-    findWithAssert('.test-operative-plan .test-operative-plan-instructions-label:contains(Instructions upon Admission:)');
-    assert.dom('.test-operative-plan .test-operative-plan-instructions-data').hasText(ADMISSION_INSTRUCTIONS, 'Admission Instruction is displayed');
-  });
+  assert.dom('.patient-id .ps-info-data').hasText(PATIENT_ID, 'Patient ID is displayed');
+  assert.dom('.patient-name .ps-info-data').hasText(PATIENT, 'Patient First Name & Last Name is displayed');
+  assert.dom('.test-visit-date .test-visit-date-label').hasText('Date of Visit:', 'Visit date label displayed');
+  assert.ok(!isEmpty(find('.test-visit-date .test-visit-date-data').text()), 'Visit date is displayed');
+  findWithAssert('.test-visit-type .test-visit-type-label:contains(Visit Type)');
+  assert.dom('.test-visit-type .test-visit-type-data').hasText('Clinic', 'Visit Type is displayed');
+  findWithAssert('.test-examiner .test-examiner-label:contains(Examiner)');
+  assert.dom('.test-examiner .test-examiner-data').hasText(EXAMINER, 'Visit Examiner is displayed');
+  findWithAssert('.test-location .test-location-label:contains(Visit Location)');
+  assert.dom('.test-location .test-location-data').hasText(LOCATION, 'Visit Location is displayed');
+  findWithAssert(`.primary-diagnosis:contains(${PRIMARY_DIAGNOSIS})`);
+  findWithAssert(`.secondary-diagnosis:contains(${SECONDARY_DIAGNOSIS})`);
+  findWithAssert('.test-opd-procedure .test-opd-procedure-label:contains(Procedures)');
+  assert.ok(find('.test-opd-procedure .test-opd-procedure-data').text().indexOf(OPD_PROCEDURE_DESCRIPTION) > -1, 'OPD Procedure is displayed');
+  findWithAssert('.test-labs .test-labs-label:contains(Labs)');
+  assert.ok(find('.test-labs .test-labs-data').text().indexOf(LAB_TYPE) > -1, 'Lab request is displayed');
+  findWithAssert('.test-images .test-images-label:contains(Images)');
+  assert.ok(find('.test-images .test-images-data').text().indexOf(IMAGING_TYPE) > -1, 'Image request is displayed');
+  findWithAssert('.test-operative-plan .test-operative-plan-label:contains(Operative Plan)');
+  findWithAssert('.test-operative-plan .test-operative-plan-description-label:contains(Operation Description:)');
+  assert.dom('.test-operative-plan .test-operative-plan-description-data').hasText(OPERATION_DESCRIPTION);
+  findWithAssert('.test-operative-plan .test-operative-plan-procedures-label:contains(Planned Procedures:)');
+  assert.dom('.test-operative-plan .test-operative-plan-procedures-description').hasText(PROCEDURE_SPLINT);
+  findWithAssert('.test-operative-plan .test-operative-plan-instructions-label:contains(Instructions upon Admission:)');
+  assert.dom('.test-operative-plan .test-operative-plan-instructions-data').hasText(ADMISSION_INSTRUCTIONS, 'Admission Instruction is displayed');
 }
 
 function checkDischargeReport(assert) {
-  andThen(function() {
-    findWithAssert('.test-examiner .test-examiner-label:contains(Examiner)');
-    assert.dom('.test-examiner .test-examiner-data').hasText(EXAMINER, 'Examiner is displayed');
-    assert.dom('.test-visit-date .test-visit-date-label').hasText('Admission Date:', 'Visit date label displays as admission');
-    assert.dom('.test-visit-date .test-visit-discharge-date-label').hasText('Discharge Date:', 'Discharge date label displays');
-    findWithAssert('.test-notes .test-notes-label:contains(Notes)');
-    assert.ok(find('.test-notes .test-notes-data').text().indexOf(NOTE_CONTENT) > -1, 'Notes are displayed');
-  });
+  findWithAssert('.test-examiner .test-examiner-label:contains(Examiner)');
+  assert.dom('.test-examiner .test-examiner-data').hasText(EXAMINER, 'Examiner is displayed');
+  assert.dom('.test-visit-date .test-visit-date-label').hasText('Admission Date:', 'Visit date label displays as admission');
+  assert.dom('.test-visit-date .test-visit-discharge-date-label').hasText('Discharge Date:', 'Discharge date label displays');
+  findWithAssert('.test-notes .test-notes-label:contains(Notes)');
+  assert.ok(find('.test-notes .test-notes-data').text().indexOf(NOTE_CONTENT) > -1, 'Notes are displayed');
 }
 
-function saveReport(assert, type) {
-  andThen(function() {
-    click('.panel-footer button:contains(Add)');
-    waitToAppear('.modal-dialog');
-  });
-  andThen(function() {
-    assert.dom('.modal-title').hasText('Report saved', `${type} report saved successfully`);
-    click('button:contains(Ok)');
-    waitToDisappear('.modal-dialog');
-  });
-  andThen(function() {
-    assert.dom('.view-current-title').hasText(`${type} Report`, 'Report title updated correctly');
-    assert.ok(find('.panel-footer button:contains(Print)').is(':visible'), 'Print button is now visible');
-    click('button:contains(Return)');
-  });
-  andThen(function() {
-    assert.ok(currentURL().indexOf('visits/edit/') > -1, 'Visit url is correct');
-  });
+async function saveReport(assert, type) {
+  await click('.panel-footer button:contains(Add)');
+  await waitToAppear('.modal-dialog');
+  assert.dom('.modal-title').hasText('Report saved', `${type} report saved successfully`);
+
+  await click('button:contains(Ok)');
+  await waitToDisappear('.modal-dialog');
+  assert.dom('.view-current-title').hasText(`${type} Report`, 'Report title updated correctly');
+  assert.ok(find('.panel-footer button:contains(Print)').is(':visible'), 'Print button is now visible');
+
+  await click('button:contains(Return)');
+  assert.ok(currentURL().indexOf('visits/edit/') > -1, 'Visit url is correct');
 }
 
-function viewReport(assert, type, testCase) {
-  andThen(function() {
-    click('[data-test-selector=reports-tab]');
-    waitToAppear('[data-test-selector=view-report-btn]');
-    click('[data-test-selector=view-report-btn]');
-  });
-  andThen(function() {
-    assert.ok(currentURL().indexOf('visits/reports/edit') > -1, 'Edit report url is correct');
-    assert.dom('.patient-name .ps-info-data').hasText(PATIENT, 'Patient record displays');
-    assert.dom('.view-current-title').hasText(`${type} Report`, 'Report title displayed correctly');
-    assert.ok(find('.panel-footer button:contains(Print)').is(':visible'), 'Print button is visible');
+async function viewReport(assert, type, testCase) {
+  await click('[data-test-selector=reports-tab]');
+  await waitToAppear('[data-test-selector=view-report-btn]');
+  await click('[data-test-selector=view-report-btn]');
 
-    (testCase && testCase.customForms || []).forEach((f) => {
-      checkCustomFormIsFilledAndReadonly(assert, f.name);
-    });
-  });
+  assert.ok(currentURL().indexOf('visits/reports/edit') > -1, 'Edit report url is correct');
+  assert.dom('.patient-name .ps-info-data').hasText(PATIENT, 'Patient record displays');
+  assert.dom('.view-current-title').hasText(`${type} Report`, 'Report title displayed correctly');
+  assert.ok(find('.panel-footer button:contains(Print)').is(':visible'), 'Print button is visible');
+
+  for (let f of (testCase && testCase.customForms || [])) {
+    await checkCustomFormIsFilledAndReadonly(assert, f.name);
+  }
 }
 
-function updateVisitData(assert, modalTitle) {
-  andThen(() => {
-    click('.panel-footer button:contains(Add)');
-    waitToAppear('.modal-dialog');
-  });
-  andThen(() => {
-    assert.dom('.modal-title').hasText(modalTitle, `${modalTitle} modal displays`);
-    click('.modal-footer button:contains(Ok)');
-  });
-  andThen(function() {
-    waitToDisappear('.modal-dialog');
-  });
-  andThen(() => {
-    click('button:contains(Return)');
-  });
-  andThen(() => {
-    assert.ok(currentURL().indexOf('visits/edit/') > -1, 'Returns back to visit URL');
-  });
+async function updateVisitData(assert, modalTitle) {
+  await click('.panel-footer button:contains(Add)');
+  await waitToAppear('.modal-dialog');
+  assert.dom('.modal-title').hasText(modalTitle, `${modalTitle} modal displays`);
+
+  await click('.modal-footer button:contains(Ok)');
+  await waitToDisappear('.modal-dialog');
+  await click('button:contains(Return)');
+  assert.ok(currentURL().indexOf('visits/edit/') > -1, 'Returns back to visit URL');
 }
 
-function updateVisit(assert, buttonText, visitType) {
-  andThen(function() {
-    if (visitType) {
-      select('select[id*="visitType"]', visitType);
-      waitToDisappear('label[for*="display_endDate"]');
-    }
-    click(`.panel-footer button:contains(${buttonText})`);
-    waitToAppear('.modal-dialog');
-  });
-  andThen(function() {
-    assert.dom('.modal-title').hasText('Visit Saved', 'Visit Saved dialog displays');
-    click('button:contains(Ok)');
-  });
+async function updateVisit(assert, buttonText, visitType) {
+  if (visitType) {
+    await select('select[id*="visitType"]', visitType);
+    await waitToDisappear('label[for*="display_endDate"]');
+  }
+  await click(`.panel-footer button:contains(${buttonText})`);
+  await waitToAppear('.modal-dialog');
+  assert.dom('.modal-title').hasText('Visit Saved', 'Visit Saved dialog displays');
+
+  await click('button:contains(Ok)');
 }

--- a/tests/helpers/run-with-pouch-dump.js
+++ b/tests/helpers/run-with-pouch-dump.js
@@ -131,7 +131,7 @@ function runWithPouchDumpAsyncHelper(app, dumpName, functionToRun) {
       db.setMaxListeners(35);
       createPouchViews(db, true, dumpName).then(function() {
         functionToRun();
-        andThen(function() {
+        wait().then(function() {
           let databasesToClean = [
             configDB,
             db

--- a/tests/helpers/run-with-pouch-dump.js
+++ b/tests/helpers/run-with-pouch-dump.js
@@ -126,34 +126,32 @@ function runWithPouchDumpAsyncHelper(app, dumpName, functionToRun) {
   app.__deprecatedInstance__.register('service:config', InMemoryConfigService);
   app.__deprecatedInstance__.register('service:database', InMemoryDatabaseService);
 
-  return new EmberPromise(function(resolve) {
-    promise.then(function() {
-      db.setMaxListeners(35);
-      createPouchViews(db, true, dumpName).then(function() {
-        functionToRun();
-        wait().then(function() {
-          let databasesToClean = [
-            configDB,
-            db
-          ];
-          if (window.ELECTRON) {
-            databasesToClean.push(usersDB);
-          }
-          cleanupDatabases(db, databasesToClean).then(function() {
-            configDB = null;
-            db = null;
-            if (window.ELECTRON) {
-              usersDB = null;
-            }
-            resolve();
-          }, function(err) {
-            console.log('error cleaning up dbs:', err);
-          });
-        });
-      });
-    }, function(err) {
-      console.log('error loading db', JSON.stringify(err, null, 2));
-    });
+  return promise.then(function() {
+    db.setMaxListeners(35);
+    return createPouchViews(db, true, dumpName);
+
+  }).then(function() {
+    return functionToRun();
+
+  }).then(function() {
+    return wait();
+
+  }).then(function() {
+    let databasesToClean = [
+      configDB,
+      db
+    ];
+    if (window.ELECTRON) {
+      databasesToClean.push(usersDB);
+    }
+    return cleanupDatabases(db, databasesToClean);
+
+  }).then(function() {
+    configDB = null;
+    db = null;
+    if (window.ELECTRON) {
+      usersDB = null;
+    }
   });
 }
 

--- a/tests/helpers/run-with-pouch-dump.js
+++ b/tests/helpers/run-with-pouch-dump.js
@@ -36,7 +36,7 @@ function destroyDatabases(dbs) {
   return all(destroyQueue);
 }
 
-function runWithPouchDumpAsyncHelper(app, dumpName, functionToRun) {
+async function runWithPouchDumpAsyncHelper(app, dumpName, functionToRun) {
   PouchDB.plugin(PouchAdapterMemory);
   PouchDB.plugin(PouchDBUsers);
 
@@ -126,33 +126,28 @@ function runWithPouchDumpAsyncHelper(app, dumpName, functionToRun) {
   app.__deprecatedInstance__.register('service:config', InMemoryConfigService);
   app.__deprecatedInstance__.register('service:database', InMemoryDatabaseService);
 
-  return promise.then(function() {
-    db.setMaxListeners(35);
-    return createPouchViews(db, true, dumpName);
+  await promise;
 
-  }).then(function() {
-    return functionToRun();
+  db.setMaxListeners(35);
+  await createPouchViews(db, true, dumpName);
 
-  }).then(function() {
-    return wait();
+  await functionToRun();
+  await wait();
 
-  }).then(function() {
-    let databasesToClean = [
-      configDB,
-      db
-    ];
-    if (window.ELECTRON) {
-      databasesToClean.push(usersDB);
-    }
-    return cleanupDatabases(db, databasesToClean);
+  let databasesToClean = [
+    configDB,
+    db
+  ];
+  if (window.ELECTRON) {
+    databasesToClean.push(usersDB);
+  }
+  await cleanupDatabases(db, databasesToClean);
 
-  }).then(function() {
-    configDB = null;
-    db = null;
-    if (window.ELECTRON) {
-      usersDB = null;
-    }
-  });
+  configDB = null;
+  db = null;
+  if (window.ELECTRON) {
+    usersDB = null;
+  }
 }
 
 registerAsyncHelper('runWithPouchDump', runWithPouchDumpAsyncHelper);

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -2,6 +2,9 @@ import Application from '../app';
 import config from '../config/environment';
 import { setApplication } from '@ember/test-helpers';
 import { start } from 'ember-qunit';
+import loadEmberExam from 'ember-exam/test-support/load';
+
+loadEmberExam();
 
 setApplication(Application.create(config.APP));
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5412,6 +5412,17 @@ ember-electron@^2.7.2:
     tree-sync "^1.2.2"
     yarn-or-npm "^2.0.4"
 
+ember-exam@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/ember-exam/-/ember-exam-1.0.0.tgz#dd750ea407c05b01e74ee27ba42edb58585ae06b"
+  dependencies:
+    chalk "^2.1.0"
+    cli-table2 "^0.2.0"
+    debug "^3.1.0"
+    ember-cli-babel "^6.3.0"
+    fs-extra "^4.0.2"
+    rimraf "^2.6.2"
+
 ember-export-application-global@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ember-export-application-global/-/ember-export-application-global-2.0.0.tgz#8d6d7619ac8a1a3f8c43003549eb21ebed685bd2"
@@ -12839,7 +12850,7 @@ rimraf@2, rimraf@^2.2.8, rimraf@^2.3.2, rimraf@^2.3.4, rimraf@^2.4.3, rimraf@^2.
   dependencies:
     glob "^7.0.5"
 
-rimraf@^2.5.2:
+rimraf@^2.5.2, rimraf@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
   dependencies:


### PR DESCRIPTION
This PR simplifies the asynchronous test code by replacing `andThen()` blocks with `async/await`

/cc @tangollama @stukalin 