### PR TITLE
Add form-input-group class to select controls.

### DIFF
--- a/app/admin/query/template.hbs
+++ b/app/admin/query/template.hbs
@@ -5,7 +5,7 @@
     <div class="panel-body">
       {{#em-form model=this submitButton=false as |form|}}
         <div class="row">
-          {{form.select class="col-xs-3" label="Object Type"
+          {{form.select class="col-xs-3 form-input-group" label="Object Type"
               property="objectType" content=objectTypes
               selected=objectType
           }}

--- a/app/admin/roles/template.hbs
+++ b/app/admin/roles/template.hbs
@@ -2,7 +2,7 @@
   <div class="panel panel-primary">
     <div class="panel-body">
       {{#em-form model=this submitButton=false as |form|}}
-        <div class="form-group has-success">
+        <div class="form-input-group has-success">
           <label class="control-label">{{t 'labels.role'}}</label>
           <select onchange={{action "selectRole" value="target.value"}} class="form-control role-select">
             <option disabled selected={{is-not selectedRole}}>

--- a/app/admin/visit-forms/template.hbs
+++ b/app/admin/visit-forms/template.hbs
@@ -11,14 +11,16 @@
         <tr>
           <td>{{visitForm.type}}</td>
           <td>
-            <select onchange={{action 'selectForm' visitForm.type}} class="form-control role-select">
-              {{#each visitTemplates as |visitTemplate|}}
-                <option value="{{visitTemplate.id}}"
-                        selected={{eq visitForm.form visitTemplate.id}}>
-                  {{visitTemplate.value}}
-                </option>
-              {{/each}}
-            </select>
+            <div class="form-input-group">
+              <select onchange={{action 'selectForm' visitForm.type}} class="form-control role-select">
+                {{#each visitTemplates as |visitTemplate|}}
+                  <option value="{{visitTemplate.id}}"
+                          selected={{eq visitForm.form visitTemplate.id}}>
+                    {{visitTemplate.value}}
+                  </option>
+                {{/each}}
+              </select>
+            </div>
           </td>
         </tr>
       {{/each}}

--- a/app/custom-form-add/template.hbs
+++ b/app/custom-form-add/template.hbs
@@ -7,7 +7,7 @@
   {{#em-form model=model submitButton=false as |form|}}
     {{form.select label=(t 'customForms.labels.formToAdd')
       property="selectedForm" content=model.customForms
-      prompt=" " class="form-to-add"
+      prompt=" " class="form-to-add form-input-group"
     }}
   {{/em-form}}
 {{/modal-dialog}}

--- a/app/imaging/edit/template.hbs
+++ b/app/imaging/edit/template.hbs
@@ -7,7 +7,7 @@
     {{/if}}
     {{#if model.isNew}}
       <div class="row">
-        {{form.select class="col-xs-3 required" label=(t 'labels.visit')
+        {{form.select class="col-xs-3 required form-input-group" label=(t 'labels.visit')
           property="visit" content=patientVisitsForSelect
           optionValuePath="selectObject" optionLabelPath="selectObject.visitDescription"
           prompt=(t 'imaging.labels.addNewVisit')

--- a/app/inventory/adjust/template.hbs
+++ b/app/inventory/adjust/template.hbs
@@ -17,7 +17,7 @@
       <p class="form-control-static">{{model.quantity}}</p>
     </div>
     <div class="row">
-      {{form.select class="col-sm-4" label=(t 'inventory.labels.adjustmentType')
+      {{form.select class="col-sm-4 form-input-group" label=(t 'inventory.labels.adjustmentType')
         property="transactionType" content=adjustmentTypes
         optionValuePath="type" optionLabelPath="name"
       }}

--- a/app/inventory/rank-select/template.hbs
+++ b/app/inventory/rank-select/template.hbs
@@ -2,6 +2,6 @@
   label=(t 'inventory.labels.rank')
   property=property
   content=options
-  class=class
+  class=(concat 'form-input-group ' class)
   prompt=prompt
   }}

--- a/app/invoices/edit/template.hbs
+++ b/app/invoices/edit/template.hbs
@@ -13,7 +13,7 @@
       {{date-picker model=model property="billDate" label=(t 'labels.billDate') class="col-xs-2"}}
       {{#if model.isNew}}
         {{patient-typeahead model=model property="patientTypeAhead" label=(t 'labels.patient') content=patientList selection=selectedPatient class="col-xs-4 required invoice-patient"}}
-        {{form.select class="col-xs-4 required invoice-visit" label=(t 'labels.visit')
+        {{form.select class="col-xs-4 required form-input-group invoice-visit" label=(t 'labels.visit')
             property="visit" content=patientVisitsForSelect
             optionValuePath="selectObject" optionLabelPath="selectObject.visitDescription"
             selected=model.visit
@@ -33,7 +33,7 @@
         content=pricingProfiles
         optionValuePath="selectObject"
         optionLabelPath="selectObject.name"
-        class="col-xs-3"
+        class="col-xs-3 form-input-group"
         prompt=" "
         selected=model.paymentProfile
       }}

--- a/app/labs/edit/template.hbs
+++ b/app/labs/edit/template.hbs
@@ -7,7 +7,7 @@
     {{/if}}
     {{#if model.isNew}}
       <div class="row">
-        {{form.select class="col-xs-3 required test-visit-type" label=(t 'labels.visit')
+        {{form.select class="col-xs-3 required form-input-group test-visit-type" label=(t 'labels.visit')
           property="visit" content=patientVisitsForSelect
           optionValuePath="selectObject" optionLabelPath="selectObject.visitDescription"
           prompt=(t 'labs.labels.addNewVisit')

--- a/app/medication/edit/template.hbs
+++ b/app/medication/edit/template.hbs
@@ -8,7 +8,7 @@
         {{patient-typeahead model=model property="patientTypeAhead" label=(t 'labels.patient') content=patientList selection=selectedPatient class="col-xs-6 required test-patient-input"}}
       {{/if}}
       {{#if model.isNew}}
-        {{form.select class="col-xs-4 required test-add-visit" label=(t 'labels.visit')
+        {{form.select class="col-xs-4 required form-input-group test-add-visit" label=(t 'labels.visit')
           property="visit" content=patientVisitsForSelect
           optionValuePath="selectObject" optionLabelPath="selectObject.visitDescription"
           prompt=(t 'labels.addNewOutpatientVisit')

--- a/app/medication/return/template.hbs
+++ b/app/medication/return/template.hbs
@@ -1,7 +1,7 @@
 {{#edit-panel editPanelProps=editPanelProps}}
   {{#em-form model=model submitButton=false as |form|}}
     {{#if showPatientMedicationList}}
-      {{form.select class="required" label=(t 'labels.medication')
+      {{form.select class="required form-input-group" label=(t 'labels.medication')
         property="medication" content=patientMedication
         optionValuePath="selectObject" optionLabelPath="selectObject.inventoryItem.name"
         selected=model.medication
@@ -11,7 +11,7 @@
     {{/if}}
     <div class="row">
       {{patient-typeahead model=model property="patientTypeAhead" label=(t 'labels.patient') content=patientList selection=selectedPatient class="col-xs-6"}}
-      {{form.select class="col-xs-6" label=(t 'labels.visit')
+      {{form.select class="col-xs-6 form-input-group" label=(t 'labels.visit')
         property="visit" content=patientVisitsForSelect
         optionValuePath="selectObject" optionLabelPath="selectObject.visitDescription"
         selected=model.visit

--- a/app/patients/notes/template.hbs
+++ b/app/patients/notes/template.hbs
@@ -7,7 +7,7 @@
   updateButtonText=updateButtonText }}
   {{#em-form model=model submitButton=false as |form|}}
     {{expand-text label=(t 'labels.note') property="content" rows=3 class="test-note-content required form-input-group" form=form}}
-    {{form.select class="required" label=(t 'labels.visit')
+    {{form.select class="required form-input-group" label=(t 'labels.visit')
       property="visit" content=patientVisitsForSelect
       optionValuePath="selectObject" optionLabelPath="selectObject.visitDescription"
       prompt=(t 'patients.notes.pleaseSelectAVisit')

--- a/app/patients/reports/template.hbs
+++ b/app/patients/reports/template.hbs
@@ -14,6 +14,7 @@
       </div>
       {{#if isStatusReport}}
         {{form.select property="status" label="Patient Status"
+          class="form-input-group"
           content=statusList
           prompt=" "
         }}
@@ -29,21 +30,21 @@
       {{/if}}
       {{#if isVisitReport}}
         <div class="row">
-          {{form.select class="col-sm-6" label="Visit Type"
+          {{form.select class="col-sm-6 form-input-group" label="Visit Type"
             property="visitType" content=visitTypes
             prompt=" "
           }}
-          {{form.select class="col-sm-6" label="Examiner"
+          {{form.select class="col-sm-6 form-input-group" label="Examiner"
             property="examiner" content=physicianList
             prompt=" "
           }}
         </div>
         <div class="row">
-          {{form.select class="col-sm-6" label="Location"
+          {{form.select class="col-sm-6 form-input-group" label="Location"
             property="location" content=locationList
             prompt=" "
           }}
-          {{form.select class="col-sm-6" label="Clinic"
+          {{form.select class="col-sm-6 form-input-group" label="Clinic"
             property="clinic" content=clinicList
             prompt=" "
           }}

--- a/app/patients/socialwork/expense/template.hbs
+++ b/app/patients/socialwork/expense/template.hbs
@@ -6,7 +6,7 @@
     updateButtonAction=updateButtonAction
     updateButtonText=updateButtonText }}
   {{#em-form model=model submitButton=false as |form|}}
-    {{form.select label=(t 'inventory.reports.rows.category') property="category" class="required"
+    {{form.select label=(t 'inventory.reports.rows.category') property="category" class="required form-input-group"
       content=categoryTypes
       prompt=" "
     }}

--- a/app/pricing/override/template.hbs
+++ b/app/pricing/override/template.hbs
@@ -9,7 +9,7 @@
       content=pricingProfiles
       optionValuePath="selectObject"
       optionLabelPath="selectObject.name"
-      class="required pricing-profile"
+      class="required form-input-group pricing-profile"
       prompt=" "
     }}
     {{number-input model=model label=(t 'labels.price') property="price" class="required pricing-override-price"}}

--- a/app/templates/components/custom-form.hbs
+++ b/app/templates/components/custom-form.hbs
@@ -50,7 +50,7 @@
             model=model
             property=(concat propertyPrefix field.property)
             content=field.values
-            class=field.displayClassNames
+            class=(concat 'form-input-group ' field.displayClassNames)
             prompt=field.prompt
             optionValuePath="label"
             optionLabelPath="label"

--- a/app/templates/inventory-basic.hbs
+++ b/app/templates/inventory-basic.hbs
@@ -19,7 +19,7 @@
 <div class="row">
   {{form.select label=(t 'labels.type') property="inventoryType"
     content=inventoryTypes
-      class="required col-sm-4 test-inv-type"
+      class="required col-sm-4 form-input-group test-inv-type"
       prompt=" "
   }}
   {{form.input property="crossReference" label=(t 'inventory.labels.crossReference') class="col-sm-8 test-inv-cross"}}
@@ -27,7 +27,7 @@
 <div class="row">
   {{form.input property="reorderPoint" label=(t 'inventory.labels.reorderPoint') class="col-sm-3 test-inv-reorder"}}
   {{number-input model=model property="price" label=(t 'inventory.labels.salePricePerUnit') class="col-sm-3 test-inv-price"}}
-  {{form.select label=(t 'inventory.labels.distributionUnit') class="col-sm-3 required test-inv-dist-unit"
+  {{form.select label=(t 'inventory.labels.distributionUnit') class="col-sm-3 required form-input-group test-inv-dist-unit"
     property="distributionUnit"
     content=unitListForSelect
     prompt=" "

--- a/app/users/edit/template.hbs
+++ b/app/users/edit/template.hbs
@@ -11,7 +11,7 @@
     {{form.input property="displayName" label=(t 'labels.displayName')  class="user-display-name"}}
     {{form.input property="email" type="email" label=(t 'labels.email')  class="user-email"}}
     {{form.input property="password" type="password" label=(t 'labels.password')  class="user-password"}}
-    <div class="form-group has-success">
+    <div class="form-input-group has-success">
       <label class="control-label">{{t 'labels.role'}}</label>
       {{role-select selection=model.roles content=userRoles action=(action (mut model.roles)) class="user-role"}}
     </div>


### PR DESCRIPTION
The .form-input-group class in _form_styles.scss sets a height of 46px for drop-down select inputs so they're the same height as the other text and typeahead inputs in the application. But, this style is not applied consistently in the application, with the result that some select inputs are thinner and look out of place. This PR applies .form-input-group to the remaining select inputs. Example:
![form input group example](https://user-images.githubusercontent.com/36939751/40039427-0753736e-57dc-11e8-9b1e-3b1e0a1a8d32.png)

cc @HospitalRun/core-maintainers
