### PR TITLE
chore(package): fix broken lint script

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "pretest": "npm run lint && npm run build",
     "test": "react-scripts test",
     "test:ci": "cross-env CI=true react-scripts test",
-    "lint": "eslint './src/**/*.{ts,tsx}'",
+    "lint": "eslint ./src/**/*.{ts,tsx}",
     "coveralls": "jest --coverage --coverageReporters=text-lcov | coveralls",
     "semantic-release": "semantic-release"
   },


### PR DESCRIPTION
**Changes proposed in this pull request:**
Currently running `npm run lint` or `yarn lint` results in an error saying no files can be found. This is due to the `'` that is surrounding the expression to find files in the script. Removing them fixes the issue.