### PR TITLE
Added ISO codes to language drop down

### DIFF
--- a/app/components/language-select.js
+++ b/app/components/language-select.js
@@ -17,7 +17,8 @@ export default Component.extend({
       i18n.set('locale', item);
       return {
         id: item,
-        name: i18n.t('languageName')
+        name: i18n.t('languageName'),
+        iso: i18n.t('isoCode')
       };
     });
     i18n.set('locale', currentLocale);

--- a/app/locales/cn/translations.js
+++ b/app/locales/cn/translations.js
@@ -1,5 +1,6 @@
 export default {
   languageName: '简体中文',
+  isoCode: 'CN',  
   admin: {
     address: {
       address1Label: '地址标签1',

--- a/app/locales/de/translations.js
+++ b/app/locales/de/translations.js
@@ -1,5 +1,6 @@
 export default {
   languageName: 'Deutsch',
+  isoCode: 'DE',
   admin: {
     address: {
       address1Label: 'Adresse 1 Kennzeichen',

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -1,5 +1,6 @@
 export default {
   languageName: 'English',
+  isoCode: 'EN',
   admin: {
     address: {
       address1Label: 'Address 1 Label',

--- a/app/locales/es-co/translations.js
+++ b/app/locales/es-co/translations.js
@@ -1,5 +1,6 @@
 export default {
   languageName: 'Español (Colombiano)',
+  isoCode: 'CO',  
   admin: {
     address: {
       address1Label: 'Texto direccion 1',

--- a/app/locales/es/translations.js
+++ b/app/locales/es/translations.js
@@ -1,5 +1,6 @@
 export default {
   languageName: 'Español',
+  isoCode: 'ES',  
   admin: {
     address: {
       address1Label: 'Texto dirección 1',

--- a/app/locales/fr/translations.js
+++ b/app/locales/fr/translations.js
@@ -1,4 +1,5 @@
 export default {
+  isoCode: 'FR',  
   admin: {
     address: {
       address1Label: "Label de l'adresse 1",

--- a/app/locales/gr/translations.js
+++ b/app/locales/gr/translations.js
@@ -1,5 +1,6 @@
 export default {
   languageName: 'Ελληνικά',
+  isoCode: 'GR',  
   admin: {
     address: {
       address1Label: 'Ετικέτα Διεύθυνσης 1',

--- a/app/locales/he/translations.js
+++ b/app/locales/he/translations.js
@@ -1,5 +1,6 @@
 export default {
   languageName: 'עברית',
+  isoCode: 'HE',  
   admin: {
     address: {
       address1Label: 'כתובת 1 תווית',

--- a/app/locales/hi/translations.js
+++ b/app/locales/hi/translations.js
@@ -1,5 +1,6 @@
 export default {
   languageName: 'हिंदी',
+  isoCode: 'HI',  
   admin: {
     address: {
       address1Label: 'पता 1 लेबल',

--- a/app/locales/it/translations.js
+++ b/app/locales/it/translations.js
@@ -1,5 +1,6 @@
 export default {
   languageName: 'Italiano',
+  isoCode: 'IT',  
   admin: {
     address: {
       address1Label: 'Indirizzo 1 etichetta',

--- a/app/locales/pt-br/translations.js
+++ b/app/locales/pt-br/translations.js
@@ -1,5 +1,6 @@
 export default {
   languageName: 'Portugues (Brasileiro)',
+  isoCode: 'BR',  
   admin: {
     address: {
       address1Label: 'Rótulo Endereço 1',

--- a/app/locales/ru/translations.js
+++ b/app/locales/ru/translations.js
@@ -1,5 +1,6 @@
 export default {
   languageName: 'русский',
+  isoCode: 'RU',
   admin: {
     address: {
       address1Label: '',

--- a/app/locales/tr/translations.js
+++ b/app/locales/tr/translations.js
@@ -1,5 +1,6 @@
 export default {
   languageName: 'Türk',
+  isoCode: 'TR',  
   admin: {
     address: {
       address1Label: '',

--- a/app/locales/tw/translations.js
+++ b/app/locales/tw/translations.js
@@ -1,5 +1,6 @@
 export default {
   languageName: '繁體中文',
+    isoCode: 'TR',
   admin: {
     address: {
       address1Label: '地址標籤1',

--- a/app/locales/ur/translations.js
+++ b/app/locales/ur/translations.js
@@ -1,5 +1,6 @@
 export default {
   languageName: 'اردو',
+  isoCode: 'UR',  
   admin: {
     address: {
       address1Label: 'ایڈریس 1 لیبل',

--- a/app/templates/components/language-select.hbs
+++ b/app/templates/components/language-select.hbs
@@ -1,6 +1,6 @@
 <select tabindex="-1" class="language-select" onchange={{action 'selectLanguage' value='target.value'}}>
   <option value disabled>{{t 'navigation.actions.selectLanguage'}}</option>
   {{#each languageOptions as |lang|}}
-    <option value={{lang.id}} selected={{eq selectedLanguage lang.id}}>{{lang.name}}</option>
+    <option value={{lang.id}} selected={{eq selectedLanguage lang.id}}>{{lang.iso}} - {{lang.name}}</option>
   {{/each}}
 </select>


### PR DESCRIPTION
Fixes #1245

**In the language select drop down, you now get ISO code as well as language name:**
- Changed translations.js, now includes isoCode field
- language-select.js pulls that out as well as the language name
- language-select.hbs now displays it in dropdown, ie 'EN - English'

This is my first pull request and I'm very excited to be working on this project. I don't know if this is particularly helpful, but anything you want me to do, just say.

cc @HospitalRun/core-maintainers
