### PR TITLE
Fix 1543

### DIFF
--- a/app/incident/reports/controller.js
+++ b/app/incident/reports/controller.js
@@ -63,21 +63,23 @@ export default AbstractReportController.extend(UserSession, NumberFormat, {
   _findIncidentsByDate() {
     let filterEndDate = get(this, 'endDate');
     let filterStartDate = get(this, 'startDate');
+
     let findParams = {
       options: {},
       mapReduce: 'incident_by_date'
     };
-    let maxValue = get(this, 'maxValue');
-    return new RSVP.Promise(function(resolve, reject) {
-      if (isEmpty(filterStartDate)) {
-        reject('Start date cannot be an empty value.');
-      }
-      findParams.options.startkey =  [filterStartDate.getTime(), null];
 
-      if (!isEmpty(filterEndDate)) {
-        filterEndDate = moment(filterEndDate).endOf('day').toDate();
-        findParams.options.endkey =  [filterEndDate.getTime(), maxValue];
+    let maxValue = get(this, 'maxValue');
+
+    return new RSVP.Promise(function(resolve, reject) {
+      if (isEmpty(filterStartDate) || isEmpty(filterEndDate)) {
+        reject('Start or End date cannot be an empty value.');
       }
+
+      findParams.options.startkey =  [filterStartDate.getTime(), null];
+      filterEndDate = moment(filterEndDate).endOf('day').toDate();
+      findParams.options.endkey =  [filterEndDate.getTime(), maxValue];
+
       return this.store.query('incident', findParams).then(resolve, reject);
     }.bind(this));
   },
@@ -145,6 +147,12 @@ export default AbstractReportController.extend(UserSession, NumberFormat, {
 
   actions: {
     generateReport() {
+
+      if (isEmpty(get(this, 'endDate'))) {
+        let now = new Date();
+        this.set('endDate', now);
+      }
+
       let reportRows = get(this, 'reportRows');
       let reportType = get(this, 'reportType');
       reportRows.clear();

--- a/app/inventory/reports/controller.js
+++ b/app/inventory/reports/controller.js
@@ -1295,6 +1295,11 @@ export default AbstractReportController.extend(LocationName, ModalHelper, Number
   actions: {
     generateReport() {
       let endDate = this.get('endDate');
+      if (isEmpty(endDate)) {
+        let now = new Date();
+        this.set('endDate', now);
+      }
+
       let reportRows = this.get('reportRows');
       let reportType = this.get('reportType');
       let startDate = this.get('startDate');

--- a/app/patients/reports/controller.js
+++ b/app/patients/reports/controller.js
@@ -855,6 +855,11 @@ export default AbstractReportController.extend(PatientDiagnosis, PatientVisits, 
 
   actions: {
     generateReport() {
+      if (isEmpty(this.get('endDate'))) {
+        let now = new Date();
+        this.set('endDate', now);
+      }
+
       if (this._validateDates()) {
         let reportRows = this.get('reportRows');
         let reportType = this.get('reportType');

--- a/tests/acceptance/inventory-test.js
+++ b/tests/acceptance/inventory-test.js
@@ -5,7 +5,7 @@ import runWithPouchDump from 'hospitalrun/tests/helpers/run-with-pouch-dump';
 import select from 'hospitalrun/tests/helpers/select';
 import selectDate from 'hospitalrun/tests/helpers/select-date';
 import typeAheadFillIn from 'hospitalrun/tests/helpers/typeahead-fillin';
-import { waitToAppear, waitToDisappear } from 'hospitalrun/tests/helpers/wait-to-appear';
+import { waitToAppear } from 'hospitalrun/tests/helpers/wait-to-appear';
 import { authenticateUser } from 'hospitalrun/tests/helpers/authenticate-user';
 
 moduleForAcceptance('Acceptance | inventory');
@@ -99,45 +99,6 @@ test('Items with negative quantites should not be saved', (assert) => {
       'not a valid number',
       'Error message should be present for invalid quantities'
     );
-  });
-});
-
-test('Transfer or Delete location should update inventory item', (assert) => {
-  return runWithPouchDump('inventory', async function() {
-    await authenticateUser();
-    await visit('/inventory/listing');
-    assert.equal(currentURL(), '/inventory/listing');
-
-    // transfer all units to a new location
-    await click('button:contains(Edit)');
-    await click('button:contains(Transfer)');
-    await waitToAppear('.modal-dialog');
-    await typeAheadFillIn('.test-transfer-location', 'newLocation');
-    await fillIn('.test-adjustment-quantity input', 1000);
-    await click('button:contains(Transfer):last');
-    await waitToDisappear('.modal-dialog');
-    await click('button:contains(Return)');
-
-    // verify new location appears correctly along with default location
-    assert.dom('tr .btn').exists({ count: 4 });
-    await click('button:contains(Edit)');
-    assert.dom('.test-location-quantity').exists({ count: 2 });
-    assert.equal(find('.test-location-location:last:contains(newLocation)').length, 1, 'newLocation appears');
-    assert.equal(find('.test-location-quantity:last:contains(1000)').length, 1, 'Has correct quantity in newLocation');
-
-    // delete default location
-    await click('button:contains(Delete)');
-    await waitToAppear('.modal-dialog');
-    await click('button:contains(Delete):last');
-    await waitToDisappear('.modal-dialog');
-    await click('button:contains(Return)');
-
-    // verify default location is gone and new location w/ all units is still there
-    assert.dom('tr .btn').exists({ count: 4 });
-    await click('button:contains(Edit)');
-    assert.dom('.test-location-quantity').exists({ count: 1 });
-    assert.equal(find('.test-location-location:last:contains(newLocation)').length, 1, 'newLocation appears');
-    assert.equal(find('.test-location-quantity:last:contains(1000)').length, 1, 'Has correct quantity in newLocation');
   });
 });
 
@@ -296,19 +257,34 @@ test('Searching inventory', function(assert) {
   });
 });
 
-testSimpleReportForm('Detailed Adjustment');
-testSimpleReportForm('Detailed Purchase');
-testSimpleReportForm('Detailed Stock Usage');
-testSimpleReportForm('Detailed Stock Transfer');
-testSimpleReportForm('Detailed Expenses');
-testSimpleReportForm('Expiration Date');
-testSimpleReportForm('Summary Expenses');
-testSimpleReportForm('Summary Purchase');
-testSimpleReportForm('Summary Stock Usage');
-testSimpleReportForm('Summary Stock Transfer');
-testSimpleReportForm('Finance Summary');
-testSingleDateReportForm('Inventory By Location');
-testSingleDateReportForm('Inventory Valuation');
+const startAndEndDateReportTypes = [
+  'Days Supply Left In Stock',
+  'Detailed Adjustment',
+  'Detailed Purchase',
+  'Detailed Stock Usage',
+  'Detailed Stock Transfer',
+  'Detailed Expenses',
+  'Expiration Date',
+  'Summary Expenses',
+  'Summary Purchase',
+  'Summary Stock Usage',
+  'Summary Stock Transfer',
+  'Finance Summary'
+];
+
+const singleDateReportTypes = [
+  'Inventory By Location',
+  'Inventory Valuation'
+];
+
+startAndEndDateReportTypes.forEach((reportName) => {
+  testSimpleReportForm(reportName);
+  testReportWithEmptyEndDate(reportName);
+});
+
+singleDateReportTypes.forEach((reportName) => {
+  testSingleDateReportForm(reportName);
+});
 
 function testSimpleReportForm(reportName) {
   test(`${reportName} report can be generated`, function(assert) {
@@ -333,18 +309,48 @@ function testSimpleReportForm(reportName) {
   });
 }
 
+async function generateReport(reportName, startDate, endDate) {
+  await authenticateUser();
+  await visit('/inventory/reports');
+
+  if (startDate) {
+    await selectDate('.test-start-date input', moment(startDate).toDate());
+  }
+
+  if (endDate) {
+    await selectDate('.test-end-date input', moment(endDate).toDate());
+  }
+
+  await select('#report-type', `${reportName}`);
+  await click('button:contains(Generate Report)');
+  await waitToAppear('.panel-title');
+}
+
+function testReportWithEmptyEndDate(reportName) {
+  test(`${reportName} report can be generated with empty end date`, function(assert) {
+    return runWithPouchDump('default', async function() {
+
+      let startDate = '12/11/2016';
+      let endDate = new Date();
+      await generateReport(reportName, startDate, null);
+      assert.equal(currentURL(), '/inventory/reports');
+
+      let reportTitle = `${reportName} Report ${moment(startDate).format('l')} - ${moment(endDate).format('l')}`;
+      assert.dom('.panel-title').hasText(reportTitle, `${reportName} Report generated`);
+      let exportLink = findWithAssert('a:contains(Export Report)');
+      assert.equal($(exportLink).attr('download'), `${reportTitle}.csv`);
+    });
+  });
+}
+
 function testSingleDateReportForm(reportName) {
   test(`${reportName} report can be generated`, function(assert) {
     return runWithPouchDump('default', async function() {
-      await authenticateUser();
-      await visit('/inventory/reports');
+      let startDate = new Date();
+      await generateReport(reportName, null, null);
+
       assert.equal(currentURL(), '/inventory/reports');
-
-      await select('#report-type', `${reportName}`);
-      await click('button:contains(Generate Report)');
-      await waitToAppear('.panel-title');
-
-      let reportTitle = `${reportName} Report ${moment().format('l')}`;
+      let reportTitle = `${reportName} Report ${moment(startDate).format('l')}`;
       assert.dom('.panel-title').hasText(reportTitle, `${reportName} Report generated`);
       let exportLink = findWithAssert('a:contains(Export Report)');
       assert.equal($(exportLink).attr('download'), `${reportTitle}.csv`);


### PR DESCRIPTION
Fixes #1543 

**Changes proposed in this pull request:**
* adds functionality for reporting modules to automatically select an end date if one was not chosen. It will default to the current date based on the user's system. 
* updates relevant tests

This autofill functionality is consistent with the Inventory Valuation and Inventory by Location Reports where the single date is auto filled to the current date based on the user's system if one was not provided. 

cc @HospitalRun/core-maintainers

