### PR TITLE
feat(appointments): adds ability to display appointments on calendar

### DIFF
--- a/src/__tests__/HospitalRun.test.tsx
+++ b/src/__tests__/HospitalRun.test.tsx
@@ -114,6 +114,7 @@ describe('HospitalRun', () => {
             store={mockStore({
               title: 'test',
               user: { permissions: [Permissions.ReadAppointments] },
+              appointments: { appointments: [] },
             })}
           >
             <MemoryRouter initialEntries={['/appointments']}>
@@ -131,6 +132,7 @@ describe('HospitalRun', () => {
             store={mockStore({
               title: 'test',
               user: { permissions: [] },
+              appointments: { appointments: [] },
             })}
           >
             <MemoryRouter initialEntries={['/appointments']}>

--- a/src/__tests__/scheduling/appointments-slice.test.ts
+++ b/src/__tests__/scheduling/appointments-slice.test.ts
@@ -1,12 +1,16 @@
 import { AnyAction } from 'redux'
+import { mocked } from 'ts-jest/utils'
 import Appointment from 'model/Appointment'
 import { createMemoryHistory } from 'history'
 import AppointmentRepository from 'clients/db/AppointmentsRepository'
+
 import appointments, {
   createAppointmentStart,
   createAppointment,
+  getAppointmentsStart,
+  getAppointmentsSuccess,
+  fetchAppointments,
 } from '../../scheduling/appointments/appointments-slice'
-import { mocked } from 'ts-jest/utils'
 
 describe('appointments slice', () => {
   describe('appointments reducer', () => {
@@ -21,6 +25,81 @@ describe('appointments slice', () => {
       })
 
       expect(appointmentsStore.isLoading).toBeTruthy()
+    })
+
+    it('should handle the GET_APPOINTMENTS_START action', () => {
+      const appointmentsStore = appointments(undefined, {
+        type: getAppointmentsStart.type,
+      })
+
+      expect(appointmentsStore.isLoading).toBeTruthy()
+    })
+
+    it('should handle the GET_APPOINTMENTS_SUCCESS action', () => {
+      const expectedAppointments = [
+        {
+          patientId: '1234',
+          startDateTime: new Date().toISOString(),
+          endDateTime: new Date().toISOString(),
+        },
+      ]
+      const appointmentsStore = appointments(undefined, {
+        type: getAppointmentsSuccess.type,
+        payload: expectedAppointments,
+      })
+
+      expect(appointmentsStore.isLoading).toBeFalsy()
+      expect(appointmentsStore.appointments).toEqual(expectedAppointments)
+    })
+  })
+
+  describe('fetchAppointments()', () => {
+    let findAllSpy = jest.spyOn(AppointmentRepository, 'findAll')
+    const expectedAppointments: Appointment[] = [
+      {
+        id: '1',
+        rev: '1',
+        patientId: '123',
+        startDateTime: new Date().toISOString(),
+        endDateTime: new Date().toISOString(),
+        location: 'location',
+        type: 'type',
+        reason: 'reason',
+      },
+    ]
+
+    beforeEach(() => {
+      findAllSpy = jest.spyOn(AppointmentRepository, 'findAll')
+      mocked(AppointmentRepository, true).findAll.mockResolvedValue(
+        expectedAppointments as Appointment[],
+      )
+    })
+
+    it('should dispatch the GET_APPOINTMENTS_START event', async () => {
+      const dispatch = jest.fn()
+      const getState = jest.fn()
+      await fetchAppointments()(dispatch, getState, null)
+
+      expect(dispatch).toHaveBeenCalledWith({ type: getAppointmentsStart.type })
+    })
+
+    it('should call the AppointmentsRepository findAll() function', async () => {
+      const dispatch = jest.fn()
+      const getState = jest.fn()
+      await fetchAppointments()(dispatch, getState, null)
+
+      expect(findAllSpy).toHaveBeenCalled()
+    })
+
+    it('should dispatch the GET_APPOINTMENTS_SUCCESS event', async () => {
+      const dispatch = jest.fn()
+      const getState = jest.fn()
+      await fetchAppointments()(dispatch, getState, null)
+
+      expect(dispatch).toHaveBeenCalledWith({
+        type: getAppointmentsSuccess.type,
+        payload: expectedAppointments,
+      })
     })
   })
 

--- a/src/scheduling/appointments/Appointments.tsx
+++ b/src/scheduling/appointments/Appointments.tsx
@@ -1,12 +1,61 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import { Calendar } from '@hospitalrun/components'
 import useTitle from 'page-header/useTitle'
 import { useTranslation } from 'react-i18next'
+import { useSelector, useDispatch } from 'react-redux'
+import { RootState } from 'store'
+import { useHistory } from 'react-router'
+import { fetchAppointments } from './appointments-slice'
+
+interface Event {
+  id: string
+  start: Date
+  end: Date
+  title: string
+  allDay: boolean
+}
 
 const Appointments = () => {
   const { t } = useTranslation()
+  const history = useHistory()
   useTitle(t('scheduling.appointments.label'))
-  return <Calendar />
+  const dispatch = useDispatch()
+  const { appointments } = useSelector((state: RootState) => state.appointments)
+  const [events, setEvents] = useState<Event[]>([])
+
+  useEffect(() => {
+    dispatch(fetchAppointments())
+  }, [dispatch])
+
+  useEffect(() => {
+    if (appointments) {
+      const newEvents: Event[] = []
+      appointments.forEach((a) => {
+        const event = {
+          id: a.id,
+          start: new Date(a.startDateTime),
+          end: new Date(a.endDateTime),
+          title: a.patientId,
+          allDay: false,
+        }
+
+        newEvents.push(event)
+      })
+
+      setEvents(newEvents)
+    }
+  }, [appointments])
+
+  return (
+    <div>
+      <Calendar
+        events={events}
+        onEventClick={(event) => {
+          history.push(`/appointments/${event.id}`)
+        }}
+      />
+    </div>
+  )
 }
 
 export default Appointments

--- a/src/scheduling/appointments/appointments-slice.ts
+++ b/src/scheduling/appointments/appointments-slice.ts
@@ -1,14 +1,16 @@
-import { createSlice } from '@reduxjs/toolkit'
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 import Appointment from 'model/Appointment'
 import { AppThunk } from 'store'
 import AppointmentRepository from 'clients/db/AppointmentsRepository'
 
 interface AppointmentsState {
   isLoading: boolean
+  appointments: Appointment[]
 }
 
 const initialState: AppointmentsState = {
   isLoading: false,
+  appointments: [],
 }
 
 function startLoading(state: AppointmentsState) {
@@ -20,10 +22,25 @@ const appointmentsSlice = createSlice({
   initialState,
   reducers: {
     createAppointmentStart: startLoading,
+    getAppointmentsStart: startLoading,
+    getAppointmentsSuccess: (state, { payload }: PayloadAction<Appointment[]>) => {
+      state.isLoading = false
+      state.appointments = payload
+    },
   },
 })
 
-export const { createAppointmentStart } = appointmentsSlice.actions
+export const {
+  createAppointmentStart,
+  getAppointmentsStart,
+  getAppointmentsSuccess,
+} = appointmentsSlice.actions
+
+export const fetchAppointments = (): AppThunk => async (dispatch) => {
+  dispatch(getAppointmentsStart())
+  const appointments = await AppointmentRepository.findAll()
+  dispatch(getAppointmentsSuccess(appointments))
+}
 
 export const createAppointment = (appointment: Appointment, history: any): AppThunk => async (
   dispatch,

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -2,6 +2,7 @@ import { configureStore, combineReducers, Action } from '@reduxjs/toolkit'
 import ReduxThunk, { ThunkAction } from 'redux-thunk'
 import patient from '../patients/patient-slice'
 import patients from '../patients/patients-slice'
+import appointments from '../scheduling/appointments/appointments-slice'
 import title from '../page-header/title-slice'
 import user from '../user/user-slice'
 
@@ -10,6 +11,7 @@ const reducer = combineReducers({
   patients,
   title,
   user,
+  appointments,
 })
 
 const store = configureStore({


### PR DESCRIPTION
Fixes #1767 .

**Changes proposed in this pull request:**

- adds the ability to fetch appointments and display them on the calendar. 
** Note: this is an extremely naive implementation of this. It fetches all records in PouchDB. Once https://github.com/HospitalRun/components/issues/255 is implemented, it will give a better understanding of what this interface will need to be and what kind of data needs to be pulled back.  
