### PR TITLE
Update Travis badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ HospitalRun frontend
 
 _Ember frontend for [HospitalRun](http://hospitalrun.io/): free software for developing world hospitals_
 
-[![Build Status](https://travis-ci.org/HospitalRun/hospitalrun-frontend.svg?branch=master)](https://travis-ci.org/HospitalRun/hospitalrun-frontend) [![CouchDB](https://img.shields.io/badge/couchdb-1.x-green.svg)](http://couchdb.apache.org/)
+[![Build Status](https://travis-ci.com/HospitalRun/hospitalrun-frontend.svg?branch=master)](https://travis-ci.com/HospitalRun/hospitalrun-frontend) [![CouchDB](https://img.shields.io/badge/couchdb-1.x-green.svg)](http://couchdb.apache.org/)
 
 To run the development environment for this frontend you will need to have [Git](https://git-scm.com/), [Node.js](https://nodejs.org), [Ember CLI](http://ember-cli.com/), [Bower](http://bower.io/), and [CouchDB](http://couchdb.apache.org/) installed.
 


### PR DESCRIPTION
Update Travis.ci URL from travis-ci.org to the functional travis-ci.com

Fixes Travis badge

**Changes proposed in this pull request:**
- Change Travis badge URL to the functional travis-ci.com

cc @HospitalRun/core-maintainers
