### PR TITLE
Add link to v1.6.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ yarn install
   - **Note:** *If you just want to use the project, cloning is the best option. However, if you wish to contribute to the project, you will need to fork the project first, and then clone your `hospitalrun-frontend` fork and make your contributions via a branch on your fork.*
 6. Install and configure [CouchDB](http://couchdb.apache.org/):
     1. Download and install CouchDB from http://couchdb.apache.org/#download.
+      - Note: CouchDB v1.6.1 is recommended for this project, and the current version, CouchDB 2.3.0, is not fully supported. Files for v1.6.1 are available on [the Apache Archives](http://archive.apache.org/dist/couchdb/binary/mac/1.6.1/).
     2. Start CouchDB:
         1. If you downloaded the installed app, navigate to CouchDB and double-click on the application.
         2. If you installed CouchDB via Homebrew or some other command line tool, launch the tool from the command line.


### PR DESCRIPTION
Due to the issues surrounding CouchDB v2.3.0, it would be very helpful to add a direct link to the archived location of v1.6.1 and mention that it is the recommended, working version of CouchDB to use with the HospitalRun project. The instructions currently direct you to download CouchDB, and then reveal, several steps later, that v2.3.0 (the version linked to) is experimental and not fully supported.

I spent a while scratching my head last night trying to clone and set up the project, and after I found CouchDB v1.6.1 on the Apache archives, everything immediately clicked and built just fine. Finding the particular page and version of CouchDB is a bit of a nested process, and linking directly to it, along with a note for the purpose of doing that, will be beneficial to anyone coming to HospitalRun for the first time.

**Changes proposed in this pull request:**
- Add link to CouchDB v1.6.1
- Add note that CouchDB v2.3.0 isn't fully supported before user installs v2.3.0

@HospitalRun/core-maintainers