### PR TITLE
Fix for deleting inv-location

### DIFF
--- a/app/inventory/delete/controller.js
+++ b/app/inventory/delete/controller.js
@@ -1,5 +1,15 @@
 import { translationMacro as t } from 'ember-i18n';
+import { inject as controller } from '@ember/controller';
 import AbstractDeleteController from 'hospitalrun/controllers/abstract-delete-controller';
 export default AbstractDeleteController.extend({
-  title: t('inventory.labels.deleteItem')
+  title: t('inventory.labels.deleteItem'),
+  editController: controller('inventory/edit'),
+  afterDeleteAction: 'updateAndCloseModal',
+
+  actions: {
+    updateAndCloseModal() {
+      this.get('editController').send('update', true);
+      this.send('closeModal');
+    }
+  }
 });

--- a/app/inventory/edit/template.hbs
+++ b/app/inventory/edit/template.hbs
@@ -70,7 +70,7 @@
         {{#each model.locations as |location|}}
           {{#unless location.archived}}
             <tr>
-              <td>{{location.location}}</td>
+              <td class="test-location-location">{{location.location}}</td>
               <td>{{location.aisleLocation}}</td>
               <td class="test-location-quantity">{{location.quantity}}</td>
               {{#if canAdjustLocation}}

--- a/app/inventory/transfer/template.hbs
+++ b/app/inventory/transfer/template.hbs
@@ -16,10 +16,10 @@
       <label class="control-label">{{t 'inventory.labels.quantityAvailable'}}</label>
       <p class="form-control-static">{{model.quantity}}</p>
     </div>
-    {{select-or-typeahead form=form model=model class="required" property="transferLocation" label=(t 'inventory.labels.transferTo') list=warehouseList selection=model.transferLocation }}
+    {{select-or-typeahead form=form model=model class="required test-transfer-location" property="transferLocation" label=(t 'inventory.labels.transferTo') list=warehouseList selection=model.transferLocation }}
     {{select-or-typeahead form=form model=model property="transferAisleLocation" label=(t 'inventory.labels.transferToAisle') list=aisleLocationList selection=model.transferAisleLocation }}
     <div class="row">
-      {{number-input model=model property="adjustmentQuantity" label=(t 'labels.quantity') class="col-sm-3 required"}}
+      {{number-input model=model class="required test-adjustment-quantity col-sm-3" property="adjustmentQuantity" label=(t 'labels.quantity')}}
     </div>
     <div class="row">
       {{date-picker model=model property="dateCompleted" label=(t 'inventory.labels.dateTransferred') class="col-sm-4 required"}}

--- a/tests/acceptance/inventory-test.js
+++ b/tests/acceptance/inventory-test.js
@@ -5,7 +5,7 @@ import runWithPouchDump from 'hospitalrun/tests/helpers/run-with-pouch-dump';
 import select from 'hospitalrun/tests/helpers/select';
 import selectDate from 'hospitalrun/tests/helpers/select-date';
 import typeAheadFillIn from 'hospitalrun/tests/helpers/typeahead-fillin';
-import { waitToAppear } from 'hospitalrun/tests/helpers/wait-to-appear';
+import { waitToAppear, waitToDisappear } from 'hospitalrun/tests/helpers/wait-to-appear';
 import { authenticateUser } from 'hospitalrun/tests/helpers/authenticate-user';
 
 moduleForAcceptance('Acceptance | inventory');
@@ -99,6 +99,38 @@ test('Items with negative quantites should not be saved', (assert) => {
       'not a valid number',
       'Error message should be present for invalid quantities'
     );
+  });
+});
+
+test('Transfer or Delete location should update inventory item', (assert) => {
+  return runWithPouchDump('inventory', async function() {
+    await authenticateUser();
+    await visit('/inventory/listing');
+    assert.equal(currentURL(), '/inventory/listing');
+
+    await click('button:contains(Edit)');
+    await click('button:contains(Transfer)');
+
+    await waitToAppear('.modal-dialog');
+    await typeAheadFillIn('.test-transfer-location', 'newLocation');
+    await fillIn('.test-adjustment-quantity input', 1000);
+    await click('button:contains(Transfer):last');
+    await waitToDisappear('.modal-dialog');
+
+    await click('button:contains(Return)');
+
+
+
+    assert.dom('tr .btn').exists({count: 4});
+    await click('button:contains(Edit)');
+
+    await click('button:contains(Delete)');
+    await waitToAppear('.modal-dialog');
+    await click('button:contains(Delete):last');
+    await waitToDisappear('.modal-dialog');
+
+    await click('button:contains(Return)');
+    assert.dom('tr .btn').exists({count: 4});
   });
 });
 

--- a/tests/acceptance/inventory-test.js
+++ b/tests/acceptance/inventory-test.js
@@ -108,29 +108,36 @@ test('Transfer or Delete location should update inventory item', (assert) => {
     await visit('/inventory/listing');
     assert.equal(currentURL(), '/inventory/listing');
 
+    // transfer all units to a new location
     await click('button:contains(Edit)');
     await click('button:contains(Transfer)');
-
     await waitToAppear('.modal-dialog');
     await typeAheadFillIn('.test-transfer-location', 'newLocation');
     await fillIn('.test-adjustment-quantity input', 1000);
     await click('button:contains(Transfer):last');
     await waitToDisappear('.modal-dialog');
-
     await click('button:contains(Return)');
 
-
-
+    // verify new location appears correctly along with default location
     assert.dom('tr .btn').exists({count: 4});
     await click('button:contains(Edit)');
+    assert.dom('.test-location-quantity').exists({count: 2});
+    assert.equal(find('.test-location-location:last:contains(newLocation)').length, 1, 'newLocation appears');
+    assert.equal(find('.test-location-quantity:last:contains(1000)').length, 1, 'Has correct quantity in newLocation');
 
+    // delete default location
     await click('button:contains(Delete)');
     await waitToAppear('.modal-dialog');
     await click('button:contains(Delete):last');
     await waitToDisappear('.modal-dialog');
-
     await click('button:contains(Return)');
+
+    // verify default location is gone and new location w/ all units is still there
     assert.dom('tr .btn').exists({count: 4});
+    await click('button:contains(Edit)');
+    assert.dom('.test-location-quantity').exists({count: 1});
+    assert.equal(find('.test-location-location:last:contains(newLocation)').length, 1, 'newLocation appears');
+    assert.equal(find('.test-location-quantity:last:contains(1000)').length, 1, 'Has correct quantity in newLocation');
   });
 });
 

--- a/tests/acceptance/inventory-test.js
+++ b/tests/acceptance/inventory-test.js
@@ -119,9 +119,9 @@ test('Transfer or Delete location should update inventory item', (assert) => {
     await click('button:contains(Return)');
 
     // verify new location appears correctly along with default location
-    assert.dom('tr .btn').exists({count: 4});
+    assert.dom('tr .btn').exists({ count: 4 });
     await click('button:contains(Edit)');
-    assert.dom('.test-location-quantity').exists({count: 2});
+    assert.dom('.test-location-quantity').exists({ count: 2 });
     assert.equal(find('.test-location-location:last:contains(newLocation)').length, 1, 'newLocation appears');
     assert.equal(find('.test-location-quantity:last:contains(1000)').length, 1, 'Has correct quantity in newLocation');
 
@@ -133,9 +133,9 @@ test('Transfer or Delete location should update inventory item', (assert) => {
     await click('button:contains(Return)');
 
     // verify default location is gone and new location w/ all units is still there
-    assert.dom('tr .btn').exists({count: 4});
+    assert.dom('tr .btn').exists({ count: 4 });
     await click('button:contains(Edit)');
-    assert.dom('.test-location-quantity').exists({count: 1});
+    assert.dom('.test-location-quantity').exists({ count: 1 });
     assert.equal(find('.test-location-location:last:contains(newLocation)').length, 1, 'newLocation appears');
     assert.equal(find('.test-location-quantity:last:contains(1000)').length, 1, 'Has correct quantity in newLocation');
   });


### PR DESCRIPTION
Fixes one of the bugs in #1439, next PR will fix the other one.

**Changes proposed in this pull request:**
The inventory/edit page lets you delete any inv-location that has 0 units assigned. But deleting this (through a modal dialog and inventory/delete) doesn't persist the inv-location's parent inventory model, so the inventory model's 'locations' property still contains a reference to the inv-location you deleted.

It's OK if you click "Update" on inventory/edit after you perform the deletion, but if you just delete and click "Return", you'll break the inventory model and you won't be able to view it anymore, and also break inventory/listing.

This PR sends an "update" action on inventory/edit controller automatically after an inv-location is deleted.

cc @HospitalRun/core-maintainers
