### PR TITLE
#1515: Update computed properties to avoid deprecated method

### DIFF
--- a/app/admin/lookup/edit/controller.js
+++ b/app/admin/lookup/edit/controller.js
@@ -1,19 +1,21 @@
 import { isEmpty } from '@ember/utils';
 import Controller, { inject as controller } from '@ember/controller';
 import IsUpdateDisabled from 'hospitalrun/mixins/is-update-disabled';
+import { computed } from '@ember/object';
+
 export default Controller.extend(IsUpdateDisabled, {
   editController: controller('admin/lookup'),
   showUpdateButton: true,
 
   updateButtonAction: 'update',
-  updateButtonText: function() {
+  updateButtonText: computed('model.isNew', function() {
     let i18n = this.get('i18n');
     if (this.get('model.isNew')) {
       return i18n.t('buttons.add');
     } else {
       return i18n.t('buttons.update');
     }
-  }.property('model.isNew'),
+  }),
 
   actions: {
     cancel() {

--- a/app/admin/route.js
+++ b/app/admin/route.js
@@ -1,15 +1,17 @@
 import AbstractModuleRoute from 'hospitalrun/routes/abstract-module-route';
+import { computed } from '@ember/object';
+
 export default AbstractModuleRoute.extend({
   addCapability: 'add_user',
   allowSearch: false,
   moduleName: 'admin',
   sectionTitle: 'Admin',
 
-  editPath: function() {
+  editPath: computed(function() {
     return 'users.edit';
-  }.property(),
+  }),
 
-  deletePath: function() {
+  deletePath: computed(function() {
     return 'users.delete';
-  }.property()
+  })
 });

--- a/app/appointments/delete/controller.js
+++ b/app/appointments/delete/controller.js
@@ -1,13 +1,15 @@
 import AbstractDeleteController from 'hospitalrun/controllers/abstract-delete-controller';
+import { computed } from '@ember/object';
+
 export default AbstractDeleteController.extend({
   title: 'Delete Appointment',
 
-  afterDeleteAction: function() {
+  afterDeleteAction: computed('model.deleteFromPatient', function() {
     let deleteFromPatient = this.get('model.deleteFromPatient');
     if (deleteFromPatient) {
       return 'appointmentDeleted';
     } else {
       return 'closeModal';
     }
-  }.property('model.deleteFromPatient')
+  })
 });

--- a/app/appointments/index/controller.js
+++ b/app/appointments/index/controller.js
@@ -1,19 +1,21 @@
 import AbstractPagedController from 'hospitalrun/controllers/abstract-paged-controller';
 import UserSession from 'hospitalrun/mixins/user-session';
+import { computed } from '@ember/object';
+
 export default AbstractPagedController.extend(UserSession, {
   startKey: [],
-  canAddVisit: function() {
+  canAddVisit: computed(function() {
     return this.currentUserCan('add_visit');
-  }.property(),
+  }),
 
-  canEdit: function() {
+  canEdit: computed(function() {
     // Add and edit are the same capability
     return this.currentUserCan('add_appointment');
-  }.property(),
+  }),
 
-  canDelete: function() {
+  canDelete: computed(function() {
     return this.currentUserCan('delete_appointment');
-  }.property(),
+  }),
 
   sortProperties: ['startDate', 'endDate'],
   sortAscending: true

--- a/app/appointments/search/controller.js
+++ b/app/appointments/search/controller.js
@@ -5,13 +5,16 @@ import AppointmentIndexController from 'hospitalrun/appointments/index/controlle
 import AppointmentStatuses from 'hospitalrun/mixins/appointment-statuses';
 import SelectValues from 'hospitalrun/utils/select-values';
 import VisitTypes from 'hospitalrun/mixins/visit-types';
+import { computed } from '@ember/object';
+
 export default AppointmentIndexController.extend(AppointmentStatuses, VisitTypes, {
   appointmentsController: controller('appointments'),
   appointmentType: null,
   physicians: alias('appointmentsController.physicianList.value'),
-  physicianList: function() {
+
+  physicianList: computed('physicians', function() {
     return SelectValues.selectValues(this.get('physicians'), true);
-  }.property('physicians'),
+  }),
 
   provider: null,
   queryParams: ['appointmentType', 'provider', 'status', 'startKey', 'startDate'],

--- a/app/components/array-display.js
+++ b/app/components/array-display.js
@@ -1,8 +1,10 @@
 import { isArray } from '@ember/array';
+import { computed } from '@ember/object';
 import Component from '@ember/component';
+
 export default Component.extend({
-  isArray: function() {
+  isArray: computed('content', function() {
     let content = this.get('content');
     return isArray(content);
-  }.property('content')
+  })
 });

--- a/app/components/charge-quantity.js
+++ b/app/components/charge-quantity.js
@@ -2,6 +2,8 @@ import { isEmpty } from '@ember/utils';
 import { alias } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
+import { computed } from '@ember/object';
+
 export default Component.extend({
   i18n: service(),
   classNames: ['col-xs-2', 'form-group'],
@@ -14,15 +16,15 @@ export default Component.extend({
     this.quantitySelected = alias(`model.${this.get('pricingItem.id')}`);
   },
 
-  hasError: function() {
+  hasError: computed('quantitySelected', function() {
     let quantitySelected = this.get('quantitySelected');
     return !isEmpty(quantitySelected) && isNaN(quantitySelected);
-  }.property('quantitySelected'),
+  }),
 
-  quantityHelp: function() {
+  quantityHelp: computed('hasError', function() {
     if (this.get('hasError')) {
       return this.get('i18n').t('errors.invalidNumber');
     }
-  }.property('hasError')
+  })
 
 });

--- a/app/components/charges-by-type-tab.js
+++ b/app/components/charges-by-type-tab.js
@@ -1,4 +1,6 @@
 import Component from '@ember/component';
+import { computed } from '@ember/object';
+
 export default Component.extend({
   attributeBindings: ['role'],
   classNameBindings: ['active'],
@@ -7,17 +9,17 @@ export default Component.extend({
   role: 'presentation',
   tagName: 'li',
 
-  active: function() {
+  active: computed(function() {
     let index = this.get('index');
     return (index === 0);
-  }.property(),
+  }),
 
-  tabId: function() {
+  tabId: computed('pricingType', function() {
     return this.get('pricingType').toLowerCase().dasherize();
-  }.property('pricingType'),
+  }),
 
-  tabHref: function() {
+  tabHref: computed('tabId', function() {
     let tabId = this.get('tabId');
     return `#${tabId}`;
-  }.property('tabId')
+  })
 });

--- a/app/components/checkbox-or-typeahead.js
+++ b/app/components/checkbox-or-typeahead.js
@@ -34,7 +34,7 @@ export default SelectOrTypeahead.extend({
     }));
   }.on('init'),
 
-  checkboxRows: function() {
+  checkboxRows: computed('content', 'checkboxesPerRow', function() {
     let checkboxRows = [];
     let checkboxesPerRow = this.get('checkboxesPerRow');
     let content = this.get('content');
@@ -44,7 +44,7 @@ export default SelectOrTypeahead.extend({
       checkboxRows.push(checkBoxRowValues);
     }
     return checkboxRows;
-  }.property('content', 'checkboxesPerRow'),
+  }),
 
   actions: {
     checkboxChanged(value, checked) {

--- a/app/components/date-input.js
+++ b/app/components/date-input.js
@@ -1,4 +1,4 @@
-import { defineProperty } from '@ember/object';
+import { defineProperty, computed } from '@ember/object';
 import { alias } from '@ember/object/computed';
 import { isEmpty } from '@ember/utils';
 import EmInput from 'ember-rapid-forms/components/em-input';
@@ -19,14 +19,14 @@ export default EmInput.extend(PikadayComponent, {
     }
   },
 
-  format: function() {
+  format: computed('showTime', function() {
     let showTime = this.get('showTime');
     if (showTime) {
       return 'l h:mm A';
     } else {
       return 'l';
     }
-  }.property('showTime'),
+  }),
 
   showTimeChanged: function() {
     let picker = this.get('_picker');

--- a/app/components/ext-radio.js
+++ b/app/components/ext-radio.js
@@ -1,20 +1,22 @@
 import { isEmpty } from '@ember/utils';
 import Component from '@ember/component';
+import { computed } from '@ember/object';
+
 export default Component.extend({
   includeOtherOption: false,
   otherOptionLabel: null,
   showInline: false,
 
-  haveLabel: function() {
+  haveLabel: computed('content', function() {
     let firstRadio = this.get('content.firstObject');
     return !isEmpty(firstRadio.label);
-  }.property('content'),
+  }),
 
-  radioClass: function() {
+  radioClass: computed('showInline', function() {
     if (this.get('showInline')) {
       return 'radio-inline';
     } else {
       return 'radio';
     }
-  }.property('showInline')
+  })
 });

--- a/app/components/inventory-location-picker.js
+++ b/app/components/inventory-location-picker.js
@@ -1,6 +1,6 @@
 import { scheduleOnce } from '@ember/runloop';
 import { alias } from '@ember/object/computed';
-import EmberObject, { defineProperty } from '@ember/object';
+import EmberObject, { defineProperty, computed } from '@ember/object';
 import { isEmpty } from '@ember/utils';
 import Component from '@ember/component';
 import SelectValues from 'hospitalrun/utils/select-values';
@@ -71,7 +71,7 @@ export default Component.extend({
     this.set('calculatedLocationPickers', locationPickers);
   },
 
-  locationPickers: function() {
+  locationPickers: computed('calculatedLocationPickers', 'locationList', 'quantityRequested', function() {
     let locationList = this.get('locationList');
     let locationPickers = [];
     let quantityRequested = this.get('quantityRequested');
@@ -90,5 +90,5 @@ export default Component.extend({
     scheduleOnce('afterRender', this, this.locationChange);
     this.set('doingSetup', false);
     return this.get('calculatedLocationPickers');
-  }.property('calculatedLocationPickers', 'locationList', 'quantityRequested')
+  })
 });

--- a/app/components/inventory-typeahead.js
+++ b/app/components/inventory-typeahead.js
@@ -2,6 +2,8 @@ import { once } from '@ember/runloop';
 import { isEmpty } from '@ember/utils';
 import { inject as service } from '@ember/service';
 import TypeAhead from 'hospitalrun/components/type-ahead';
+import { computed } from '@ember/object';
+
 export default TypeAhead.extend({
   classNameBindings: ['haveInventoryItems'],
   displayKey: 'name',
@@ -23,21 +25,21 @@ export default TypeAhead.extend({
     return returnObj;
   },
 
-  haveInventoryItems: function() {
+  haveInventoryItems: computed('content', function() {
     let content = this.get('content');
     if (!isEmpty(content) && content.length > 0) {
       return 'have-inventory-items';
     }
-  }.property('content'),
+  }),
 
-  mappedContent: function() {
+  mappedContent: computed('content', function() {
     let content = this.get('content');
     let mapped = [];
     if (content) {
       mapped = content.map(this._mapInventoryItems.bind(this));
     }
     return mapped;
-  }.property('content'),
+  }),
 
   contentChanged: function() {
     let bloodhound = this.get('bloodhound');

--- a/app/components/modal-dialog.js
+++ b/app/components/modal-dialog.js
@@ -1,6 +1,8 @@
 import { isEmpty } from '@ember/utils';
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
+import { computed } from '@ember/object';
+
 export default Component.extend({
   i18n: service(),
   cancelAction: 'cancel',
@@ -13,14 +15,14 @@ export default Component.extend({
   updateButtonClass: '',
   updateButtonText: '',
   cancelButtonText: '',
-  cancelBtnText: function() {
+  cancelBtnText: computed('cancelButtonText', function() {
     let cancelText = this.get('cancelButtonText');
     if (isEmpty(cancelText)) {
       return this.get('i18n').t('buttons.cancel');
     } else {
       return cancelText;
     }
-  }.property('cancelButtonText'),
+  }),
   actions: {
     cancelAction() {
       this.sendAction('cancelAction');

--- a/app/components/patient-typeahead.js
+++ b/app/components/patient-typeahead.js
@@ -1,6 +1,8 @@
 import { isEmpty } from '@ember/utils';
+import { computed } from '@ember/object';
 import PatientName from 'hospitalrun/mixins/patient-name';
 import TypeAhead from 'hospitalrun/components/type-ahead';
+
 export default TypeAhead.extend(PatientName, {
   displayKey: 'name',
   selectedAction: 'selectedPatientChanged',
@@ -24,13 +26,12 @@ export default TypeAhead.extend(PatientName, {
     }
   }.observes('content.[]'),
 
-  mappedContent: function() {
+  mappedContent: computed('content', function() {
     let content = this.get('content');
     let mapped = [];
     if (content) {
       mapped = content.map(this._mapPatient.bind(this));
     }
     return mapped;
-  }.property('content')
-
+  })
 });

--- a/app/components/photo-display.js
+++ b/app/components/photo-display.js
@@ -1,7 +1,9 @@
 import { isEmpty } from '@ember/utils';
 import { alias } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
+import { computed } from '@ember/object';
 import Component from '@ember/component';
+
 export default Component.extend({
   computedPhotoUrl: null,
   filesystem: service(),
@@ -10,7 +12,7 @@ export default Component.extend({
   photo: null,
   url: alias('photo.url'),
 
-  photoUrl: function() {
+  photoUrl: computed('computedPhotoUrl', 'fileName', 'url', function() {
     let computedPhotoUrl = this.get('computedPhotoUrl');
     let fileName = this.get('fileName');
     let filesystem = this.get('filesystem');
@@ -26,5 +28,5 @@ export default Component.extend({
       }.bind(this));
     }
     return url;
-  }.property('computedPhotoUrl', 'fileName', 'url')
+  })
 });

--- a/app/components/price-list.js
+++ b/app/components/price-list.js
@@ -1,7 +1,9 @@
+import { computed } from '@ember/object';
 import { isEmpty } from '@ember/utils';
 import { alias } from '@ember/object/computed';
 import Component from '@ember/component';
 import ChargeActions from 'hospitalrun/mixins/charge-actions';
+
 export default Component.extend(ChargeActions, {
   attributeBindings: ['tabId:id', 'role'],
   charges: alias('model.charges'),
@@ -14,12 +16,12 @@ export default Component.extend(ChargeActions, {
   role: 'tab',
   setChargeQuantityAction: 'setChargeQuantity',
 
-  active: function() {
+  active: computed(function() {
     let index = this.get('index');
     return (index === 0);
-  }.property(),
+  }),
 
-  pricingListByType: function() {
+  pricingListByType: computed('pricingType', 'pricingList', function() {
     let pricingList = this.get('pricingList');
     let pricingType = this.get('pricingType');
     let rows = [];
@@ -41,10 +43,10 @@ export default Component.extend(ChargeActions, {
 
     }
     return rows;
-  }.property('pricingType', 'pricingList'),
+  }),
 
-  tabId: function() {
+  tabId: computed('pricingType', function() {
     return this.get('pricingType').toLowerCase().dasherize();
-  }.property('pricingType')
+  })
 
 });

--- a/app/components/quantity-calc.js
+++ b/app/components/quantity-calc.js
@@ -2,6 +2,7 @@ import { once } from '@ember/runloop';
 import { set } from '@ember/object';
 import Component from '@ember/component';
 import { isEmpty } from '@ember/utils';
+import { computed } from '@ember/object';
 
 export default Component.extend({
   quantityGroups: [],
@@ -25,16 +26,16 @@ export default Component.extend({
     }
   },
 
-  showTotal: function() {
+  showTotal: computed('calculated', function() {
     let calculated = this.get('calculated');
     let quantityGroups = this.get('quantityGroups');
     if (quantityGroups.length > 1 && !isEmpty(calculated) && !isNaN(calculated)) {
       return true;
     }
     return false;
-  }.property('calculated'),
+  }),
 
-  currentQuantityGroups: function() {
+  currentQuantityGroups: computed('quantityGroups', 'targetUnit', function() {
     let firstQuantityObject;
     let quantityGroups = this.get('quantityGroups');
     let targetUnit = this.get('targetUnit');
@@ -48,7 +49,7 @@ export default Component.extend({
       }
     }
     return quantityGroups;
-  }.property('quantityGroups', 'targetUnit'),
+  }),
 
   calculateTotal() {
     let quantityGroups = this.get('quantityGroups');

--- a/app/components/quantity-conv.js
+++ b/app/components/quantity-conv.js
@@ -19,7 +19,7 @@ export default Component.extend({
     return listArray.map((value) => ({ id: value, value }));
   }),
 
-  unitClass: function() {
+  unitClass: computed('targetUnit', 'unit', function() {
     let selectedUnit = this.get('unit');
     let targetUnit = this.get('targetUnit');
     let unitClass = 'has-success';
@@ -34,9 +34,9 @@ export default Component.extend({
     }
     this.get('parentView').updateCurrentUnit(selectedUnit, this.get('index'));
     return unitClass;
-  }.property('targetUnit', 'unit'),
+  }),
 
-  quantityClass: function() {
+  quantityClass: computed('quantity', 'targetUnit', function() {
     let quantity = this.get('quantity');
     let quantityClass = 'has-success';
     let targetUnit = this.get('targetUnit');
@@ -53,5 +53,5 @@ export default Component.extend({
       this.get('parentView').calculateTotal();
     });
     return quantityClass;
-  }.property('quantity', 'targetUnit')
+  })
 });

--- a/app/components/select-or-typeahead.js
+++ b/app/components/select-or-typeahead.js
@@ -1,6 +1,8 @@
 import { isEmpty } from '@ember/utils';
 import Component from '@ember/component';
+import { computed } from '@ember/object';
 import SelectValues from 'hospitalrun/utils/select-values';
+
 export default Component.extend({
   name: 'select-or-typeahead',
   className: null,
@@ -15,7 +17,7 @@ export default Component.extend({
   setOnBlur: true,
   typeAheadType: null,
 
-  content: function() {
+  content: computed('list.value.[]', function() {
     let list = this.get('list');
     let optionLabelPath = this.get('optionLabelPath');
     let optionValuePath = this.get('optionValuePath');
@@ -33,18 +35,18 @@ export default Component.extend({
         return contentList;
       }
     }
-  }.property('list.value.[]'),
+  }),
 
-  usePricingTypeAhead: function() {
+  usePricingTypeAhead: computed('typeAheadType', function() {
     return (this.get('typeAheadType') === 'pricing');
-  }.property('typeAheadType'),
+  }),
 
-  userCanAdd: function() {
+  userCanAdd: computed('list.userCanAdd', function() {
     let list = this.get('list');
     if (!isEmpty(list) && list.get) {
       return list.get('userCanAdd');
     } else {
       return true;
     }
-  }.property('list.userCanAdd')
+  })
 });

--- a/app/components/sortable-column.js
+++ b/app/components/sortable-column.js
@@ -1,5 +1,7 @@
 import { isEmpty } from '@ember/utils';
+import { computed } from '@ember/object';
 import Component from '@ember/component';
+
 export default Component.extend({
   classNames: ['sortable-column'],
   tagName: 'th',
@@ -13,11 +15,11 @@ export default Component.extend({
   sortKey: null,
   filtered: false,
 
-  sorted: function() {
+  sorted: computed('sortBy', 'sortKey', function() {
     let sortBy = this.get('sortBy');
     let sortKey = this.get('sortKey');
     return sortBy === sortKey;
-  }.property('sortBy', 'sortKey'),
+  }),
 
   actions: {
     sort() {

--- a/app/controllers/abstract-edit-controller.js
+++ b/app/controllers/abstract-edit-controller.js
@@ -3,7 +3,7 @@ import { isArray, A } from '@ember/array';
 import Controller from '@ember/controller';
 import { isEmpty } from '@ember/utils';
 import RSVP, { Promise as EmberPromise } from 'rsvp';
-import { set, get } from '@ember/object';
+import { set, get, computed } from '@ember/object';
 import EditPanelProps from 'hospitalrun/mixins/edit-panel-props';
 import IsUpdateDisabled from 'hospitalrun/mixins/is-update-disabled';
 import ModalHelper from 'hospitalrun/mixins/modal-helper';
@@ -13,7 +13,7 @@ import UserSession from 'hospitalrun/mixins/user-session';
 export default Controller.extend(EditPanelProps, IsUpdateDisabled, ModalHelper, UserSession, {
   cancelAction: 'allItems',
 
-  cancelButtonText: function() {
+  cancelButtonText: computed('model.hasDirtyAttributes', function() {
     let i18n = get(this, 'i18n');
     let hasDirtyAttributes = get(this, 'model.hasDirtyAttributes');
     if (hasDirtyAttributes) {
@@ -21,9 +21,9 @@ export default Controller.extend(EditPanelProps, IsUpdateDisabled, ModalHelper, 
     } else {
       return i18n.t('buttons.returnButton');
     }
-  }.property('model.hasDirtyAttributes'),
+  }),
 
-  disabledAction: function() {
+  disabledAction: computed('model.isValid', function() {
     let model = get(this, 'model');
     if (model.validate) {
       model.validate().catch(function() {});
@@ -32,11 +32,11 @@ export default Controller.extend(EditPanelProps, IsUpdateDisabled, ModalHelper, 
     if (!isValid) {
       return 'showDisabledDialog';
     }
-  }.property('model.isValid'),
+  }),
 
-  isNewOrDeleted: function() {
+  isNewOrDeleted: computed('model.isNew', 'model.isDeleted', function() {
     return get(this, 'model.isNew') || get(this, 'model.isDeleted');
-  }.property('model.isNew', 'model.isDeleted'),
+  }),
 
   lookupLists: service(),
   /**
@@ -50,20 +50,20 @@ export default Controller.extend(EditPanelProps, IsUpdateDisabled, ModalHelper, 
   lookupListsLastUpdate: null,
   lookupListsToUpdate: null,
 
-  showUpdateButton: function() {
+  showUpdateButton: computed('updateCapability', function() {
     let updateButtonCapability = get(this, 'updateCapability');
     return this.currentUserCan(updateButtonCapability);
-  }.property('updateCapability'),
+  }),
 
   updateButtonAction: 'update',
-  updateButtonText: function() {
+  updateButtonText: computed('model.isNew', function() {
     let i18n = get(this, 'i18n');
     if (get(this, 'model.isNew')) {
       return i18n.t('buttons.add');
     } else {
       return i18n.t('buttons.update');
     }
-  }.property('model.isNew'),
+  }),
   updateCapability: null,
 
   /* Silently update and then fire the specified action. */

--- a/app/controllers/abstract-paged-controller.js
+++ b/app/controllers/abstract-paged-controller.js
@@ -16,34 +16,34 @@ export default Controller.extend(PaginationProps, ProgressDialog, UserSession, {
   sortDesc: false,
   sortKey: null,
 
-  canAdd: function() {
+  canAdd: computed(function() {
     return this.currentUserCan(this.get('addPermission'));
-  }.property(),
+  }),
 
-  canDelete: function() {
+  canDelete: computed(function() {
     return this.currentUserCan(this.get('deletePermission'));
-  }.property(),
+  }),
 
-  canEdit: function() {
+  canEdit: computed(function() {
     // Default to using add permission
     return this.currentUserCan(this.get('addPermission'));
-  }.property(),
+  }),
 
-  showActions: function() {
+  showActions: computed('canAdd', 'canEdit', 'canDelete', function() {
     return (this.get('canAdd') || this.get('canEdit') || this.get('canDelete'));
-  }.property('canAdd', 'canEdit', 'canDelete'),
+  }),
 
-  disablePreviousPage: function() {
+  disablePreviousPage: computed('previousStartKey', function() {
     return isEmpty(this.get('previousStartKey'));
-  }.property('previousStartKey'),
+  }),
 
-  disableNextPage: function() {
+  disableNextPage: computed('nextStartKey', function() {
     return isEmpty(this.get('nextStartKey'));
-  }.property('nextStartKey'),
+  }),
 
-  showPagination: function() {
+  showPagination: computed('nextStartKey', 'previousStartKey', function() {
     return !isEmpty(this.get('previousStartKey')) || !isEmpty(this.get('nextStartKey'));
-  }.property('nextStartKey', 'previousStartKey'),
+  }),
 
   hasRecords: computed('model.length', {
     get() {

--- a/app/controllers/abstract-report-controller.js
+++ b/app/controllers/abstract-report-controller.js
@@ -1,4 +1,4 @@
-import { get } from '@ember/object';
+import { get, computed } from '@ember/object';
 import { isEmpty } from '@ember/utils';
 import Controller from '@ember/controller';
 import DateFormat from 'hospitalrun/mixins/date-format';
@@ -191,28 +191,28 @@ export default Controller.extend(DateFormat, ModalHelper, NumberFormat, Paginati
 
   },
 
-  currentReportRows: function() {
+  currentReportRows: computed('reportRows.[]', 'offset', 'limit', function() {
     let limit = this.get('limit');
     let offset = this.get('offset');
     let reportRows = this.get('reportRows');
     return reportRows.slice(offset, offset + limit);
-  }.property('reportRows.[]', 'offset', 'limit'),
+  }),
 
-  disablePreviousPage: function() {
+  disablePreviousPage: computed('offset', function() {
     return (this.get('offset') === 0);
-  }.property('offset'),
+  }),
 
-  disableNextPage: function() {
+  disableNextPage: computed('offset', 'limit', 'reportRows.length', function() {
     let limit = this.get('limit');
     let length = this.get('reportRows.length');
     let offset = this.get('offset');
     return ((offset + limit) >= length);
-  }.property('offset', 'limit', 'reportRows.length'),
+  }),
 
-  showPagination: function() {
+  showPagination: computed('reportRows.length', function() {
     let length = this.get('reportRows.length');
     let limit = this.get('limit');
     return (length > limit);
-  }.property('reportRows.length')
+  })
 
 });

--- a/app/imaging/edit/controller.js
+++ b/app/imaging/edit/controller.js
@@ -2,6 +2,7 @@ import { alias } from '@ember/object/computed';
 import { isArray } from '@ember/array';
 import { isEmpty } from '@ember/utils';
 import { inject as controller } from '@ember/controller';
+import { computed } from '@ember/object';
 import AbstractEditController from 'hospitalrun/controllers/abstract-edit-controller';
 import ChargeActions from 'hospitalrun/mixins/charge-actions';
 import PatientSubmodule from 'hospitalrun/mixins/patient-submodule';
@@ -13,7 +14,7 @@ export default AbstractEditController.extend(ChargeActions, PatientSubmodule, {
   chargeRoute: 'imaging.charge',
   selectedImagingType: null,
 
-  canComplete: function() {
+  canComplete: computed('selectedImagingType.[]', 'model.imagingTypeName', function() {
     let isNew = this.get('model.isNew');
     let imagingTypeName = this.get('model.imagingTypeName');
     let selectedImagingType = this.get('selectedImagingType');
@@ -22,7 +23,7 @@ export default AbstractEditController.extend(ChargeActions, PatientSubmodule, {
     } else {
       return this.currentUserCan('complete_imaging');
     }
-  }.property('selectedImagingType.[]', 'model.imagingTypeName'),
+  }),
 
   actions: {
     completeImaging() {
@@ -72,7 +73,7 @@ export default AbstractEditController.extend(ChargeActions, PatientSubmodule, {
     }
   },
 
-  additionalButtons: function() {
+  additionalButtons: computed('canComplete', 'model.isValid', function() {
     let i18n = this.get('i18n');
     let canComplete = this.get('canComplete');
     let isValid = this.get('model.isValid');
@@ -84,7 +85,7 @@ export default AbstractEditController.extend(ChargeActions, PatientSubmodule, {
         buttonText: i18n.t('buttons.complete')
       }];
     }
-  }.property('canComplete', 'model.isValid'),
+  }),
 
   lookupListsToUpdate: [{
     name: 'radiologistList',

--- a/app/inventory/adjust/controller.js
+++ b/app/inventory/adjust/controller.js
@@ -4,6 +4,8 @@ import { inject as controller } from '@ember/controller';
 import AbstractEditController from 'hospitalrun/controllers/abstract-edit-controller';
 import AdjustmentTypes from 'hospitalrun/mixins/inventory-adjustment-types';
 import { translationMacro as t } from 'ember-i18n';
+import { computed } from '@ember/object';
+
 export default AbstractEditController.extend(AdjustmentTypes, {
   inventoryController: controller('inventory'),
 
@@ -17,11 +19,11 @@ export default AbstractEditController.extend(AdjustmentTypes, {
     });
   }.observes('transactionType'),
 
-  updateButtonText: function() {
+  updateButtonText: computed('model.transactionType', function() {
     let transactionType = this.get('model.transactionType');
     let adjustmentType = this.get('adjustmentTypes').findBy('type', transactionType);
     return adjustmentType.name;
-  }.property('model.transactionType'),
+  }),
 
   updateButtonAction: 'adjust',
 

--- a/app/inventory/batch/controller.js
+++ b/app/inventory/batch/controller.js
@@ -1,5 +1,5 @@
 import { all } from 'rsvp';
-import EmberObject from '@ember/object';
+import EmberObject, { computed } from '@ember/object';
 import { isEmpty } from '@ember/utils';
 import { alias } from '@ember/object/computed';
 import { inject as controller } from '@ember/controller';
@@ -7,6 +7,7 @@ import AbstractEditController from 'hospitalrun/controllers/abstract-edit-contro
 import InventoryId from 'hospitalrun/mixins/inventory-id';
 import InventoryLocations from 'hospitalrun/mixins/inventory-locations';
 import { translationMacro as t } from 'ember-i18n';
+
 export default AbstractEditController.extend(InventoryId, InventoryLocations, {
   doingUpdate: false,
   inventoryController: controller('inventory'),
@@ -23,7 +24,7 @@ export default AbstractEditController.extend(InventoryId, InventoryLocations, {
     'vendorItemNo'
   ],
 
-  inventoryList: function() {
+  inventoryList: computed('inventoryItems.[]', function() {
     let inventoryItems = this.get('inventoryItems');
     if (!isEmpty(inventoryItems)) {
       let mappedItems = inventoryItems.map(function(item) {
@@ -31,7 +32,7 @@ export default AbstractEditController.extend(InventoryId, InventoryLocations, {
       });
       return mappedItems;
     }
-  }.property('inventoryItems.[]'),
+  }),
 
   lookupListsToUpdate: [{
     name: 'aisleLocationList', // Name of property containing lookup list
@@ -47,16 +48,16 @@ export default AbstractEditController.extend(InventoryId, InventoryLocations, {
     id: 'warehouse_list' // Id of the lookup list to update
   }],
 
-  showDistributionUnit: function() {
+  showDistributionUnit: computed('model.inventoryItemTypeAhead', 'model.inventoryItem', function() {
     return this._haveValidInventoryItem();
-  }.property('model.inventoryItemTypeAhead', 'model.inventoryItem'),
+  }),
 
-  showInvoiceItems: function() {
+  showInvoiceItems: computed('model.invoiceItems.[]', function() {
     let invoiceItems = this.get('model.invoiceItems');
     return !isEmpty(invoiceItems);
-  }.property('model.invoiceItems.[]'),
+  }),
 
-  totalReceived: function() {
+  totalReceived: computed('model.invoiceItems.[].purchaseCost', 'model.isValid', 'model.purchaseCost', function() {
     let invoiceItems = this.get('model.invoiceItems');
     let total = 0;
     if (!isEmpty('invoiceItems')) {
@@ -69,7 +70,7 @@ export default AbstractEditController.extend(InventoryId, InventoryLocations, {
       total += Number(purchaseCost);
     }
     return total;
-  }.property('model.invoiceItems.[].purchaseCost', 'model.isValid', 'model.purchaseCost'),
+  }),
 
   updateButtonText: t('inventory.labels.save'),
 

--- a/app/inventory/edit/controller.js
+++ b/app/inventory/edit/controller.js
@@ -17,9 +17,9 @@ export default AbstractEditController.extend(FriendlyId, InventoryLocations, Inv
   savingNewItem: false,
   sequenceView: 'inventory_by_friendly_id',
 
-  canAddPurchase: function() {
+  canAddPurchase: computed(function() {
     return this.currentUserCan('add_inventory_purchase');
-  }.property(),
+  }),
 
   canAdjustLocation() {
     return this.currentUserCan('adjust_inventory_location');
@@ -46,42 +46,42 @@ export default AbstractEditController.extend(FriendlyId, InventoryLocations, Inv
     id: 'warehouse_list' // Id of the lookup list to update
   }],
 
-  canEditQuantity: function() {
+  canEditQuantity: computed('model.isNew', function() {
     return (this.get('model.isNew'));
-  }.property('model.isNew'),
+  }),
 
-  haveTransactions: function() {
+  haveTransactions: computed('transactions.[]', function() {
     let transactions = this.get('transactions');
     return transactions !== null;
-  }.property('transactions.[]'),
+  }),
 
-  locationQuantityTotal: function() {
+  locationQuantityTotal: computed('model.locations.@each.quantity', function() {
     let locations = this.get('model.locations');
     let total = locations.reduce(function(previousValue, location) {
       return previousValue + parseInt(location.get('quantity'));
     }, 0);
     return total;
-  }.property('model.locations.@each.quantity'),
+  }),
 
   /**
    * Check to see if the total quantity by location matches the quantity calculated on the item
    * @return {boolean} true if there is a discrepency;otherwise false.
    */
-  quantityDiscrepency: function() {
+  quantityDiscrepency: computed('locationQuantityTotal', 'model.quantity', function() {
     let locationQuantityTotal = this.get('locationQuantityTotal');
     let quantity = this.get('model.quantity');
     return !isEmpty(locationQuantityTotal) && !isEmpty(quantity) && locationQuantityTotal !== quantity;
-  }.property('locationQuantityTotal', 'model.quantity'),
+  }),
 
   /**
    * Get the difference in quantity between the total quantity by location and the quantity on the item.
    * @return {int} the difference.
    */
-  quantityDifferential: function() {
+  quantityDifferential: computed('locationQuantityTotal', 'model.quantity', function() {
     let locationQuantityTotal = this.get('locationQuantityTotal');
     let quantity = this.get('model.quantity');
     return Math.abs(locationQuantityTotal - quantity);
-  }.property('locationQuantityTotal', 'model.quantity'),
+  }),
 
   originalQuantityUpdated: function() {
     let isNew = this.get('model.isNew');
@@ -96,10 +96,10 @@ export default AbstractEditController.extend(FriendlyId, InventoryLocations, Inv
     return `inventory_${inventoryType}`;
   }),
 
-  showTransactions: function() {
+  showTransactions: computed('transactions.[]', function() {
     let transactions = this.get('transactions');
     return !isEmpty(transactions);
-  }.property('transactions.[]'),
+  }),
 
   transactions: null,
 

--- a/app/inventory/index/controller.js
+++ b/app/inventory/index/controller.js
@@ -4,13 +4,13 @@ import UserSession from 'hospitalrun/mixins/user-session';
 
 export default AbstractPagedController.extend(UserSession, {
   startKey: [],
-  canAdd: function() {
+  canAdd: computed(function() {
     return this.currentUserCan('add_inventory_request');
-  }.property(),
+  }),
 
-  canFulfill: function() {
+  canFulfill: computed(function() {
     return this.currentUserCan('fulfill_inventory');
-  }.property(),
+  }),
 
   currentUserName: computed('', function() {
     return this.getUserName();

--- a/app/inventory/index/route.js
+++ b/app/inventory/index/route.js
@@ -1,15 +1,17 @@
 import AbstractIndexRoute from 'hospitalrun/routes/abstract-index-route';
 import UserSession from 'hospitalrun/mixins/user-session';
 import { translationMacro as t } from 'ember-i18n';
+import { computed } from '@ember/object';
+
 export default AbstractIndexRoute.extend(UserSession, {
   modelName: 'inv-request',
-  newButtonAction: function() {
+  newButtonAction: computed(function() {
     if (this.currentUserCan('add_inventory_request')) {
       return 'newRequest';
     } else {
       return null;
     }
-  }.property(),
+  }),
   newButtonText: t('buttons.newRequestPlus'),
   pageTitle: t('navigation.subnav.requests'),
 

--- a/app/inventory/listing/controller.js
+++ b/app/inventory/listing/controller.js
@@ -1,17 +1,19 @@
 import AbstractPagedController from 'hospitalrun/controllers/abstract-paged-controller';
 import UserSession from 'hospitalrun/mixins/user-session';
+import { computed } from '@ember/object';
+
 export default AbstractPagedController.extend(UserSession, {
-  canAddItem: function() {
+  canAddItem: computed(function() {
     return this.currentUserCan('add_inventory_item');
-  }.property(),
+  }),
 
-  canAddPurchase: function() {
+  canAddPurchase: computed(function() {
     return this.currentUserCan('add_inventory_purchase');
-  }.property(),
+  }),
 
-  canDeleteItem: function() {
+  canDeleteItem: computed(function() {
     return this.currentUserCan('delete_inventory_item');
-  }.property(),
+  }),
 
   startKey: []
 });

--- a/app/inventory/listing/route.js
+++ b/app/inventory/listing/route.js
@@ -1,15 +1,17 @@
 import AbstractIndexRoute from 'hospitalrun/routes/abstract-index-route';
 import UserSession from 'hospitalrun/mixins/user-session';
 import { translationMacro as t } from 'ember-i18n';
+import { computed } from '@ember/object';
+
 export default AbstractIndexRoute.extend(UserSession, {
   modelName: 'inventory',
-  newButtonAction: function() {
+  newButtonAction: computed(function() {
     if (this.currentUserCan('add_inventory_item')) {
       return 'newItem';
     } else {
       return null;
     }
-  }.property(),
+  }),
   newButtonText: t('buttons.newItem'),
   pageTitle: t('inventory.labels.items'),
 

--- a/app/inventory/purchase/edit/controller.js
+++ b/app/inventory/purchase/edit/controller.js
@@ -3,19 +3,20 @@ import { alias } from '@ember/object/computed';
 import { inject as controller } from '@ember/controller';
 import AbstractEditController from 'hospitalrun/controllers/abstract-edit-controller';
 import UnitTypes from 'hospitalrun/mixins/unit-types';
+import { computed } from '@ember/object';
 
 export default AbstractEditController.extend(UnitTypes, {
   inventoryController: controller('inventory'),
   cancelAction: 'closeModal',
 
-  canEditQuantity: function() {
+  canEditQuantity: computed('model.currentQuantity', 'model.originalQuantity', function() {
     let originalQuantity = this.get('model.originalQuantity');
     let currentQuantity = this.get('model.currentQuantity');
     if (currentQuantity < originalQuantity) {
       return false;
     }
     return true;
-  }.property('model.currentQuantity', 'model.originalQuantity'),
+  }),
 
   warehouseList: alias('inventoryController.warehouseList'),
   aisleLocationList: alias('inventoryController.aisleLocationList'),
@@ -42,14 +43,14 @@ export default AbstractEditController.extend(UnitTypes, {
 
   updateCapability: 'add_inventory_purchase',
 
-  title: function() {
+  title: computed('model.isNew', function() {
     let i18n = this.get('i18n');
     let isNew = this.get('model.isNew');
     if (isNew) {
       return i18n.t('inventory.titles.addPurchase');
     }
     return i18n.t('inventory.titles.editPurchase');
-  }.property('model.isNew'),
+  }),
 
   beforeUpdate() {
     let isNew = this.get('model.isNew');

--- a/app/inventory/reports/controller.js
+++ b/app/inventory/reports/controller.js
@@ -189,12 +189,12 @@ export default AbstractReportController.extend(LocationName, ModalHelper, Number
     }];
   }),
 
-  hideLocationFilter: function() {
+  hideLocationFilter: computed('reportType', function() {
     let reportType = this.get('reportType');
     return (reportType === 'summaryFinance');
-  }.property('reportType'),
+  }),
 
-  includeDate: function() {
+  includeDate: computed('reportType', function() {
     let reportType = this.get('reportType');
     if (!isEmpty(reportType) && reportType.indexOf('detailed') === 0) {
       this.set('reportColumns.date.include', true);
@@ -204,9 +204,9 @@ export default AbstractReportController.extend(LocationName, ModalHelper, Number
       return false;
     }
 
-  }.property('reportType'),
+  }),
 
-  includeDaysLeft: function() {
+  includeDaysLeft: computed('reportType', function() {
     let reportType = this.get('reportType');
     if (reportType === 'daysLeft') {
       this.set('reportColumns.consumedPerDay.include', true);
@@ -218,9 +218,9 @@ export default AbstractReportController.extend(LocationName, ModalHelper, Number
       return false;
     }
 
-  }.property('reportType'),
+  }),
 
-  includeCostFields: function() {
+  includeCostFields: computed('reportType', function() {
     let reportType = this.get('reportType');
     if (reportType === 'detailedTransfer' || reportType === 'summaryTransfer' || reportType === 'daysLeft') {
       this.set('reportColumns.total.include', false);
@@ -231,9 +231,9 @@ export default AbstractReportController.extend(LocationName, ModalHelper, Number
       this.set('reportColumns.unitcost.include', true);
       return true;
     }
-  }.property('reportType'),
+  }),
 
-  includeExpenseAccount: function() {
+  includeExpenseAccount: computed('reportType', function() {
     let reportType = this.get('reportType');
     switch (reportType) {
       case 'detailedAdjustment':
@@ -250,9 +250,9 @@ export default AbstractReportController.extend(LocationName, ModalHelper, Number
         return false;
       }
     }
-  }.property('reportType'),
+  }),
 
-  includeTransactionType: function() {
+  includeTransactionType: computed('reportType', function() {
     let reportType = this.get('reportType');
     if (reportType === 'detailedAdjustment') {
       this.set('reportColumns.transactionType.include', true);
@@ -261,9 +261,9 @@ export default AbstractReportController.extend(LocationName, ModalHelper, Number
       this.set('reportColumns.transactionType.include', false);
       return false;
     }
-  }.property('reportType'),
+  }),
 
-  showEffectiveDate: function() {
+  showEffectiveDate: computed('reportType', function() {
     let reportType = this.get('reportType');
     if (reportType === 'valuation' || reportType === 'byLocation') {
       this.set('startDate', null);
@@ -277,12 +277,12 @@ export default AbstractReportController.extend(LocationName, ModalHelper, Number
       }
       return false;
     }
-  }.property('reportType'),
+  }),
 
-  useFieldPicker: function() {
+  useFieldPicker: computed('reportType', function() {
     let reportType = this.get('reportType');
     return (reportType !== 'expiration' && reportType !== 'summaryFinance');
-  }.property('reportType'),
+  }),
 
   _addAisleColumn(locations) {
     if (!isEmpty(locations)) {

--- a/app/inventory/request/controller.js
+++ b/app/inventory/request/controller.js
@@ -1,5 +1,5 @@
 import { all, resolve } from 'rsvp';
-import EmberObject from '@ember/object';
+import EmberObject, { computed } from '@ember/object';
 import { isEmpty } from '@ember/utils';
 import { alias } from '@ember/object/computed';
 import { inject as controller } from '@ember/controller';
@@ -16,7 +16,7 @@ export default AbstractEditController.extend(FulfillRequest, InventoryLocations,
   aisleLocationList: alias('inventoryController.aisleLocationList'),
   expenseAccountList: alias('inventoryController.expenseAccountList'),
 
-  inventoryList: function() {
+  inventoryList: computed('inventoryItems.[]', function() {
     let inventoryItems = this.get('inventoryItems');
     if (!isEmpty(inventoryItems)) {
       let mappedItems = inventoryItems.map(function(item) {
@@ -24,7 +24,7 @@ export default AbstractEditController.extend(FulfillRequest, InventoryLocations,
       });
       return mappedItems;
     }
-  }.property('inventoryItems.[]'),
+  }),
 
   lookupListsToUpdate: [{
     name: 'expenseAccountList', // Name of property containing lookup list
@@ -40,12 +40,12 @@ export default AbstractEditController.extend(FulfillRequest, InventoryLocations,
     id: 'warehouse_list' // Id of the lookup list to update
   }],
 
-  canFulfill: function() {
+  canFulfill: computed('model.requestedItems.[]', function() {
     let requestedItems = this.get('model.requestedItems');
     return isEmpty(requestedItems) && this.currentUserCan('fulfill_inventory');
-  }.property('model.requestedItems.[]'),
+  }),
 
-  isFulfilling: function() {
+  isFulfilling: computed('isRequested', 'model.shouldFulfillRequest', function() {
     let canFulfill = this.get('canFulfill');
     let isRequested = this.get('isRequested');
     let fulfillRequest = this.get('model.shouldFulfillRequest');
@@ -58,35 +58,35 @@ export default AbstractEditController.extend(FulfillRequest, InventoryLocations,
       this.set('model.dateCompleted');
     }
     return isFulfilling;
-  }.property('isRequested', 'model.shouldFulfillRequest'),
+  }),
 
-  isRequested: function() {
+  isRequested: computed('model.status', function() {
     let status = this.get('model.status');
     return (status === 'Requested');
-  }.property('model.status'),
+  }),
 
-  quantityLabel: function() {
+  quantityLabel: computed('selectedInventoryItem', function() {
     let selectedInventoryItem = this.get('selectedInventoryItem');
     if (isEmpty(selectedInventoryItem)) {
       return this.get('i18n').t('labels.quantity').toString();
     } else {
       return this.get('i18n').t('inventory.labels.quantity', { unit: selectedInventoryItem.distributionUnit }).toString();
     }
-  }.property('selectedInventoryItem'),
+  }),
 
-  showRequestedItems: function() {
+  showRequestedItems: computed('model.requestedItems.[]', function() {
     let requestedItems = this.get('model.requestedItems');
     return !isEmpty(requestedItems);
-  }.property('model.requestedItems.[]'),
+  }),
 
   updateViaFulfillRequest: false,
 
-  updateButtonText: function() {
+  updateButtonText: computed('model.isNew', 'isFulfilling', function() {
     if (this.get('isFulfilling')) {
       return this.get('i18n').t('buttons.fulfill');
     }
     return this._super();
-  }.property('model.isNew', 'isFulfilling'),
+  }),
 
   updateCapability: 'add_inventory_request',
 

--- a/app/inventory/route.js
+++ b/app/inventory/route.js
@@ -2,9 +2,11 @@ import AbstractModuleRoute from 'hospitalrun/routes/abstract-module-route';
 import FulfillRequest from 'hospitalrun/mixins/fulfill-request';
 import InventoryId from 'hospitalrun/mixins/inventory-id';
 import InventoryLocations from 'hospitalrun/mixins/inventory-locations'; // inventory-locations mixin is needed for fulfill-request mixin!
+import { computed } from '@ember/object';
+
 export default AbstractModuleRoute.extend(FulfillRequest, InventoryId, InventoryLocations, {
   addCapability: 'add_inventory_item',
-  additionalButtons: function() {
+  additionalButtons: computed(function() {
     if (this.currentUserCan(this.get('addCapability'))) {
       return [{
         buttonAction: 'newInventoryBatch',
@@ -12,7 +14,7 @@ export default AbstractModuleRoute.extend(FulfillRequest, InventoryId, Inventory
         class: 'btn btn-primary'
       }];
     }
-  }.property(),
+  }),
 
   additionalModels: [{
     name: 'aisleLocationList',

--- a/app/invoices/add-line-item/controller.js
+++ b/app/invoices/add-line-item/controller.js
@@ -1,4 +1,4 @@
-import EmberObject from '@ember/object';
+import EmberObject, { computed } from '@ember/object';
 import { isEmpty } from '@ember/utils';
 import { alias } from '@ember/object/computed';
 import Controller, { inject as controller } from '@ember/controller';
@@ -27,7 +27,7 @@ export default Controller.extend(BillingCategories, IsUpdateDisabled, {
     }
   },
 
-  billingCategories: function() {
+  billingCategories: computed('billingCategoryList', 'defaultBillingCategories', function() {
     let defaultBillingCategories = this.get('defaultBillingCategories');
     let billingCategoryList = this.get('billingCategoryList');
     if (isEmpty(billingCategoryList)) {
@@ -35,6 +35,6 @@ export default Controller.extend(BillingCategories, IsUpdateDisabled, {
     } else {
       return billingCategoryList;
     }
-  }.property('billingCategoryList', 'defaultBillingCategories')
+  })
 
 });

--- a/app/invoices/edit/controller.js
+++ b/app/invoices/edit/controller.js
@@ -1,5 +1,5 @@
 import { merge } from '@ember/polyfills';
-import EmberObject, { set } from '@ember/object';
+import EmberObject, { set, computed } from '@ember/object';
 import {
   all,
   allSettled,
@@ -26,7 +26,7 @@ export default AbstractEditController.extend(NumberFormat, PatientSubmodule, Pub
   updateCapability: 'add_invoice',
   wardCharges: [],
 
-  additionalButtons: function() {
+  additionalButtons: computed('model.isValid', 'model.status', function() {
     let buttons = [];
     let isValid = this.get('model.isValid');
     let status = this.get('model.status');
@@ -46,17 +46,17 @@ export default AbstractEditController.extend(NumberFormat, PatientSubmodule, Pub
     });
     return buttons;
 
-  }.property('model.isValid', 'model.status'),
+  }),
 
-  canAddCharge: function() {
+  canAddCharge: computed(function() {
     return this.currentUserCan('add_charge');
-  }.property(),
+  }),
 
-  canAddPayment: function() {
+  canAddPayment: computed(function() {
     return this.currentUserCan('add_payment');
-  }.property(),
+  }),
 
-  pharmacyExpenseAccount: function() {
+  pharmacyExpenseAccount: computed('expenseAccountList.value', function() {
     let expenseAccountList = this.get('expenseAccountList');
     if (!isEmpty(expenseAccountList)) {
       let account = expenseAccountList.find(function(value) {
@@ -66,7 +66,7 @@ export default AbstractEditController.extend(NumberFormat, PatientSubmodule, Pub
       });
       return account;
     }
-  }.property('expenseAccountList.value'),
+  }),
 
   actions: {
     addItemCharge(lineItem) {

--- a/app/invoices/index/controller.js
+++ b/app/invoices/index/controller.js
@@ -1,13 +1,15 @@
 import AbstractPagedController from 'hospitalrun/controllers/abstract-paged-controller';
+import { computed } from '@ember/object';
+
 export default AbstractPagedController.extend({
   addPermission: 'add_invoice',
   deletePermission: 'delete_invoice',
-  isCashier: function() {
+  isCashier: computed(function() {
     return this.currentUserRole() === 'Cashier';
-  }.property(),
-  canAddPayment: function() {
+  }),
+  canAddPayment: computed(function() {
     return this.currentUserCan('add_payment');
-  }.property(),
+  }),
   startKey: [],
   queryParams: ['startKey', 'status'],
   actions: {

--- a/app/invoices/payment/controller.js
+++ b/app/invoices/payment/controller.js
@@ -1,4 +1,5 @@
 import { resolve } from 'rsvp';
+import { computed } from '@ember/object';
 import { alias } from '@ember/object/computed';
 import { inject as controller } from '@ember/controller';
 import AbstractEditController from 'hospitalrun/controllers/abstract-edit-controller';
@@ -18,16 +19,16 @@ export default AbstractEditController.extend(PatientSubmodule, {
     this.displayAlert(title, message);
   },
 
-  currentPatient: function() {
+  currentPatient: computed('model.isNew', 'model.paymentType', 'model.invoice.patient', function() {
     let type = this.get('model.paymentType');
     if (type === 'Deposit') {
       return this.get('model.patient');
     } else {
       return this.get('model.invoice.patient');
     }
-  }.property('model.patient', 'model.paymentType', 'model.invoice.patient'),
+  }),
 
-  title: function() {
+  title: computed('model.isNew', 'model.paymentType', function() {
     let isNew = this.get('model.isNew');
     let type = this.get('model.paymentType');
     if (isNew) {
@@ -35,13 +36,13 @@ export default AbstractEditController.extend(PatientSubmodule, {
     } else {
       return `Edit ${type}`;
     }
-  }.property('model.isNew', 'model.paymentType'),
+  }),
 
-  selectPatient: function() {
+  selectPatient: computed('model.isNew', 'model.paymentType', function() {
     let isNew = this.get('model.isNew');
     let type = this.get('model.paymentType');
     return (isNew && type === 'Deposit');
-  }.property('model.isNew', 'model.paymentType'),
+  }),
 
   beforeUpdate() {
     if (this.get('model.isNew')) {

--- a/app/invoices/route.js
+++ b/app/invoices/route.js
@@ -1,7 +1,7 @@
 import AbstractModuleRoute from 'hospitalrun/routes/abstract-module-route';
 import ModalHelper from 'hospitalrun/mixins/modal-helper';
 import PatientListRoute from 'hospitalrun/mixins/patient-list-route';
-import Ember from 'ember';
+import { computed } from '@ember/object';
 import { translationMacro as t } from 'ember-i18n';
 
 export default AbstractModuleRoute.extend(ModalHelper, PatientListRoute, {
@@ -13,7 +13,7 @@ export default AbstractModuleRoute.extend(ModalHelper, PatientListRoute, {
   newButtonText: t('billing.buttons.newInvoice'),
   sectionTitle: t('billing.invoiceTitle'),
 
-  additionalButtons: function() {
+  additionalButtons: computed(function() {
     if (this.currentUserCan('add_payment')) {
       return [{
         class: 'btn btn-default',
@@ -21,7 +21,7 @@ export default AbstractModuleRoute.extend(ModalHelper, PatientListRoute, {
         buttonAction: 'showAddDeposit'
       }];
     }
-  }.property(),
+  }),
 
   additionalModels: [{
     name: 'billingCategoryList',
@@ -59,7 +59,7 @@ export default AbstractModuleRoute.extend(ModalHelper, PatientListRoute, {
     }
   },
 
-  subActions: Ember.computed(function() {
+  subActions: computed(function() {
     let actions = [{
       text: this.get('i18n').t('billing.navigation.billed'),
       linkTo: 'invoices.index',
@@ -85,6 +85,6 @@ export default AbstractModuleRoute.extend(ModalHelper, PatientListRoute, {
       });
     }
     return actions;
-  }).property()
+  })
 
 });

--- a/app/labs/edit/controller.js
+++ b/app/labs/edit/controller.js
@@ -75,7 +75,7 @@ export default AbstractEditController.extend(ChargeActions, PatientSubmodule, {
     }
   },
 
-  additionalButtons: function() {
+  additionalButtons: computed('canComplete', 'model.isValid', function() {
     let canComplete = this.get('canComplete');
     let isValid = this.get('model.isValid');
     let i18n = this.get('i18n');
@@ -87,7 +87,7 @@ export default AbstractEditController.extend(ChargeActions, PatientSubmodule, {
         buttonText: i18n.t('buttons.complete')
       }];
     }
-  }.property('canComplete', 'model.isValid'),
+  }),
 
   pricingTypeForObjectType: 'Lab Procedure',
   pricingTypes: alias('labsController.labPricingTypes'),

--- a/app/medication/edit/controller.js
+++ b/app/medication/edit/controller.js
@@ -1,4 +1,5 @@
 import { Promise as EmberPromise, resolve } from 'rsvp';
+import { computed } from '@ember/object';
 import { isEmpty } from '@ember/utils';
 import { alias } from '@ember/object/computed';
 import { inject as controller } from '@ember/controller';
@@ -13,36 +14,36 @@ export default AbstractEditController.extend(AddNewPatient, FulfillRequest, Inve
   medicationController: controller('medication'),
   expenseAccountList: alias('medicationController.expenseAccountList'),
 
-  canFulfill: function() {
+  canFulfill: computed(function() {
     return this.currentUserCan('fulfill_medication');
-  }.property(),
+  }),
 
-  isFulfilled: function() {
+  isFulfilled: computed('model.status', function() {
     let status = this.get('model.status');
     return (status === 'Fulfilled');
-  }.property('model.status'),
+  }),
 
-  isFulfilling: function() {
+  isFulfilling: computed('canFulfill', 'model.isRequested', 'model.shouldFulfillRequest', function() {
     let canFulfill = this.get('canFulfill');
     let isRequested = this.get('model.isRequested');
     let fulfillRequest = this.get('model.shouldFulfillRequest');
     let isFulfilling = canFulfill && (isRequested || fulfillRequest);
     this.get('model').set('isFulfilling', isFulfilling);
     return isFulfilling;
-  }.property('canFulfill', 'model.isRequested', 'model.shouldFulfillRequest'),
+  }),
 
-  isFulfilledOrRequested: function() {
+  isFulfilledOrRequested: computed('isFulfilled', 'model.isRequested', function() {
     return (this.get('isFulfilled') || this.get('model.isRequested'));
-  }.property('isFulfilled', 'model.isRequested'),
+  }),
 
-  prescriptionClass: function() {
+  prescriptionClass: computed('model.quantity', function() {
     let quantity = this.get('model.quantity');
     if (isEmpty(quantity)) {
       return 'required test-medication-prescription';
     }
-  }.property('model.quantity'),
+  }),
 
-  quantityClass: function() {
+  quantityClass: computed('isFulfilling', 'model.prescription', function() {
     let prescription = this.get('model.prescription');
     let returnClass = 'col-xs-3';
     let isFulfilling = this.get('isFulfilling');
@@ -50,9 +51,9 @@ export default AbstractEditController.extend(AddNewPatient, FulfillRequest, Inve
       returnClass += ' required';
     }
     return `${returnClass} test-quantity-input`;
-  }.property('isFulfilling', 'model.prescription'),
+  }),
 
-  quantityLabel: function() {
+  quantityLabel: computed('isFulfilled', function() {
     let i18n = this.get('i18n');
     let returnLabel = i18n.t('medication.labels.quantityRequested');
     let isFulfilled = this.get('isFulfilled');
@@ -63,7 +64,7 @@ export default AbstractEditController.extend(AddNewPatient, FulfillRequest, Inve
       returnLabel = i18n.t('medication.labels.quantityDistributed');
     }
     return returnLabel;
-  }.property('isFulfilled'),
+  }),
 
   medicationList: [],
   updateCapability: 'add_medication',
@@ -147,16 +148,16 @@ export default AbstractEditController.extend(AddNewPatient, FulfillRequest, Inve
     }
   },
 
-  showUpdateButton: function() {
+  showUpdateButton: computed('updateCapability', 'isFulfilled', function() {
     let isFulfilled = this.get('isFulfilled');
     if (isFulfilled) {
       return false;
     } else {
       return this._super();
     }
-  }.property('updateCapability', 'isFulfilled'),
+  }),
 
-  updateButtonText: function() {
+  updateButtonText: computed('model.isNew', 'isFulfilling', 'model.hideFulfillRequest', function() {
     let i18n = this.get('i18n');
     if (this.get('model.hideFulfillRequest')) {
       return i18n.t('buttons.dispense');
@@ -165,6 +166,6 @@ export default AbstractEditController.extend(AddNewPatient, FulfillRequest, Inve
     }
     return this._super();
 
-  }.property('model.isNew', 'isFulfilling', 'model.hideFulfillRequest')
+  })
 
 });

--- a/app/medication/index/controller.js
+++ b/app/medication/index/controller.js
@@ -1,12 +1,14 @@
 import AbstractPagedController from 'hospitalrun/controllers/abstract-paged-controller';
 import UserSession from 'hospitalrun/mixins/user-session';
+import { computed } from '@ember/object';
+
 export default AbstractPagedController.extend(UserSession, {
   startKey: [],
-  canAdd: function() {
+  canAdd: computed(function() {
     return this.currentUserCan('add_medication');
-  }.property(),
+  }),
 
-  showActions: function() {
+  showActions: computed(function() {
     return this.currentUserCan('fulfill_medication');
-  }.property()
+  })
 });

--- a/app/medication/return/controller.js
+++ b/app/medication/return/controller.js
@@ -1,5 +1,6 @@
 import { later } from '@ember/runloop';
 import { isEmpty } from '@ember/utils';
+import { computed } from '@ember/object';
 import { alias } from '@ember/object/computed';
 import { inject as controller } from '@ember/controller';
 import { translationMacro as t } from 'ember-i18n';
@@ -56,13 +57,13 @@ export default AbstractEditController.extend(FulfillRequest, InventoryLocations,
     }
   }.observes('patientVisits'),
 
-  showPatientMedicationList: function() {
+  showPatientMedicationList: computed('patientMedicationList', 'model.patient', 'model.visit', function() {
     let patientMedicationList = this.get('patientMedicationList');
     this.get('patientMedication'); // Request patient medication be updated
     return !isEmpty(patientMedicationList);
-  }.property('patientMedicationList', 'model.patient', 'model.visit'),
+  }),
 
-  patientMedication: function() {
+  patientMedication: computed('setNewMedicationList', 'model.patient', 'model.visit', function() {
     let setNewMedicationList = this.get('setNewMedicationList');
     let visit = this.get('model.visit');
     if (setNewMedicationList) {
@@ -76,7 +77,7 @@ export default AbstractEditController.extend(FulfillRequest, InventoryLocations,
       }.bind(this));
     }
     return this.get('patientMedicationList');
-  }.property('setNewMedicationList', 'model.patient', 'model.visit'),
+  }),
 
   _finishUpdate() {
     let aisle = this.get('model.deliveryAisle');

--- a/app/medication/route.js
+++ b/app/medication/route.js
@@ -1,13 +1,15 @@
 import { isEmpty } from '@ember/utils';
+import { computed } from '@ember/object';
 import { translationMacro as t } from 'ember-i18n';
 import AbstractModuleRoute from 'hospitalrun/routes/abstract-module-route';
+
 export default AbstractModuleRoute.extend({
   addCapability: 'add_medication',
   moduleName: 'medication',
   newButtonText: t('medication.buttons.newButton'),
   sectionTitle: t('medication.sectionTitle'),
 
-  additionalButtons: function() {
+  additionalButtons: computed(function() {
     let i18n = this.get('i18n');
     let additionalButtons = [];
     if (this.currentUserCan('fulfill_medication')) {
@@ -29,7 +31,7 @@ export default AbstractModuleRoute.extend({
     if (!isEmpty(additionalButtons)) {
       return additionalButtons;
     }
-  }.property(),
+  }),
 
   additionalModels: [{
     name: 'aisleLocationList',

--- a/app/mixins/appointment-statuses.js
+++ b/app/mixins/appointment-statuses.js
@@ -1,6 +1,8 @@
 import { map } from '@ember/object/computed';
 import Mixin from '@ember/object/mixin';
 import SelectValues from 'hospitalrun/utils/select-values';
+import { computed } from '@ember/object';
+
 export default Mixin.create({
   appointmentStatusList: [
     'Attended',
@@ -10,7 +12,7 @@ export default Mixin.create({
   ],
   appointmentStatuses: map('appointmentStatusList', SelectValues.selectValuesMap),
 
-  appointmentStatusesWithEmpty: function() {
+  appointmentStatusesWithEmpty: computed(function() {
     return SelectValues.selectValues(this.get('appointmentStatusList'), true);
-  }.property()
+  })
 });

--- a/app/mixins/can-edit-requested.js
+++ b/app/mixins/can-edit-requested.js
@@ -1,7 +1,9 @@
 import Mixin from '@ember/object/mixin';
+import { computed } from '@ember/object';
+
 export default Mixin.create({
-  canEdit: function() {
+  canEdit: computed('status', function() {
     let status = this.get('status');
     return (status === 'Requested');
-  }.property('status')
+  })
 });

--- a/app/mixins/charge-actions.js
+++ b/app/mixins/charge-actions.js
@@ -2,6 +2,8 @@ import { isArray } from '@ember/array';
 import { alias } from '@ember/object/computed';
 import { isEmpty } from '@ember/utils';
 import EmberObject from '@ember/object';
+import { computed } from '@ember/object';
+
 import {
   Promise as EmberPromise,
   all,
@@ -83,22 +85,22 @@ export default Mixin.create({
     }
   },
 
-  canAddCharge: function() {
+  canAddCharge: computed(function() {
     return this.currentUserCan('add_charge');
-  }.property(),
+  }),
 
   /**
    * Returns pricing list without object types
    * Used for labs and imaging where the labs and imaging types are
    * directly in the price list.
    */
-  chargesPricingList: function() {
+  chargesPricingList: computed('pricingList', 'pricingTypeForObjectType', function() {
     let pricingList = this.get('pricingList');
     let pricingTypeForObjectType = this.get('pricingTypeForObjectType');
     return pricingList.filter(function(item) {
       return (item.type !== pricingTypeForObjectType);
     });
-  }.property('pricingList', 'pricingTypeForObjectType'),
+  }),
 
   chargeRoute: null,
 
@@ -114,7 +116,7 @@ export default Mixin.create({
    * Used for labs and imaging where the labs and imaging types are
    * directly in the price list.
    */
-  objectTypeList: function() {
+  objectTypeList: computed('pricingList', 'pricingTypeForObjectType', 'pricingTypeValues', function() {
     let pricingList = this.get('pricingList');
     let pricingTypeForObjectType = this.get('pricingTypeForObjectType');
     let userCanAddPricingTypes = this.get('userCanAddPricingTypes');
@@ -126,11 +128,11 @@ export default Mixin.create({
       returnList.set('value', pricingList.filterBy('pricingType', pricingTypeForObjectType));
     }
     return returnList;
-  }.property('pricingList', 'pricingTypeForObjectType', 'pricingTypeValues'),
+  }),
 
   organizeByType: alias('pricingTypes.organizeByType'),
 
-  pricingTypeList: function() {
+  pricingTypeList: computed('pricingTypeValues', 'pricingTypeForObjectType', 'pricingList', function() {
     let pricingList = this.get('pricingList');
     let pricingTypeValues = this.get('pricingTypeValues');
     let pricingTypeForObjectType = this.get('pricingTypeForObjectType');
@@ -145,7 +147,7 @@ export default Mixin.create({
       pricingTypeValues = pricingTypeValues.sortBy('name');
       return pricingTypeValues;
     }
-  }.property('pricingTypeValues', 'pricingTypeForObjectType', 'pricingList'),
+  }),
 
   pricingTypeValues: alias('pricingTypes.value'),
 
@@ -238,7 +240,7 @@ export default Mixin.create({
     }
   },
 
-  showAddCharge: function() {
+  showAddCharge: computed('canAddCharge', 'organizeByType', function() {
     let canAddCharge = this.get('canAddCharge');
     let organizeByType = this.get('organizeByType');
     if (canAddCharge) {
@@ -246,9 +248,9 @@ export default Mixin.create({
     } else {
       return false;
     }
-  }.property('canAddCharge', 'organizeByType'),
+  }),
 
-  showEditCharges: function() {
+  showEditCharges: computed('canAddCharge', 'organizeByType', function() {
     let canAddCharge = this.get('canAddCharge');
     let organizeByType = this.get('organizeByType');
     if (canAddCharge) {
@@ -256,21 +258,21 @@ export default Mixin.create({
     } else {
       return false;
     }
-  }.property('canAddCharge', 'organizeByType'),
+  }),
 
-  showPricingTypeTabs: function() {
+  showPricingTypeTabs: computed('pricingTypeList', function() {
     let pricingTypeList = this.get('pricingTypeList');
     return !isEmpty(pricingTypeList) && pricingTypeList.get('length') > 1;
-  }.property('pricingTypeList'),
+  }),
 
-  userCanAddPricingTypes: function() {
+  userCanAddPricingTypes: computed('pricingTypes', function() {
     let pricingTypes = this.get('pricingTypes');
     if (isEmpty(pricingTypes)) {
       return true;
     } else {
       return pricingTypes.get('userCanAdd');
     }
-  }.property('pricingTypes'),
+  }),
 
   /**
    * When using organizeByType charges need to be mapped over from the price lists

--- a/app/mixins/inventory-adjustment-types.js
+++ b/app/mixins/inventory-adjustment-types.js
@@ -1,7 +1,8 @@
 import Mixin from '@ember/object/mixin';
+import { computed } from '@ember/object';
 
 export default Mixin.create({
-  adjustmentTypes: function() {
+  adjustmentTypes: computed(function() {
     let i18n = this.get('i18n');
     return [
       {
@@ -25,5 +26,5 @@ export default Mixin.create({
         type: 'Write Off'
       }
     ];
-  }.property()
+  })
 });

--- a/app/mixins/inventory-type-list.js
+++ b/app/mixins/inventory-type-list.js
@@ -1,13 +1,15 @@
 import { isEmpty } from '@ember/utils';
 import Mixin from '@ember/object/mixin';
 import SelectValues from 'hospitalrun/utils/select-values';
+import { computed } from '@ember/object';
+
 export default Mixin.create({
   defaultInventoryTypes: [
     'Medication',
     'Supply'
   ],
 
-  inventoryTypes: function() {
+  inventoryTypes: computed('inventoryTypeList', 'defaultInventoryTypes', function() {
     let defaultInventoryTypes = this.get('defaultInventoryTypes');
     let inventoryTypeList = this.get('inventoryTypeList');
     let typeList;
@@ -18,5 +20,5 @@ export default Mixin.create({
     }
     typeList = SelectValues.selectValues(typeList);
     return typeList;
-  }.property('inventoryTypeList', 'defaultInventoryTypes')
+  })
 });

--- a/app/mixins/is-update-disabled.js
+++ b/app/mixins/is-update-disabled.js
@@ -1,11 +1,13 @@
 import { isNone } from '@ember/utils';
+import { computed } from '@ember/object';
 import Mixin from '@ember/object/mixin';
+
 export default Mixin.create({
-  isUpdateDisabled: function() {
+  isUpdateDisabled: computed('model.isValid', function() {
     if (!isNone(this.get('model.isValid'))) {
       return !this.get('model.isValid');
     } else {
       return false;
     }
-  }.property('model.isValid')
+  })
 });

--- a/app/mixins/location-name.js
+++ b/app/mixins/location-name.js
@@ -1,5 +1,7 @@
 import { isEmpty } from '@ember/utils';
 import Mixin from '@ember/object/mixin';
+import { computed } from '@ember/object';
+
 export default Mixin.create({
   getDisplayLocationName(location, aisleLocation) {
     let locationName = this.formatLocationName(location, aisleLocation);
@@ -23,9 +25,9 @@ export default Mixin.create({
     return locationName;
   },
 
-  locationName: function() {
+  locationName: computed('location', 'aisleLocation', function() {
     let aisleLocation = this.get('aisleLocation');
     let location = this.get('location');
     return this.getDisplayLocationName(location, aisleLocation);
-  }.property('location', 'aisleLocation')
+  })
 });

--- a/app/mixins/pagination-props.js
+++ b/app/mixins/pagination-props.js
@@ -1,6 +1,7 @@
 import Mixin from '@ember/object/mixin';
+import { computed } from '@ember/object';
 export default Mixin.create({
-  paginationProps: function() {
+  paginationProps: computed('disableNextPage', 'disablePreviousPage', 'showFirstPageButton', 'showLastPageButton', 'showPagination', function() {
     let paginationProperties = [
       'disableNextPage',
       'disablePreviousPage',
@@ -9,5 +10,5 @@ export default Mixin.create({
       'showPagination'
     ];
     return this.getProperties(paginationProperties);
-  }.property('disableNextPage', 'disablePreviousPage', 'showFirstPageButton', 'showLastPageButton', 'showPagination')
+  })
 });

--- a/app/mixins/patient-submodule.js
+++ b/app/mixins/patient-submodule.js
@@ -107,7 +107,7 @@ export default Mixin.create(PatientVisits, {
     }.bind(this), reject);
   },
 
-  cancelAction: function() {
+  cancelAction: computed('model.returnToPatient', 'model.returnToVisit', function() {
     let returnToPatient = this.get('model.returnToPatient');
     let returnToVisit = this.get('model.returnToVisit');
     if (!isEmpty(returnToVisit)) {
@@ -117,7 +117,7 @@ export default Mixin.create(PatientVisits, {
     } else {
       return 'returnToAllItems';
     }
-  }.property('model.returnToPatient', 'model.returnToVisit'),
+  }),
 
   createNewVisit(newVisitType) {
     return new EmberPromise(function(resolve, reject) {
@@ -174,7 +174,7 @@ export default Mixin.create(PatientVisits, {
 
   patientSelected(/* patient */) {},
 
-  patientVisits: function() {
+  patientVisits: computed('model.patient.id', 'newVisitAdded', function() {
     let patient = this.get('model.patient');
     let visitPromise;
 
@@ -186,7 +186,7 @@ export default Mixin.create(PatientVisits, {
     return DS.PromiseArray.create({
       promise: visitPromise
     });
-  }.property('model.patient.id', 'newVisitAdded'),
+  }),
 
   patientProcedures: computed('patientVisits.[]', function() {
     let patient = get(this, 'model.patient');
@@ -199,13 +199,13 @@ export default Mixin.create(PatientVisits, {
     });
   }),
 
-  patientVisitsForSelect: function() {
+  patientVisitsForSelect: computed('patientVisits.[]', function() {
     return DS.PromiseArray.create({
       promise: this.get('patientVisits').then(function(patientVisits) {
         return patientVisits.map(SelectValues.selectObjectMap);
       })
     });
-  }.property('patientVisits.[]'),
+  }),
 
   /**
    * Removes the specified child from the current visit object and then saves the visit.

--- a/app/mixins/return-to.js
+++ b/app/mixins/return-to.js
@@ -1,12 +1,14 @@
 import { isEmpty } from '@ember/utils';
+import { computed } from '@ember/object';
 import Mixin from '@ember/object/mixin';
+
 export default Mixin.create({
-  cancelAction: function() {
+  cancelAction: computed('returnTo', function() {
     let returnTo = this.get('model.returnTo');
     if (isEmpty(returnTo)) {
       return 'allItems';
     } else {
       return 'returnTo';
     }
-  }.property('returnTo')
+  })
 });

--- a/app/mixins/unit-types.js
+++ b/app/mixins/unit-types.js
@@ -2,6 +2,8 @@ import { map } from '@ember/object/computed';
 import { isEmpty } from '@ember/utils';
 import Mixin from '@ember/object/mixin';
 import SelectValues from 'hospitalrun/utils/select-values';
+import { computed } from '@ember/object';
+
 export default Mixin.create({
   defaultUnitList: [
     'ampoule',
@@ -37,7 +39,7 @@ export default Mixin.create({
     'vial'
   ],
 
-  unitList: function() {
+  unitList: computed('inventoryUnitList', 'defaultUnitList', function() {
     let defaultUnitList = this.get('defaultUnitList');
     let inventoryUnitList = this.get('inventoryUnitList');
     if (isEmpty(inventoryUnitList)) {
@@ -45,7 +47,7 @@ export default Mixin.create({
     } else {
       return inventoryUnitList;
     }
-  }.property('inventoryUnitList', 'defaultUnitList'),
+  }),
 
   unitListForSelect: map('unitList', SelectValues.selectValuesMap)
 });

--- a/app/mixins/visit-types.js
+++ b/app/mixins/visit-types.js
@@ -1,6 +1,8 @@
 import { isEmpty } from '@ember/utils';
 import Mixin from '@ember/object/mixin';
 import SelectValues from 'hospitalrun/utils/select-values';
+import { computed } from '@ember/object';
+
 export default Mixin.create({
   defaultVisitTypes: [
     'Admission',
@@ -24,11 +26,11 @@ export default Mixin.create({
     return visitList;
   },
 
-  visitTypes: function() {
+  visitTypes: computed('visitTypesList', 'defaultVisitTypes', function() {
     return this._getVisitTypes();
-  }.property('visitTypesList', 'defaultVisitTypes').volatile(),
+  }),
 
-  visitTypesWithEmpty: function() {
+  visitTypesWithEmpty: computed('visitTypesList', 'defaultVisitTypes', function() {
     return this._getVisitTypes(true);
-  }.property('visitTypesList', 'defaultVisitTypes').volatile()
+  })
 });

--- a/app/patients/edit/controller.js
+++ b/app/patients/edit/controller.js
@@ -22,70 +22,70 @@ import PatientVisits from 'hospitalrun/mixins/patient-visits';
 
 export default AbstractEditController.extend(AllergyActions, BloodTypes, DiagnosisActions, ReturnTo, UserSession, PatientId, PatientNotes, PatientVisits, {
 
-  canAddAppointment: function() {
+  canAddAppointment: computed(function() {
     return this.currentUserCan('add_appointment');
-  }.property(),
+  }),
 
-  canAddContact: function() {
+  canAddContact: computed(function() {
     return this.currentUserCan('add_patient');
-  }.property(),
+  }),
 
-  canAddImaging: function() {
+  canAddImaging: computed(function() {
     return this.currentUserCan('add_imaging');
-  }.property(),
+  }),
 
-  canAddLab: function() {
+  canAddLab: computed(function() {
     return this.currentUserCan('add_lab');
-  }.property(),
+  }),
 
-  canAddMedication: function() {
+  canAddMedication: computed(function() {
     return this.currentUserCan('add_medication');
-  }.property(),
+  }),
 
-  canAddPhoto: function() {
+  canAddPhoto: computed(function() {
     let isFileSystemEnabled = this.get('isFileSystemEnabled');
     return (this.currentUserCan('add_photo') && isFileSystemEnabled);
-  }.property(),
+  }),
 
-  canAddSocialWork: function() {
+  canAddSocialWork: computed(function() {
     return this.currentUserCan('add_socialwork');
-  }.property(),
+  }),
 
-  canAddVisit: function() {
+  canAddVisit: computed(function() {
     return this.currentUserCan('add_visit');
-  }.property(),
+  }),
 
-  canDeleteAppointment: function() {
+  canDeleteAppointment: computed(function() {
     return this.currentUserCan('delete_appointment');
-  }.property(),
+  }),
 
-  canDeleteContact: function() {
+  canDeleteContact: computed(function() {
     return this.currentUserCan('add_patient');
-  }.property(),
+  }),
 
-  canDeleteImaging: function() {
+  canDeleteImaging: computed(function() {
     return this.currentUserCan('delete_imaging');
-  }.property(),
+  }),
 
-  canDeleteLab: function() {
+  canDeleteLab: computed(function() {
     return this.currentUserCan('delete_lab');
-  }.property(),
+  }),
 
-  canDeleteMedication: function() {
+  canDeleteMedication: computed(function() {
     return this.currentUserCan('delete_medication');
-  }.property(),
+  }),
 
-  canDeletePhoto: function() {
+  canDeletePhoto: computed(function() {
     return this.currentUserCan('delete_photo');
-  }.property(),
+  }),
 
-  canDeleteSocialWork: function() {
+  canDeleteSocialWork: computed(function() {
     return this.currentUserCan('delete_socialwork');
-  }.property(),
+  }),
 
-  canDeleteVisit: function() {
+  canDeleteVisit: computed(function() {
     return this.currentUserCan('delete_visit');
-  }.property(),
+  }),
 
   patientTypes: computed(function() {
     let i18n = get(this, 'i18n');
@@ -121,15 +121,15 @@ export default AbstractEditController.extend(AllergyActions, BloodTypes, Diagnos
   sexList: alias('patientController.sexList'),
   statusList: alias('patientController.statusList'),
 
-  haveAdditionalContacts: function() {
+  haveAdditionalContacts: computed('model.additionalContacts', function() {
     let additionalContacts = this.get('model.additionalContacts');
     return !isEmpty(additionalContacts);
-  }.property('model.additionalContacts'),
+  }),
 
-  haveAddressOptions: function() {
+  haveAddressOptions: computed('addressOptions', function() {
     let addressOptions = this.get('addressOptions');
     return !isEmpty(addressOptions);
-  }.property('addressOptions'),
+  }),
 
   lookupListsToUpdate: [{
     name: 'countryList',
@@ -149,30 +149,30 @@ export default AbstractEditController.extend(AllergyActions, BloodTypes, Diagnos
     id: 'patient_status_list'
   }],
 
-  patientImaging: function() {
+  patientImaging: computed('model.visits.[].imaging', function() {
     return this.getVisitCollection('imaging');
-  }.property('model.visits.[].imaging'),
+  }),
 
-  patientLabs: function() {
+  patientLabs: computed('model.visits.[].labs', function() {
     return this.getVisitCollection('labs');
-  }.property('model.visits.[].labs'),
+  }),
 
-  patientMedications: function() {
+  patientMedications: computed('model.visits.[].medication', function() {
     return this.getVisitCollection('medication');
-  }.property('model.visits.[].medication'),
+  }),
 
-  patientProcedures: function() {
+  patientProcedures: computed('model.visits.[].procedures', 'model.operationReports.[].procedures', function() {
     let visits = this.get('model.visits');
     let operationReports = get(this, 'model.operationReports');
     return this._getPatientProcedures(operationReports, visits);
-  }.property('model.visits.[].procedures', 'model.operationReports.[].procedures'),
+  }),
 
-  showExpenseTotal: function() {
+  showExpenseTotal: computed('model.expenses.[]', function() {
     let expenses = this.get('model.expenses');
     return !isEmpty(expenses);
-  }.property('model.expenses.[]'),
+  }),
 
-  totalExpenses: function() {
+  totalExpenses: computed('model.expenses.@each.cost', function() {
     let expenses = this.get('model.expenses');
     if (!isEmpty(expenses)) {
       let total = expenses.reduce(function(previousValue, expense) {
@@ -182,7 +182,7 @@ export default AbstractEditController.extend(AllergyActions, BloodTypes, Diagnos
       }, 0);
       return total;
     }
-  }.property('model.expenses.@each.cost'),
+  }),
 
   updateCapability: 'add_patient',
 

--- a/app/patients/index/controller.js
+++ b/app/patients/index/controller.js
@@ -1,16 +1,18 @@
 import AbstractPagedController from 'hospitalrun/controllers/abstract-paged-controller';
 import PatientVisits from 'hospitalrun/mixins/patient-visits';
 import VisitStatus from 'hospitalrun/utils/visit-statuses';
+import { computed } from '@ember/object';
+
 export default AbstractPagedController.extend(PatientVisits, {
   addPermission: 'add_patient',
   deletePermission: 'delete_patient',
-  canAdmitPatient: function() {
+  canAdmitPatient: computed(function() {
     return this.currentUserCan('admit_patient');
-  }.property(),
+  }),
 
-  canDischargePatient: function() {
+  canDischargePatient: computed(function() {
     return this.currentUserCan('discharge_patient');
-  }.property(),
+  }),
 
   startKey: [],
   actions: {

--- a/app/patients/notes/controller.js
+++ b/app/patients/notes/controller.js
@@ -8,6 +8,7 @@ import moment from 'moment';
 import PatientSubmodule from 'hospitalrun/mixins/patient-submodule';
 import PatientNotes from 'hospitalrun/mixins/patient-notes';
 import UserSession from 'hospitalrun/mixins/user-session';
+
 export default AbstractEditController.extend(IsUpdateDisabled, UserSession, PatientSubmodule, PatientNotes, {
   cancelAction: 'closeModal',
   updateAction: 'updateNote',
@@ -19,13 +20,13 @@ export default AbstractEditController.extend(IsUpdateDisabled, UserSession, Pati
     property: 'model.attribution',
     id: 'physician_list'
   }],
-  title: function() {
+  title: computed('model.patient.displayName', function() {
     if (this.get('model.isNew')) {
       return `${this.get('i18n').t('patients.notes.newNote')} ${this.get('model.patient.displayName')}`;
     } else {
       return `${this.get('i18n').t('patients.notes.newNote')} ${moment(this.get('model.date')).format('MM/DD/YYYY')} for ${this.get('model.patient.displayName')}`;
     }
-  }.property('model.patient.displayName'),
+  }),
   showSelectVisit: computed('applicationController.currentPath', function() {
     return (this.get('applicationController.currentPath') == 'patients.edit');
   }),

--- a/app/patients/reports/controller.js
+++ b/app/patients/reports/controller.js
@@ -269,20 +269,20 @@ export default AbstractReportController.extend(PatientDiagnosis, PatientVisits, 
     }];
   }),
 
-  isDischargeReport: function() {
+  isDischargeReport: computed('reportType', function() {
     let reportType = this.get('reportType');
     return (reportType.toLowerCase().indexOf('discharges') > -1);
-  }.property('reportType'),
+  }),
 
-  isStatusReport: function() {
+  isStatusReport: computed('reportType', function() {
     let reportType = this.get('reportType');
     return reportType === 'status';
-  }.property('reportType'),
+  }),
 
-  isVisitReport: function() {
+  isVisitReport: computed('reportType', function() {
     let reportType = this.get('reportType');
     return (reportType === 'visit');
-  }.property('reportType'),
+  }),
 
   _addContactToList(phone, email, prefix, contactList) {
     let contactArray = [];

--- a/app/patients/socialwork/expense/controller.js
+++ b/app/patients/socialwork/expense/controller.js
@@ -3,6 +3,7 @@ import Controller, { inject as controller } from '@ember/controller';
 import IsUpdateDisabled from 'hospitalrun/mixins/is-update-disabled';
 import SelectValues from 'hospitalrun/utils/select-values';
 import { translationMacro as t } from 'ember-i18n';
+import { computed } from '@ember/object';
 
 export default Controller.extend(IsUpdateDisabled, {
   patientsController: controller('patients'),
@@ -24,14 +25,14 @@ export default Controller.extend(IsUpdateDisabled, {
   title: t('patients.titles.socialWork'),
   updateButtonAction: 'update',
 
-  updateButtonText: function() {
+  updateButtonText: computed('model.isNew', function() {
     let isNew = this.get('model.isNew');
     if (isNew) {
       return this.get('i18n').t('buttons.add');
     } else {
       return this.get('i18n').t('buttons.update');
     }
-  }.property('model.isNew'),
+  }),
 
   actions: {
     cancel() {

--- a/app/patients/socialwork/family-info/controller.js
+++ b/app/patients/socialwork/family-info/controller.js
@@ -2,6 +2,8 @@ import { alias } from '@ember/object/computed';
 import Controller, { inject as controller } from '@ember/controller';
 import IsUpdateDisabled from 'hospitalrun/mixins/is-update-disabled';
 import { translationMacro as t } from 'ember-i18n';
+import { computed } from '@ember/object';
+
 export default Controller.extend(IsUpdateDisabled, {
   patientsController: controller('patients'),
 
@@ -10,14 +12,14 @@ export default Controller.extend(IsUpdateDisabled, {
   title: t('patients.titles.familyInfo'),
   updateButtonAction: 'update',
 
-  updateButtonText: function() {
+  updateButtonText: computed('model.isNew', function() {
     let isNew = this.get('model.isNew');
     if (isNew) {
       return this.get('i18n').t('buttons.add');
     } else {
       return this.get('i18n').t('buttons.update');
     }
-  }.property('model.isNew'),
+  }),
 
   actions: {
     cancel() {

--- a/app/pricing/override/controller.js
+++ b/app/pricing/override/controller.js
@@ -1,4 +1,5 @@
 import { map } from '@ember/object/computed';
+import { computed } from '@ember/object';
 import Controller, { inject as controller } from '@ember/controller';
 import IsUpdateDisabled from 'hospitalrun/mixins/is-update-disabled';
 import SelectValues from 'hospitalrun/utils/select-values';
@@ -29,22 +30,23 @@ export default Controller.extend(IsUpdateDisabled, {
   pricingProfiles: map('pricingController.pricingProfiles', SelectValues.selectObjectMap),
   showUpdateButton: true,
 
-  title: function() {
+  title: computed('model.isNew', function() {
     if (this.get('model.isNew')) {
       return 'Add Override';
     } else {
       return 'Edit Override';
     }
-  }.property('model.isNew'),
+  }),
 
   updateButtonAction: 'update',
-  updateButtonText: function() {
+
+  updateButtonText: computed('model.isNew', function() {
     let isNew = this.get('model.isNew');
     if (isNew) {
       return 'Add';
     } else {
       return 'Update';
     }
-  }.property('model.isNew')
+  })
 
 });

--- a/app/pricing/profiles/edit/controller.js
+++ b/app/pricing/profiles/edit/controller.js
@@ -1,4 +1,6 @@
 import AbstractEditController from 'hospitalrun/controllers/abstract-edit-controller';
+import { computed } from '@ember/object';
+
 export default AbstractEditController.extend({
   actions: {
     cancel() {
@@ -11,12 +13,12 @@ export default AbstractEditController.extend({
     this.displayAlert('Pricing Profile Saved', message, 'refreshProfiles');
   },
 
-  title: function() {
+  title: computed('model.isNew', function() {
     let isNew = this.get('model.isNew');
     if (isNew) {
       return 'New Pricing Profile';
     } else {
       return 'Edit Pricing Profile';
     }
-  }.property('model.isNew')
+  })
 });

--- a/app/procedures/charge/controller.js
+++ b/app/procedures/charge/controller.js
@@ -3,6 +3,7 @@ import { Promise as EmberPromise } from 'rsvp';
 import { alias } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
 import { inject as controller } from '@ember/controller';
+import { computed } from '@ember/object';
 import AbstractEditController from 'hospitalrun/controllers/abstract-edit-controller';
 
 export default AbstractEditController.extend({
@@ -15,13 +16,13 @@ export default AbstractEditController.extend({
   selectedItem: null,
   updateCapability: 'add_charge',
 
-  title: function() {
+  title: computed('model.isNew', function() {
     let isNew = this.get('model.isNew');
     if (isNew) {
       return this.get('i18n').t('procedures.titles.addChargeItem');
     }
     return this.get('i18n').t('procedures.titles.editChargeItem');
-  }.property('model.isNew'),
+  }),
 
   beforeUpdate() {
     this.set('newCharge', this.get('model.isNew'));

--- a/app/procedures/edit/controller.js
+++ b/app/procedures/edit/controller.js
@@ -3,6 +3,7 @@ import EmberObject from '@ember/object';
 import { alias } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
 import { inject as controller } from '@ember/controller';
+import { computed } from '@ember/object';
 import AbstractEditController from 'hospitalrun/controllers/abstract-edit-controller';
 import ChargeActions from 'hospitalrun/mixins/charge-actions';
 import PatientSubmodule from 'hospitalrun/mixins/patient-submodule';
@@ -14,14 +15,14 @@ export default AbstractEditController.extend(ChargeActions, PatientSubmodule, {
   chargePricingCategory: 'Procedure',
   chargeRoute: 'procedures.charge',
 
-  canAddPhoto: function() {
+  canAddPhoto: computed(function() {
     let isFileSystemEnabled = this.get('isFileSystemEnabled');
     return (this.currentUserCan('add_photo') && isFileSystemEnabled);
-  }.property(),
+  }),
 
-  canDeletePhoto: function() {
+  canDeletePhoto: computed(function() {
     return this.currentUserCan('delete_photo');
-  }.property(),
+  }),
 
   anesthesiaTypes: alias('visitsController.anesthesiaTypes'),
   anesthesiologistList: alias('visitsController.anesthesiologistList'),
@@ -66,13 +67,13 @@ export default AbstractEditController.extend(ChargeActions, PatientSubmodule, {
   newProcedure: false,
   isFileSystemEnabled: alias('filesystem.isFileSystemEnabled'),
 
-  title: function() {
+  title: computed('model.isNew', function() {
     let isNew = this.get('model.isNew');
     if (isNew) {
       return this.get('i18n').t('procedures.titles.add');
     }
     return this.get('i18n').t('procedures.titles.edit');
-  }.property('model.isNew'),
+  }),
 
   updateCapability: 'add_procedure',
 

--- a/app/procedures/medication/controller.js
+++ b/app/procedures/medication/controller.js
@@ -1,6 +1,7 @@
 import { Promise as EmberPromise } from 'rsvp';
 import { alias } from '@ember/object/computed';
 import { inject as controller } from '@ember/controller';
+import { computed } from '@ember/object';
 import AbstractEditController from 'hospitalrun/controllers/abstract-edit-controller';
 
 export default AbstractEditController.extend({
@@ -11,13 +12,13 @@ export default AbstractEditController.extend({
 
   updateCapability: 'add_charge',
 
-  title: function() {
+  title: computed('model.isNew', function() {
     let isNew = this.get('model.isNew');
     if (isNew) {
       return this.get('i18n').t('procedures.titles.addMedicationUsed');
     }
     return this.get('i18n').t('procedures.titles.editMedicationUsed');
-  }.property('model.isNew'),
+  }),
 
   beforeUpdate() {
     let isNew = this.get('model.isNew');

--- a/app/routes/abstract-edit-route.js
+++ b/app/routes/abstract-edit-route.js
@@ -1,7 +1,7 @@
 import { isEmpty } from '@ember/utils';
 import { Promise as EmberPromise, resolve } from 'rsvp';
 import Route from '@ember/routing/route';
-import { get } from '@ember/object';
+import { get, computed } from '@ember/object';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 
 export default Route.extend(AuthenticatedRouteMixin, {
@@ -28,10 +28,10 @@ export default Route.extend(AuthenticatedRouteMixin, {
     }.bind(this));
   },
 
-  idParam: function() {
+  idParam: computed('modelName', function() {
     let modelName = get(this, 'modelName');
     return `${modelName}_id`;
-  }.property('modelName'),
+  }),
 
   /**
    * Override this function to generate an id for a new record

--- a/app/routes/abstract-module-route.js
+++ b/app/routes/abstract-module-route.js
@@ -5,6 +5,7 @@ import {
   allSettled,
   resolve
 } from 'rsvp';
+import { computed } from '@ember/object';
 import Route from '@ember/routing/route';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 import UserSession from 'hospitalrun/mixins/user-session';
@@ -21,28 +22,28 @@ export default Route.extend(UserSession, AuthenticatedRouteMixin, {
   sectionTitle: null,
   subActions: null,
 
-  editPath: function() {
+  editPath: computed('moduleName', function() {
     let module = this.get('moduleName');
     return `${module}.edit`;
-  }.property('moduleName'),
+  }),
 
-  deletePath: function() {
+  deletePath: computed('moduleName', function() {
     let module = this.get('moduleName');
     return `${module}.delete`;
-  }.property('moduleName'),
+  }),
 
-  newButtonAction: function() {
+  newButtonAction: computed(function() {
     if (this.currentUserCan(this.get('addCapability'))) {
       return 'newItem';
     } else {
       return null;
     }
-  }.property(),
+  }),
 
-  searchRoute: function() {
+  searchRoute: computed('moduleName', function() {
     let module = this.get('moduleName');
     return `/${module}/search`;
-  }.property('moduleName'),
+  }),
 
   actions: {
     allItems() {

--- a/app/services/filesystem.js
+++ b/app/services/filesystem.js
@@ -1,6 +1,6 @@
 import { Promise as EmberPromise } from 'rsvp';
 import { isEmpty } from '@ember/utils';
-import { get } from '@ember/object';
+import { get, computed } from '@ember/object';
 import Service, { inject as service } from '@ember/service';
 export default Service.extend({
   config: service(),
@@ -208,10 +208,10 @@ export default Service.extend({
   /**
    * Property to determine if file system API is available.
    */
-  isFileSystemEnabled: function() {
+  isFileSystemEnabled: computed('filer', function() {
     let filer = this.get('filer');
     return !(isEmpty(filer));
-  }.property('filer'),
+  }),
 
   /**
    * Get filesystem url from specified path.

--- a/app/users/index/route.js
+++ b/app/users/index/route.js
@@ -2,15 +2,17 @@ import { inject as service } from '@ember/service';
 import AbstractIndexRoute from 'hospitalrun/routes/abstract-index-route';
 import UserSession from 'hospitalrun/mixins/user-session';
 import { translationMacro as t } from 'ember-i18n';
+import { computed } from '@ember/object';
+
 export default AbstractIndexRoute.extend(UserSession, {
   config: service(),
-  newButtonAction: function() {
+  newButtonAction: computed(function() {
     if (this.currentUserCan('add_user')) {
       return 'newItem';
     } else {
       return null;
     }
-  }.property(),
+  }),
   newButtonText: t('user.plusNewUser'),
   pageTitle: t('user.usersPageTile'),
   model() {

--- a/app/visits/delete/controller.js
+++ b/app/visits/delete/controller.js
@@ -1,13 +1,15 @@
 import AbstractDeleteController from 'hospitalrun/controllers/abstract-delete-controller';
+import { computed } from '@ember/object';
+
 export default AbstractDeleteController.extend({
   title: 'Delete Visit',
 
-  afterDeleteAction: function() {
+  afterDeleteAction: computed('model.deleteFromPatient', function() {
     let deleteFromPatient = this.get('model.deleteFromPatient');
     if (deleteFromPatient) {
       return 'visitDeleted';
     } else {
       return 'closeModal';
     }
-  }.property('model.deleteFromPatient')
+  })
 });

--- a/app/visits/edit/controller.js
+++ b/app/visits/edit/controller.js
@@ -47,70 +47,70 @@ export default AbstractEditController.extend(AddNewPatient, AllergyActions, Char
     return (!this.get('model.isNew') && this.currentUserCan('add_billing_diagnosis'));
   }),
 
-  canAddImaging: function() {
+  canAddImaging: computed(function() {
     return this.currentUserCan('add_imaging');
-  }.property(),
+  }),
 
-  canAddLab: function() {
+  canAddLab: computed(function() {
     return this.currentUserCan('add_lab');
-  }.property(),
+  }),
 
-  canAddMedication: function() {
+  canAddMedication: computed(function() {
     return this.currentUserCan('add_medication');
-  }.property(),
+  }),
 
-  canAddPhoto: function() {
+  canAddPhoto: computed(function() {
     let isFileSystemEnabled = this.get('isFileSystemEnabled');
     return (this.currentUserCan('add_photo') && isFileSystemEnabled);
-  }.property(),
+  }),
 
-  canAddProcedure: function() {
+  canAddProcedure: computed(function() {
     return this.currentUserCan('add_procedure');
-  }.property(),
+  }),
 
-  canAddVitals: function() {
+  canAddVitals: computed(function() {
     return this.currentUserCan('add_vitals');
-  }.property(),
+  }),
 
   canAddReport: computed('hasReport', function() {
     return this.currentUserCan('add_report') && !this.get('hasReport');
   }),
 
-  canDeleteImaging: function() {
+  canDeleteImaging: computed(function() {
     return this.currentUserCan('delete_imaging');
-  }.property(),
+  }),
 
-  canDeleteLab: function() {
+  canDeleteLab: computed(function() {
     return this.currentUserCan('delete_lab');
-  }.property(),
+  }),
 
-  canDeleteMedication: function() {
+  canDeleteMedication: computed(function() {
     return this.currentUserCan('delete_medication');
-  }.property(),
+  }),
 
-  canDeletePhoto: function() {
+  canDeletePhoto: computed(function() {
     return this.currentUserCan('delete_photo');
-  }.property(),
+  }),
 
-  canDeleteProcedure: function() {
+  canDeleteProcedure: computed(function() {
     return this.currentUserCan('delete_procedure');
-  }.property(),
+  }),
 
-  canDeleteVitals: function() {
+  canDeleteVitals: computed(function() {
     return this.currentUserCan('delete_vitals');
-  }.property(),
+  }),
 
-  canDeleteReport: function() {
+  canDeleteReport: computed(function() {
     return this.currentUserCan('delete_report');
-  }.property(),
+  }),
 
-  isAdmissionVisit: function() {
+  isAdmissionVisit: computed('model.visitType', function() {
     let visitType = this.get('model.visitType');
     let isAdmission = (visitType === 'Admission');
     return isAdmission;
-  }.property('model.visitType'),
+  }),
 
-  cancelAction: function() {
+  cancelAction: computed('model.returnTo', 'model.returnToPatient', function() {
     let returnTo = this.get('model.returnTo');
     if (!isEmpty(returnTo)) {
       return 'returnTo';
@@ -119,7 +119,7 @@ export default AbstractEditController.extend(AddNewPatient, AllergyActions, Char
     } else {
       return this._super();
     }
-  }.property('model.returnTo', 'model.returnToPatient'),
+  }),
 
   allowAddAllergy: not('model.isNew'),
   allowAddDiagnosis: not('model.isNew'),
@@ -170,7 +170,7 @@ export default AbstractEditController.extend(AddNewPatient, AllergyActions, Char
     }
   }),
 
-  validVisitTypes: function() {
+  validVisitTypes: computed('visitTypes', 'model.outPatient', function() {
     let outPatient = this.get('model.outPatient');
     let visitTypes = this.get('visitTypes');
     if (outPatient === true) {
@@ -179,7 +179,7 @@ export default AbstractEditController.extend(AddNewPatient, AllergyActions, Char
       });
     }
     return visitTypes;
-  }.property('visitTypes', 'model.outPatient'),
+  }),
 
   _addChildObject(route, afterTransition) {
     let options = {
@@ -263,9 +263,9 @@ export default AbstractEditController.extend(AddNewPatient, AllergyActions, Char
     });
   },
 
-  haveAdditionalDiagnoses: function() {
+  haveAdditionalDiagnoses: computed('model.additionalDiagnoses.[]', function() {
     return !isEmpty(this.get('model.additionalDiagnoses'));
-  }.property('model.additionalDiagnoses.[]'),
+  }),
 
   afterUpdate(visit) {
     this.updatePatientVisitFlags(visit).then(this._finishAfterUpdate.bind(this));

--- a/app/visits/vitals/edit/controller.js
+++ b/app/visits/vitals/edit/controller.js
@@ -1,5 +1,6 @@
 import { Promise as EmberPromise } from 'rsvp';
 import { inject as controller } from '@ember/controller';
+import { computed } from '@ember/object';
 import AbstractEditController from 'hospitalrun/controllers/abstract-edit-controller';
 
 export default AbstractEditController.extend({
@@ -11,13 +12,13 @@ export default AbstractEditController.extend({
 
   temperatureLabel: 'Temperature (\xb0C)',
 
-  title: function() {
+  title: computed('model.isNew', function() {
     let isNew = this.get('model.isNew');
     if (isNew) {
       return 'Add Vitals';
     }
     return 'Edit Vitals';
-  }.property('model.isNew'),
+  }),
 
   updateCapability: 'add_vitals',
 


### PR DESCRIPTION
Fixes #1515 

## Description
To pre-empt the upcoming deprecation of `fn().properties(...)` for computed properties, all usages have been removed and replaced with the correct `Ember.computed(..., fn())` method.

### Tests
All tests pass on Solus Linux, using Node 6.14.4.

```
1..1603
# tests 1603
# pass  1603
# skip  0
# fail  0

# ok
```
*Note: pull requests without proper descriptions may simply be closed without further discussion. We appreciate your contributions, but need to know what you are offering in clearly described format. Thanks! (you can delete this text)*

cc @HospitalRun/core-maintainers
