### PR TITLE
perf(docker): add `yarn` for faster dependency installs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install:
   - yarn global add greenkeeper-lockfile@1
 
 install:
-  - yarn install
+  - yarn install --silent
   - export DISPLAY=':99.0'
 
 before_script: greenkeeper-lockfile-update

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
----
 language: node_js
 node_js:
-  - "6"
+  - '6'
 
 dist: trusty
 sudo: required
@@ -9,9 +8,9 @@ sudo: required
 addons:
   apt:
     sources:
-    - ubuntu-toolchain-r-test
+      - ubuntu-toolchain-r-test
     packages:
-    - g++-4.8
+      - g++-4.8
 cache:
   yarn: true
   directories:
@@ -20,7 +19,7 @@ cache:
 
 before_install:
   - npm config set spin false
-  - "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1024x768x24"
+  - '/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1024x768x24'
   - yarn global add greenkeeper-lockfile@1
 
 install:
@@ -30,14 +29,11 @@ install:
 before_script: greenkeeper-lockfile-update
 
 script:
-  - npm run $COMMAND
+  - yarn run $COMMAND
 
 after_script: greenkeeper-lockfile-upload
 
 env:
   matrix:
-  - COMMAND=test
-  - CXX=g++-4.8 COMMAND=electron-test
-
-
-
+    - COMMAND=test
+    - CXX=g++-4.8 COMMAND=electron-test

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ cache:
     - $HOME/.cache # includes bowers cache
 
 before_install:
-  - npm config set spin false
   - '/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1024x768x24'
   - yarn global add greenkeeper-lockfile@1
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,12 +12,12 @@ RUN apk update && apk add \
   wget
 
 # install global npm dependencies
-RUN npm install -g ember-cli@latest
+RUN yarn global add ember-cli@latest
 
 # use changes to package.json to force Docker not to use the cache
 # when we change our application's nodejs dependencies:
 COPY package*.json /tmp/
-RUN cd /tmp && npm install
+RUN cd /tmp && yarn install --silent
 RUN mkdir -p /usr/src/app && cp -a /tmp/node_modules /usr/src/app
 
 # setup folders
@@ -34,4 +34,4 @@ RUN sed -i -e "s/localhost:5984/couchdb:5984/g" ./script/server.js
 
 EXPOSE 4200
 
-ENTRYPOINT ./script/initcouch.sh && npm start
+ENTRYPOINT ./script/initcouch.sh && yarn start


### PR DESCRIPTION
**Changes proposed in this pull request:**
- Replaced the usage of `npm` with `yarn` in Docker to improve build performance.

cc @HospitalRun/core-maintainers
