### PR TITLE
test(tests): improve coverage, fix issues and errors in tests, cleanup

### DIFF
--- a/src/__mocks__/i18next.js
+++ b/src/__mocks__/i18next.js
@@ -1,0 +1,12 @@
+const i18next = jest.genMockFromModule('i18next')
+
+function use() {
+  return this
+}
+
+const t = (k) => k
+
+i18next.use = use
+i18next.t = t
+
+module.exports = i18next

--- a/src/__tests__/HospitalRun.test.tsx
+++ b/src/__tests__/HospitalRun.test.tsx
@@ -7,6 +7,7 @@ import { mocked } from 'ts-jest/utils'
 import thunk from 'redux-thunk'
 import configureMockStore from 'redux-mock-store'
 import { Toaster } from '@hospitalrun/components'
+import { act } from 'react-dom/test-utils'
 import Dashboard from 'dashboard/Dashboard'
 import Appointments from 'scheduling/appointments/Appointments'
 import NewAppointment from 'scheduling/appointments/new/NewAppointment'
@@ -107,7 +108,7 @@ describe('HospitalRun', () => {
         expect(wrapper.find(Dashboard)).toHaveLength(1)
       })
 
-      it('should render the Dashboard when the user does not have read patient privileges', () => {
+      it('should render the Dashboard when the user does not have write patient privileges', () => {
         const wrapper = mount(
           <Provider
             store={mockStore({
@@ -190,6 +191,10 @@ describe('HospitalRun', () => {
             </MemoryRouter>
           </Provider>,
         )
+
+        await act(async () => {
+          wrapper.update()
+        })
 
         expect(wrapper.find(Appointments)).toHaveLength(1)
       })

--- a/src/__tests__/page-header/useTitle.test.tsx
+++ b/src/__tests__/page-header/useTitle.test.tsx
@@ -1,12 +1,12 @@
 import React from 'react'
 import { renderHook } from '@testing-library/react-hooks'
-import createMockStore from 'redux-mock-store'
+import configureMockStore from 'redux-mock-store'
 import thunk from 'redux-thunk'
 import { Provider } from 'react-redux'
 import useTitle from '../../page-header/useTitle'
 import * as titleSlice from '../../page-header/title-slice'
 
-const store = createMockStore([thunk])
+const store = configureMockStore([thunk])
 
 describe('useTitle', () => {
   it('should call the updateTitle with the correct data', () => {

--- a/src/__tests__/patients/GeneralInformation.test.tsx
+++ b/src/__tests__/patients/GeneralInformation.test.tsx
@@ -27,7 +27,7 @@ describe('Error handling', () => {
   })
 })
 
-describe('General Information', () => {
+describe('General Information, without isEditable', () => {
   const patient = {
     id: '123',
     prefix: 'prefix',
@@ -42,7 +42,7 @@ describe('General Information', () => {
     email: 'email@email.com',
     address: 'address',
     friendlyId: 'P00001',
-    dateOfBirth: new Date().toISOString(),
+    dateOfBirth: '1957-06-14T05:00:00.000Z',
     isApproximateDateOfBirth: false,
   } as Patient
 
@@ -163,6 +163,9 @@ describe('General Information', () => {
   })
 
   it('should render the age and date of birth as approximate if patient.isApproximateDateOfBirth is true', async () => {
+    jest
+      .spyOn(global.Date, 'now')
+      .mockImplementation(() => new Date('1987-06-14T05:00:00.000Z').valueOf())
     patient.isApproximateDateOfBirth = true
     await act(async () => {
       wrapper = await mount(
@@ -175,8 +178,309 @@ describe('General Information', () => {
     wrapper.update()
 
     const ageInput = wrapper.findWhere((w: any) => w.prop('name') === 'approximateAge')
-    expect(ageInput.prop('value')).toEqual('0')
+    expect(ageInput.prop('value')).toEqual('30')
     expect(ageInput.prop('label')).toEqual('patient.approximateAge')
     expect(ageInput.prop('isEditable')).toBeFalsy()
+  })
+})
+
+describe('General Information, isEditable', () => {
+  const patient = {
+    id: '123',
+    prefix: 'prefix',
+    givenName: 'givenName',
+    familyName: 'familyName',
+    suffix: 'suffix',
+    sex: 'male',
+    type: 'charity',
+    occupation: 'occupation',
+    preferredLanguage: 'preferredLanguage',
+    phoneNumber: 'phoneNumber',
+    email: 'email@email.com',
+    address: 'address',
+    friendlyId: 'P00001',
+    dateOfBirth: '1957-06-14T05:00:00.000Z',
+    isApproximateDateOfBirth: false,
+  } as Patient
+
+  let wrapper: ReactWrapper
+  let history = createMemoryHistory()
+
+  const onFieldChange = jest.fn()
+
+  beforeEach(() => {
+    history = createMemoryHistory()
+    wrapper = mount(
+      <Router history={history}>
+        <GeneralInformation patient={patient} onFieldChange={onFieldChange} isEditable />)
+      </Router>,
+    )
+  })
+
+  beforeEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  const expectedPrefix = 'expectedPrefix'
+  const expectedGivenName = 'expectedGivenName'
+  const expectedFamilyName = 'expectedFamilyName'
+  const expectedSuffix = 'expectedSuffix'
+  const expectedSex = 'expectedSex'
+  const expectedType = 'expectedType'
+  const expectedOccupation = 'expectedOccupation'
+  const expectedPreferredLanguage = 'expectedPreferredLanguage'
+  const expectedPhoneNumber = 'expectedPhoneNumber'
+  const expectedEmail = 'expectedEmail'
+  const expectedAddress = 'expectedAddress'
+  const expectedDateOfBirth = '1937-06-14T05:00:00.000Z'
+
+  it('should render the prefix', () => {
+    const prefixInput = wrapper.findWhere((w: any) => w.prop('name') === 'prefix')
+    const generalInformation = wrapper.find(GeneralInformation)
+    expect(prefixInput.prop('value')).toEqual(patient.prefix)
+    expect(prefixInput.prop('label')).toEqual('patient.prefix')
+    expect(prefixInput.prop('isEditable')).toBeTruthy()
+
+    act(() => {
+      prefixInput.prop('onChange')({ target: { value: expectedPrefix } })
+    })
+
+    expect(generalInformation.prop('onFieldChange')).toHaveBeenCalledWith('prefix', expectedPrefix)
+  })
+
+  it('should render the given name', () => {
+    const givenNameInput = wrapper.findWhere((w: any) => w.prop('name') === 'givenName')
+    const generalInformation = wrapper.find(GeneralInformation)
+    expect(givenNameInput.prop('value')).toEqual(patient.givenName)
+    expect(givenNameInput.prop('label')).toEqual('patient.givenName')
+    expect(givenNameInput.prop('isEditable')).toBeTruthy()
+
+    act(() => {
+      givenNameInput.prop('onChange')({ target: { value: expectedGivenName } })
+    })
+
+    expect(generalInformation.prop('onFieldChange')).toHaveBeenCalledWith(
+      'givenName',
+      expectedGivenName,
+    )
+  })
+
+  it('should render the family name', () => {
+    const familyNameInput = wrapper.findWhere((w: any) => w.prop('name') === 'familyName')
+    const generalInformation = wrapper.find(GeneralInformation)
+
+    expect(familyNameInput.prop('value')).toEqual(patient.familyName)
+    expect(familyNameInput.prop('label')).toEqual('patient.familyName')
+    expect(familyNameInput.prop('isEditable')).toBeTruthy()
+
+    act(() => {
+      familyNameInput.prop('onChange')({ target: { value: expectedFamilyName } })
+    })
+
+    expect(generalInformation.prop('onFieldChange')).toHaveBeenCalledWith(
+      'familyName',
+      expectedFamilyName,
+    )
+  })
+
+  it('should render the suffix', () => {
+    const suffixInput = wrapper.findWhere((w: any) => w.prop('name') === 'suffix')
+    const generalInformation = wrapper.find(GeneralInformation)
+
+    expect(suffixInput.prop('value')).toEqual(patient.suffix)
+    expect(suffixInput.prop('label')).toEqual('patient.suffix')
+    expect(suffixInput.prop('isEditable')).toBeTruthy()
+
+    act(() => {
+      suffixInput.prop('onChange')({ target: { value: expectedSuffix } })
+    })
+
+    expect(generalInformation.prop('onFieldChange')).toHaveBeenCalledWith('suffix', expectedSuffix)
+  })
+
+  it('should render the sex select', () => {
+    const sexSelect = wrapper.findWhere((w: any) => w.prop('name') === 'sex')
+    const generalInformation = wrapper.find(GeneralInformation)
+
+    expect(sexSelect.prop('value')).toEqual(patient.sex)
+    expect(sexSelect.prop('label')).toEqual('patient.sex')
+    expect(sexSelect.prop('isEditable')).toBeTruthy()
+    expect(sexSelect.prop('options')).toHaveLength(4)
+    expect(sexSelect.prop('options')[0].label).toEqual('sex.male')
+    expect(sexSelect.prop('options')[0].value).toEqual('male')
+    expect(sexSelect.prop('options')[1].label).toEqual('sex.female')
+    expect(sexSelect.prop('options')[1].value).toEqual('female')
+    expect(sexSelect.prop('options')[2].label).toEqual('sex.other')
+    expect(sexSelect.prop('options')[2].value).toEqual('other')
+    expect(sexSelect.prop('options')[3].label).toEqual('sex.unknown')
+    expect(sexSelect.prop('options')[3].value).toEqual('unknown')
+
+    act(() => {
+      sexSelect.prop('onChange')({ target: { value: expectedSex } })
+    })
+
+    expect(generalInformation.prop('onFieldChange')).toHaveBeenCalledWith('sex', expectedSex)
+  })
+
+  it('should render the patient type select', () => {
+    const typeSelect = wrapper.findWhere((w: any) => w.prop('name') === 'type')
+    const generalInformation = wrapper.find(GeneralInformation)
+
+    expect(typeSelect.prop('value')).toEqual(patient.type)
+    expect(typeSelect.prop('label')).toEqual('patient.type')
+    expect(typeSelect.prop('isEditable')).toBeTruthy()
+    expect(typeSelect.prop('options')).toHaveLength(2)
+    expect(typeSelect.prop('options')[0].label).toEqual('patient.types.charity')
+    expect(typeSelect.prop('options')[0].value).toEqual('charity')
+    expect(typeSelect.prop('options')[1].label).toEqual('patient.types.private')
+    expect(typeSelect.prop('options')[1].value).toEqual('private')
+
+    act(() => {
+      typeSelect.prop('onChange')({ target: { value: expectedType } })
+    })
+
+    expect(generalInformation.prop('onFieldChange')).toHaveBeenCalledWith('type', expectedType)
+  })
+
+  it('should render the date of the birth of the patient', () => {
+    const dateOfBirthInput = wrapper.findWhere((w: any) => w.prop('name') === 'dateOfBirth')
+    const generalInformation = wrapper.find(GeneralInformation)
+
+    expect(dateOfBirthInput.prop('value')).toEqual(new Date(patient.dateOfBirth))
+    expect(dateOfBirthInput.prop('label')).toEqual('patient.dateOfBirth')
+    expect(dateOfBirthInput.prop('isEditable')).toBeTruthy()
+
+    act(() => {
+      dateOfBirthInput.prop('onChange')(new Date(expectedDateOfBirth))
+    })
+
+    expect(generalInformation.prop('onFieldChange')).toHaveBeenCalledWith(
+      'dateOfBirth',
+      expectedDateOfBirth,
+    )
+  })
+
+  it('should render the occupation of the patient', () => {
+    const occupationInput = wrapper.findWhere((w: any) => w.prop('name') === 'occupation')
+    const generalInformation = wrapper.find(GeneralInformation)
+
+    expect(occupationInput.prop('value')).toEqual(patient.occupation)
+    expect(occupationInput.prop('label')).toEqual('patient.occupation')
+    expect(occupationInput.prop('isEditable')).toBeTruthy()
+
+    act(() => {
+      occupationInput.prop('onChange')({ target: { value: expectedOccupation } })
+    })
+
+    expect(generalInformation.prop('onFieldChange')).toHaveBeenCalledWith(
+      'occupation',
+      expectedOccupation,
+    )
+  })
+
+  it('should render the preferred language of the patient', () => {
+    const preferredLanguageInput = wrapper.findWhere(
+      (w: any) => w.prop('name') === 'preferredLanguage',
+    )
+    const generalInformation = wrapper.find(GeneralInformation)
+
+    expect(preferredLanguageInput.prop('value')).toEqual(patient.preferredLanguage)
+    expect(preferredLanguageInput.prop('label')).toEqual('patient.preferredLanguage')
+    expect(preferredLanguageInput.prop('isEditable')).toBeTruthy()
+
+    act(() => {
+      preferredLanguageInput.prop('onChange')({ target: { value: expectedPreferredLanguage } })
+    })
+
+    expect(generalInformation.prop('onFieldChange')).toHaveBeenCalledWith(
+      'preferredLanguage',
+      expectedPreferredLanguage,
+    )
+  })
+
+  it('should render the phone number of the patient', () => {
+    const phoneNumberInput = wrapper.findWhere((w: any) => w.prop('name') === 'phoneNumber')
+    const generalInformation = wrapper.find(GeneralInformation)
+
+    expect(phoneNumberInput.prop('value')).toEqual(patient.phoneNumber)
+    expect(phoneNumberInput.prop('label')).toEqual('patient.phoneNumber')
+    expect(phoneNumberInput.prop('isEditable')).toBeTruthy()
+
+    act(() => {
+      phoneNumberInput.prop('onChange')({ target: { value: expectedPhoneNumber } })
+    })
+
+    expect(generalInformation.prop('onFieldChange')).toHaveBeenCalledWith(
+      'phoneNumber',
+      expectedPhoneNumber,
+    )
+  })
+
+  it('should render the email of the patient', () => {
+    const emailInput = wrapper.findWhere((w: any) => w.prop('name') === 'email')
+    const generalInformation = wrapper.find(GeneralInformation)
+
+    expect(emailInput.prop('value')).toEqual(patient.email)
+    expect(emailInput.prop('label')).toEqual('patient.email')
+    expect(emailInput.prop('isEditable')).toBeTruthy()
+
+    act(() => {
+      emailInput.prop('onChange')({ target: { value: expectedEmail } })
+    })
+
+    expect(generalInformation.prop('onFieldChange')).toHaveBeenCalledWith('email', expectedEmail)
+  })
+
+  it('should render the address of the patient', () => {
+    const addressInput = wrapper.findWhere((w: any) => w.prop('name') === 'address')
+    const generalInformation = wrapper.find(GeneralInformation)
+
+    expect(addressInput.prop('value')).toEqual(patient.address)
+    expect(addressInput.prop('label')).toEqual('patient.address')
+    expect(addressInput.prop('isEditable')).toBeTruthy()
+
+    act(() => {
+      addressInput.prop('onChange')({ currentTarget: { value: expectedAddress } })
+    })
+
+    expect(generalInformation.prop('onFieldChange')).toHaveBeenCalledWith(
+      'address',
+      expectedAddress,
+    )
+  })
+
+  it('should render the age and date of birth as approximate if patient.isApproximateDateOfBirth is true', async () => {
+    jest
+      .spyOn(global.Date, 'now')
+      .mockImplementation(() => new Date('1987-06-14T05:00:00.000Z').valueOf())
+
+    patient.isApproximateDateOfBirth = true
+    await act(async () => {
+      wrapper = await mount(
+        <Router history={history}>
+          <GeneralInformation patient={patient} onFieldChange={jest.fn()} isEditable />)
+        </Router>,
+      )
+    })
+
+    wrapper.update()
+
+    // original patient born in '57, Date.now() mocked to '87, so value should be initially
+    // set to 30 years. when user changes to 20 years, onFieldChange should be called to
+    // set dateOfBirth to '67.
+    const approximateAgeInput = wrapper.findWhere((w: any) => w.prop('name') === 'approximateAge')
+    const generalInformation = wrapper.find(GeneralInformation)
+    expect(approximateAgeInput.prop('value')).toEqual('30')
+    expect(approximateAgeInput.prop('label')).toEqual('patient.approximateAge')
+    expect(approximateAgeInput.prop('isEditable')).toBeTruthy()
+
+    act(() => {
+      approximateAgeInput.prop('onChange')({ target: { value: '20' } })
+    })
+
+    expect(generalInformation.prop('onFieldChange')).toHaveBeenCalledWith(
+      'dateOfBirth',
+      '1967-06-14T05:00:00.000Z',
+    )
   })
 })

--- a/src/__tests__/patients/GeneralInformation.test.tsx
+++ b/src/__tests__/patients/GeneralInformation.test.tsx
@@ -4,6 +4,7 @@ import { Router } from 'react-router'
 import { mount, ReactWrapper } from 'enzyme'
 import GeneralInformation from 'patients/GeneralInformation'
 import { createMemoryHistory } from 'history'
+import { startOfDay, subYears } from 'date-fns'
 import { Alert } from '@hospitalrun/components'
 import { act } from '@testing-library/react'
 import Patient from '../../model/Patient'
@@ -42,7 +43,7 @@ describe('General Information, without isEditable', () => {
     email: 'email@email.com',
     address: 'address',
     friendlyId: 'P00001',
-    dateOfBirth: '1957-06-14T05:00:00.000Z',
+    dateOfBirth: startOfDay(subYears(new Date(), 30)).toISOString(),
     isApproximateDateOfBirth: false,
   } as Patient
 
@@ -162,10 +163,7 @@ describe('General Information, without isEditable', () => {
     expect(addressInput.prop('isEditable')).toBeFalsy()
   })
 
-  it('should render the age and date of birth as approximate if patient.isApproximateDateOfBirth is true', async () => {
-    jest
-      .spyOn(global.Date, 'now')
-      .mockImplementation(() => new Date('1987-06-14T05:00:00.000Z').valueOf())
+  it('should render the approximate age if patient.isApproximateDateOfBirth is true', async () => {
     patient.isApproximateDateOfBirth = true
     await act(async () => {
       wrapper = await mount(
@@ -178,6 +176,7 @@ describe('General Information, without isEditable', () => {
     wrapper.update()
 
     const ageInput = wrapper.findWhere((w: any) => w.prop('name') === 'approximateAge')
+
     expect(ageInput.prop('value')).toEqual('30')
     expect(ageInput.prop('label')).toEqual('patient.approximateAge')
     expect(ageInput.prop('isEditable')).toBeFalsy()
@@ -199,7 +198,7 @@ describe('General Information, isEditable', () => {
     email: 'email@email.com',
     address: 'address',
     friendlyId: 'P00001',
-    dateOfBirth: '1957-06-14T05:00:00.000Z',
+    dateOfBirth: startOfDay(subYears(new Date(), 30)).toISOString(),
     isApproximateDateOfBirth: false,
   } as Patient
 
@@ -449,11 +448,7 @@ describe('General Information, isEditable', () => {
     )
   })
 
-  it('should render the age and date of birth as approximate if patient.isApproximateDateOfBirth is true', async () => {
-    jest
-      .spyOn(global.Date, 'now')
-      .mockImplementation(() => new Date('1987-06-14T05:00:00.000Z').valueOf())
-
+  it('should render the approximate age if patient.isApproximateDateOfBirth is true', async () => {
     patient.isApproximateDateOfBirth = true
     await act(async () => {
       wrapper = await mount(
@@ -465,9 +460,6 @@ describe('General Information, isEditable', () => {
 
     wrapper.update()
 
-    // original patient born in '57, Date.now() mocked to '87, so value should be initially
-    // set to 30 years. when user changes to 20 years, onFieldChange should be called to
-    // set dateOfBirth to '67.
     const approximateAgeInput = wrapper.findWhere((w: any) => w.prop('name') === 'approximateAge')
     const generalInformation = wrapper.find(GeneralInformation)
     expect(approximateAgeInput.prop('value')).toEqual('30')
@@ -480,7 +472,7 @@ describe('General Information, isEditable', () => {
 
     expect(generalInformation.prop('onFieldChange')).toHaveBeenCalledWith(
       'dateOfBirth',
-      '1967-06-14T05:00:00.000Z',
+      startOfDay(subYears(new Date(Date.now()), 20)).toISOString(),
     )
   })
 })

--- a/src/__tests__/patients/new/NewPatient.test.tsx
+++ b/src/__tests__/patients/new/NewPatient.test.tsx
@@ -1,55 +1,83 @@
 import '../../../__mocks__/matchMediaMock'
 import React from 'react'
 import { mount } from 'enzyme'
-import { Router, MemoryRouter } from 'react-router-dom'
+import { Router, Route } from 'react-router-dom'
 import { Provider } from 'react-redux'
 import { mocked } from 'ts-jest/utils'
 import { createMemoryHistory } from 'history'
 import { act } from 'react-dom/test-utils'
 import { Button } from '@hospitalrun/components'
+import configureMockStore, { MockStore } from 'redux-mock-store'
+import thunk from 'redux-thunk'
 
 import NewPatient from '../../../patients/new/NewPatient'
 import GeneralInformation from '../../../patients/GeneralInformation'
-import store from '../../../store'
 import Patient from '../../../model/Patient'
 import * as patientSlice from '../../../patients/patient-slice'
 import * as titleUtil from '../../../page-header/useTitle'
 import PatientRepository from '../../../clients/db/PatientRepository'
 
+const mockStore = configureMockStore([thunk])
+
 describe('New Patient', () => {
-  it('should render a general information form', () => {
+  const patient = {
+    givenName: 'first',
+    fullName: 'first',
+  } as Patient
+
+  let history: any
+  let store: MockStore
+
+  const setup = () => {
+    jest.spyOn(PatientRepository, 'save')
+    const mockedPatientRepository = mocked(PatientRepository, true)
+    mockedPatientRepository.save.mockResolvedValue(patient)
+
+    history = createMemoryHistory()
+    store = mockStore({ patient: { patient: {} as Patient } })
+
+    history.push('/patients/new')
     const wrapper = mount(
       <Provider store={store}>
-        <MemoryRouter>
-          <NewPatient />
-        </MemoryRouter>
+        <Router history={history}>
+          <Route path="/patients/new">
+            <NewPatient />
+          </Route>
+        </Router>
       </Provider>,
     )
+
+    wrapper.update()
+    return wrapper
+  }
+
+  beforeEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('should render a general information form', async () => {
+    let wrapper: any
+    await act(async () => {
+      wrapper = await setup()
+    })
 
     expect(wrapper.find(GeneralInformation)).toHaveLength(1)
   })
 
-  it('should use "New Patient" as the header', () => {
+  it('should use "New Patient" as the header', async () => {
     jest.spyOn(titleUtil, 'default')
-    mount(
-      <Provider store={store}>
-        <MemoryRouter>
-          <NewPatient />
-        </MemoryRouter>
-      </Provider>,
-    )
+    await act(async () => {
+      await setup()
+    })
 
     expect(titleUtil.default).toHaveBeenCalledWith('patients.newPatient')
   })
 
-  it('should pass no given name error when form doesnt contain a given name on save button click', () => {
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter>
-          <NewPatient />,
-        </MemoryRouter>
-      </Provider>,
-    )
+  it('should pass no given name error when form doesnt contain a given name on save button click', async () => {
+    let wrapper: any
+    await act(async () => {
+      wrapper = await setup()
+    })
 
     const givenName = wrapper.findWhere((w: any) => w.prop('name') === 'givenName')
     expect(givenName.prop('value')).toBe('')
@@ -71,23 +99,11 @@ describe('New Patient', () => {
     )
   })
 
-  it('should call create patient when save button is clicked', async () => {
-    jest.spyOn(patientSlice, 'createPatient')
-    jest.spyOn(PatientRepository, 'save')
-    const mockedPatientRepository = mocked(PatientRepository, true)
-    const patient = {
-      givenName: 'first',
-      fullName: 'first',
-    } as Patient
-    mockedPatientRepository.save.mockResolvedValue(patient)
-
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter>
-          <NewPatient />
-        </MemoryRouter>
-      </Provider>,
-    )
+  it('should dispatch createPatient when save button is clicked', async () => {
+    let wrapper: any
+    await act(async () => {
+      wrapper = await setup()
+    })
 
     const generalInformationForm = wrapper.find(GeneralInformation)
 
@@ -101,22 +117,20 @@ describe('New Patient', () => {
     const onClick = saveButton.prop('onClick') as any
     expect(saveButton.text().trim()).toEqual('actions.save')
 
-    act(() => {
-      onClick()
+    await act(async () => {
+      await onClick()
     })
 
-    expect(patientSlice.createPatient).toHaveBeenCalledWith(patient, expect.anything())
+    expect(PatientRepository.save).toHaveBeenCalledWith(patient)
+    expect(store.getActions()).toContainEqual(patientSlice.createPatientStart())
+    expect(store.getActions()).toContainEqual(patientSlice.createPatientSuccess())
   })
 
-  it('should navigate to /patients when cancel is clicked', () => {
-    const history = createMemoryHistory()
-    const wrapper = mount(
-      <Provider store={store}>
-        <Router history={history}>
-          <NewPatient />
-        </Router>
-      </Provider>,
-    )
+  it('should navigate to /patients when cancel is clicked', async () => {
+    let wrapper: any
+    await act(async () => {
+      wrapper = await setup()
+    })
 
     const cancelButton = wrapper.find(Button).at(1)
     const onClick = cancelButton.prop('onClick') as any

--- a/src/__tests__/patients/patient-slice.test.ts
+++ b/src/__tests__/patients/patient-slice.test.ts
@@ -5,8 +5,8 @@ import { createMemoryHistory } from 'history'
 import * as components from '@hospitalrun/components'
 
 import patient, {
-  getPatientStart,
-  getPatientSuccess,
+  fetchPatientStart,
+  fetchPatientSuccess,
   fetchPatient,
   createPatientStart,
   createPatientSuccess,
@@ -30,15 +30,15 @@ describe('patients slice', () => {
       expect(patientStore.patient).toEqual({})
     })
 
-    it('should handle the GET_PATIENT_START action', () => {
+    it('should handle the FETCH_PATIENT_START action', () => {
       const patientStore = patient(undefined, {
-        type: getPatientStart.type,
+        type: fetchPatientStart.type,
       })
 
       expect(patientStore.isLoading).toBeTruthy()
     })
 
-    it('should handle the GET_PATIENT_SUCCESS actions', () => {
+    it('should handle the FETCH_PATIENT_SUCCESS actions', () => {
       const expectedPatient = {
         id: '123',
         rev: '123',
@@ -48,7 +48,7 @@ describe('patients slice', () => {
         familyName: 'test',
       }
       const patientStore = patient(undefined, {
-        type: getPatientSuccess.type,
+        type: fetchPatientSuccess.type,
         payload: {
           ...expectedPatient,
         },
@@ -182,13 +182,13 @@ describe('patients slice', () => {
       expect(mockedComponents.Toast).toHaveBeenCalledWith(
         'success',
         'Success!',
-        `Successfully created patient ${expectedGivenName} ${expectedFamilyName} ${expectedSuffix}`,
+        `patients.successfullyCreated ${expectedGivenName} ${expectedFamilyName} ${expectedSuffix}`,
       )
     })
   })
 
   describe('fetchPatient()', () => {
-    it('should dispatch the GET_PATIENT_START action', async () => {
+    it('should dispatch the FETCH_PATIENT_START action', async () => {
       const dispatch = jest.fn()
       const getState = jest.fn()
       jest.spyOn(PatientRepository, 'find')
@@ -199,7 +199,7 @@ describe('patients slice', () => {
 
       await fetchPatient(expectedPatientId)(dispatch, getState, null)
 
-      expect(dispatch).toHaveBeenCalledWith({ type: getPatientStart.type })
+      expect(dispatch).toHaveBeenCalledWith({ type: fetchPatientStart.type })
     })
 
     it('should call the PatientRepository find method with the correct patient id', async () => {
@@ -217,7 +217,7 @@ describe('patients slice', () => {
       expect(PatientRepository.find).toHaveBeenCalledWith(expectedPatientId)
     })
 
-    it('should dispatch the GET_PATIENT_SUCCESS action with the correct data', async () => {
+    it('should dispatch the FETCH_PATIENT_SUCCESS action with the correct data', async () => {
       const dispatch = jest.fn()
       const getState = jest.fn()
       jest.spyOn(PatientRepository, 'find')
@@ -229,7 +229,7 @@ describe('patients slice', () => {
       await fetchPatient(expectedPatientId)(dispatch, getState, null)
 
       expect(dispatch).toHaveBeenCalledWith({
-        type: getPatientSuccess.type,
+        type: fetchPatientSuccess.type,
         payload: {
           ...expectedPatient,
         },
@@ -307,7 +307,7 @@ describe('patients slice', () => {
       expect(mockedComponents.Toast).toHaveBeenCalledWith(
         'success',
         'Success!',
-        `Successfully updated patient ${expectedGivenName} ${expectedFamilyName} ${expectedSuffix}`,
+        `patients.successfullyUpdated ${expectedGivenName} ${expectedFamilyName} ${expectedSuffix}`,
       )
     })
   })

--- a/src/__tests__/patients/patients-slice.test.ts
+++ b/src/__tests__/patients/patients-slice.test.ts
@@ -2,8 +2,8 @@ import '../../__mocks__/matchMediaMock'
 import { AnyAction } from 'redux'
 import { mocked } from 'ts-jest/utils'
 import patients, {
-  getPatientsStart,
-  getAllPatientsSuccess,
+  fetchPatientsStart,
+  fetchPatientsSuccess,
   searchPatients,
 } from '../../patients/patients-slice'
 import Patient from '../../model/Patient'
@@ -21,10 +21,10 @@ describe('patients slice', () => {
       expect(patientsStore.patients).toHaveLength(0)
     })
 
-    it('should handle the GET_ALL_PATIENTS_SUCCESS action', () => {
+    it('should handle the FETCH_PATIENTS_SUCCESS action', () => {
       const expectedPatients = [{ id: '1234' }]
       const patientsStore = patients(undefined, {
-        type: getAllPatientsSuccess.type,
+        type: fetchPatientsSuccess.type,
         payload: [{ id: '1234' }],
       })
 
@@ -34,13 +34,13 @@ describe('patients slice', () => {
   })
 
   describe('searchPatients', () => {
-    it('should dispatch the GET_PATIENTS_START action', async () => {
+    it('should dispatch the FETCH_PATIENTS_START action', async () => {
       const dispatch = jest.fn()
       const getState = jest.fn()
 
       await searchPatients('search string')(dispatch, getState, null)
 
-      expect(dispatch).toHaveBeenCalledWith({ type: getPatientsStart.type })
+      expect(dispatch).toHaveBeenCalledWith({ type: fetchPatientsStart.type })
     })
 
     it('should call the PatientRepository search method with the correct search criteria', async () => {
@@ -54,7 +54,7 @@ describe('patients slice', () => {
       expect(PatientRepository.search).toHaveBeenCalledWith(expectedSearchString)
     })
 
-    it('should call the PatientRepository findALl method if there is no string text', async () => {
+    it('should call the PatientRepository findAll method if there is no string text', async () => {
       const dispatch = jest.fn()
       const getState = jest.fn()
       jest.spyOn(PatientRepository, 'findAll')
@@ -64,7 +64,7 @@ describe('patients slice', () => {
       expect(PatientRepository.findAll).toHaveBeenCalledTimes(1)
     })
 
-    it('should dispatch the GET_ALL_PATIENTS_SUCCESS action', async () => {
+    it('should dispatch the FETCH_PATIENTS_SUCCESS action', async () => {
       const dispatch = jest.fn()
       const getState = jest.fn()
 
@@ -80,7 +80,7 @@ describe('patients slice', () => {
       await searchPatients('search string')(dispatch, getState, null)
 
       expect(dispatch).toHaveBeenLastCalledWith({
-        type: getAllPatientsSuccess.type,
+        type: fetchPatientsSuccess.type,
         payload: expectedPatients,
       })
     })

--- a/src/__tests__/patients/related-persons/RelatedPersons.test.tsx
+++ b/src/__tests__/patients/related-persons/RelatedPersons.test.tsx
@@ -2,14 +2,14 @@ import '../../../__mocks__/matchMediaMock'
 import React from 'react'
 import { Router } from 'react-router'
 import { createMemoryHistory } from 'history'
-import { mount, ReactWrapper } from 'enzyme'
+import { mount } from 'enzyme'
 import RelatedPersonTab from 'patients/related-persons/RelatedPersonTab'
 import { Button, List, ListItem } from '@hospitalrun/components'
 import NewRelatedPersonModal from 'patients/related-persons/NewRelatedPersonModal'
 import { act } from '@testing-library/react'
 import PatientRepository from 'clients/db/PatientRepository'
 import Patient from 'model/Patient'
-import createMockStore from 'redux-mock-store'
+import configureMockStore from 'redux-mock-store'
 import thunk from 'redux-thunk'
 import { Provider } from 'react-redux'
 import Permissions from 'model/Permissions'
@@ -17,10 +17,10 @@ import { mocked } from 'ts-jest/utils'
 
 import * as patientSlice from '../../../patients/patient-slice'
 
-const mockStore = createMockStore([thunk])
+const mockStore = configureMockStore([thunk])
 
 describe('Related Persons Tab', () => {
-  let wrapper: ReactWrapper
+  let wrapper: any
   let history = createMemoryHistory()
 
   describe('Add New Related Person', () => {
@@ -91,18 +91,21 @@ describe('Related Persons Tab', () => {
       expect(newRelatedPersonModal.prop('show')).toBeTruthy()
     })
 
-    it('should call update patient with the data from the modal', () => {
-      jest.spyOn(patientSlice, 'updatePatient')
+    it('should call update patient with the data from the modal', async () => {
       jest.spyOn(PatientRepository, 'saveOrUpdate')
+      const store = mockStore({ patient, user })
       const expectedRelatedPerson = { patientId: '123', type: 'type' }
       const expectedPatient = {
         ...patient,
         relatedPersons: [expectedRelatedPerson],
       }
+      const mockedPatientRepository = mocked(PatientRepository, true)
+      mockedPatientRepository.saveOrUpdate.mockResolvedValue(expectedPatient)
+
       act(() => {
         wrapper = mount(
           <Router history={history}>
-            <Provider store={mockStore({ patient, user })}>
+            <Provider store={store}>
               <RelatedPersonTab patient={patient} />
             </Provider>
           </Router>,
@@ -115,15 +118,16 @@ describe('Related Persons Tab', () => {
       })
       wrapper.update()
 
-      act(() => {
+      await act(async () => {
         const newRelatedPersonModal = wrapper.find(NewRelatedPersonModal)
         const onSave = newRelatedPersonModal.prop('onSave') as any
         onSave(expectedRelatedPerson)
       })
       wrapper.update()
 
-      expect(patientSlice.updatePatient).toHaveBeenCalledTimes(1)
-      expect(patientSlice.updatePatient).toHaveBeenCalledWith(expectedPatient, history)
+      expect(PatientRepository.saveOrUpdate).toHaveBeenCalledWith(expectedPatient)
+      expect(store.getActions()).toContainEqual(patientSlice.updatePatientStart())
+      expect(store.getActions()).toContainEqual(patientSlice.updatePatientSuccess(expectedPatient))
     })
 
     it('should close the modal when the save button is clicked', () => {

--- a/src/__tests__/scheduling/appointments/Appointments.test.tsx
+++ b/src/__tests__/scheduling/appointments/Appointments.test.tsx
@@ -4,7 +4,7 @@ import { mount } from 'enzyme'
 import { MemoryRouter } from 'react-router-dom'
 import { Provider } from 'react-redux'
 import Appointments from 'scheduling/appointments/Appointments'
-import createMockStore from 'redux-mock-store'
+import configureMockStore from 'redux-mock-store'
 import thunk from 'redux-thunk'
 import { Calendar } from '@hospitalrun/components'
 import { act } from '@testing-library/react'
@@ -33,7 +33,7 @@ describe('Appointments', () => {
       id: '123',
       fullName: 'patient full name',
     } as Patient)
-    const mockStore = createMockStore([thunk])
+    const mockStore = configureMockStore([thunk])
     return mount(
       <Provider store={mockStore({ appointments: { appointments: expectedAppointments } })}>
         <MemoryRouter initialEntries={['/appointments']}>
@@ -43,9 +43,11 @@ describe('Appointments', () => {
     )
   }
 
-  it('should use "Appointments" as the header', () => {
+  it('should use "Appointments" as the header', async () => {
     jest.spyOn(titleUtil, 'default')
-    setup()
+    await act(async () => {
+      await setup()
+    })
     expect(titleUtil.default).toHaveBeenCalledWith('scheduling.appointments.label')
   })
 

--- a/src/__tests__/scheduling/appointments/appointment-slice.test.ts
+++ b/src/__tests__/scheduling/appointments/appointment-slice.test.ts
@@ -5,8 +5,8 @@ import { mocked } from 'ts-jest/utils'
 import PatientRepository from 'clients/db/PatientRepository'
 import Patient from 'model/Patient'
 import appointment, {
-  getAppointmentStart,
-  getAppointmentSuccess,
+  fetchAppointmentStart,
+  fetchAppointmentSuccess,
   fetchAppointment,
 } from '../../../scheduling/appointments/appointment-slice'
 
@@ -18,14 +18,14 @@ describe('appointment slice', () => {
       expect(appointmentStore.appointment).toEqual({} as Appointment)
       expect(appointmentStore.isLoading).toBeFalsy()
     })
-    it('should handle the GET_APPOINTMENT_START action', () => {
+    it('should handle the FETCH_APPOINTMENT_START action', () => {
       const appointmentStore = appointment(undefined, {
-        type: getAppointmentStart.type,
+        type: fetchAppointmentStart.type,
       })
 
       expect(appointmentStore.isLoading).toBeTruthy()
     })
-    it('should handle the GET_APPOINTMENT_SUCCESS action', () => {
+    it('should handle the FETCH_APPOINTMENT_SUCCESS action', () => {
       const expectedAppointment = {
         patientId: '1234',
         startDateTime: new Date().toISOString(),
@@ -38,7 +38,7 @@ describe('appointment slice', () => {
       }
 
       const appointmentStore = appointment(undefined, {
-        type: getAppointmentSuccess.type,
+        type: fetchAppointmentSuccess.type,
         payload: { appointment: expectedAppointment, patient: expectedPatient },
       })
 
@@ -75,12 +75,12 @@ describe('appointment slice', () => {
       mocked(PatientRepository, true).find.mockResolvedValue(expectedPatient)
     })
 
-    it('should dispatch the GET_APPOINTMENT_START action', async () => {
+    it('should dispatch the FETCH_APPOINTMENT_START action', async () => {
       const dispatch = jest.fn()
       const getState = jest.fn()
       await fetchAppointment('id')(dispatch, getState, null)
 
-      expect(dispatch).toHaveBeenCalledWith({ type: getAppointmentStart.type })
+      expect(dispatch).toHaveBeenCalledWith({ type: fetchAppointmentStart.type })
     })
 
     it('should call appointment repository find', async () => {
@@ -103,13 +103,13 @@ describe('appointment slice', () => {
       expect(findPatientSpy).toHaveBeenCalledWith(expectedId)
     })
 
-    it('should dispatch the GET_APPOINTMENT_SUCCESS action', async () => {
+    it('should dispatch the FETCH_APPOINTMENT_SUCCESS action', async () => {
       const dispatch = jest.fn()
       const getState = jest.fn()
       await fetchAppointment('id')(dispatch, getState, null)
 
       expect(dispatch).toHaveBeenCalledWith({
-        type: getAppointmentSuccess.type,
+        type: fetchAppointmentSuccess.type,
         payload: { appointment: expectedAppointment, patient: expectedPatient },
       })
     })

--- a/src/__tests__/scheduling/appointments/appointments-slice.test.ts
+++ b/src/__tests__/scheduling/appointments/appointments-slice.test.ts
@@ -7,8 +7,8 @@ import AppointmentRepository from 'clients/db/AppointmentsRepository'
 import appointments, {
   createAppointmentStart,
   createAppointment,
-  getAppointmentsStart,
-  getAppointmentsSuccess,
+  fetchAppointmentsStart,
+  fetchAppointmentsSuccess,
   fetchAppointments,
 } from '../../../scheduling/appointments/appointments-slice'
 
@@ -29,7 +29,7 @@ describe('appointments slice', () => {
 
     it('should handle the GET_APPOINTMENTS_START action', () => {
       const appointmentsStore = appointments(undefined, {
-        type: getAppointmentsStart.type,
+        type: fetchAppointmentsStart.type,
       })
 
       expect(appointmentsStore.isLoading).toBeTruthy()
@@ -44,7 +44,7 @@ describe('appointments slice', () => {
         },
       ]
       const appointmentsStore = appointments(undefined, {
-        type: getAppointmentsSuccess.type,
+        type: fetchAppointmentsSuccess.type,
         payload: expectedAppointments,
       })
 
@@ -75,12 +75,12 @@ describe('appointments slice', () => {
       )
     })
 
-    it('should dispatch the GET_APPOINTMENTS_START event', async () => {
+    it('should dispatch the FETCH_APPOINTMENTS_START event', async () => {
       const dispatch = jest.fn()
       const getState = jest.fn()
       await fetchAppointments()(dispatch, getState, null)
 
-      expect(dispatch).toHaveBeenCalledWith({ type: getAppointmentsStart.type })
+      expect(dispatch).toHaveBeenCalledWith({ type: fetchAppointmentsStart.type })
     })
 
     it('should call the AppointmentsRepository findAll() function', async () => {
@@ -91,13 +91,13 @@ describe('appointments slice', () => {
       expect(findAllSpy).toHaveBeenCalled()
     })
 
-    it('should dispatch the GET_APPOINTMENTS_SUCCESS event', async () => {
+    it('should dispatch the FETCH_APPOINTMENTS_SUCCESS event', async () => {
       const dispatch = jest.fn()
       const getState = jest.fn()
       await fetchAppointments()(dispatch, getState, null)
 
       expect(dispatch).toHaveBeenCalledWith({
-        type: getAppointmentsSuccess.type,
+        type: fetchAppointmentsSuccess.type,
         payload: expectedAppointments,
       })
     })

--- a/src/patients/GeneralInformation.tsx
+++ b/src/patients/GeneralInformation.tsx
@@ -40,7 +40,7 @@ const GeneralInformation = (props: Props) => {
       approximateAgeNumber = parseFloat(event.target.value)
     }
 
-    const approximateDateOfBirth = subYears(new Date(), approximateAgeNumber)
+    const approximateDateOfBirth = subYears(new Date(Date.now()), approximateAgeNumber)
     if (onFieldChange) {
       onFieldChange('dateOfBirth', startOfDay(approximateDateOfBirth).toISOString())
     }
@@ -137,7 +137,7 @@ const GeneralInformation = (props: Props) => {
                 label={t('patient.approximateAge')}
                 name="approximateAge"
                 type="number"
-                value={`${differenceInYears(new Date(), new Date(patient.dateOfBirth))}`}
+                value={`${differenceInYears(new Date(Date.now()), new Date(patient.dateOfBirth))}`}
                 isEditable={isEditable}
                 onChange={onApproximateAgeChange}
               />

--- a/src/patients/patient-slice.ts
+++ b/src/patients/patient-slice.ts
@@ -27,10 +27,10 @@ const patientSlice = createSlice({
   name: 'patient',
   initialState,
   reducers: {
-    getPatientStart: startLoading,
+    fetchPatientStart: startLoading,
     createPatientStart: startLoading,
     updatePatientStart: startLoading,
-    getPatientSuccess(state, { payload }: PayloadAction<Patient>) {
+    fetchPatientSuccess(state, { payload }: PayloadAction<Patient>) {
       state.isLoading = false
       state.patient = payload
     },
@@ -45,8 +45,8 @@ const patientSlice = createSlice({
 })
 
 export const {
-  getPatientStart,
-  getPatientSuccess,
+  fetchPatientStart,
+  fetchPatientSuccess,
   createPatientStart,
   createPatientSuccess,
   updatePatientStart,
@@ -54,9 +54,9 @@ export const {
 } = patientSlice.actions
 
 export const fetchPatient = (id: string): AppThunk => async (dispatch) => {
-  dispatch(getPatientStart())
+  dispatch(fetchPatientStart())
   const patient = await PatientRepository.find(id)
-  dispatch(getPatientSuccess(patient))
+  dispatch(fetchPatientSuccess(patient))
 }
 
 export const createPatient = (patient: Patient, history: any): AppThunk => async (dispatch) => {

--- a/src/patients/patients-slice.ts
+++ b/src/patients/patients-slice.ts
@@ -21,23 +21,23 @@ const patientsSlice = createSlice({
   name: 'patients',
   initialState,
   reducers: {
-    getPatientsStart: startLoading,
-    getAllPatientsSuccess(state, { payload }: PayloadAction<Patient[]>) {
+    fetchPatientsStart: startLoading,
+    fetchPatientsSuccess(state, { payload }: PayloadAction<Patient[]>) {
       state.isLoading = false
       state.patients = payload
     },
   },
 })
-export const { getPatientsStart, getAllPatientsSuccess } = patientsSlice.actions
+export const { fetchPatientsStart, fetchPatientsSuccess } = patientsSlice.actions
 
 export const fetchPatients = (): AppThunk => async (dispatch) => {
-  dispatch(getPatientsStart())
+  dispatch(fetchPatientsStart())
   const patients = await PatientRepository.findAll()
-  dispatch(getAllPatientsSuccess(patients))
+  dispatch(fetchPatientsSuccess(patients))
 }
 
 export const searchPatients = (searchString: string): AppThunk => async (dispatch) => {
-  dispatch(getPatientsStart())
+  dispatch(fetchPatientsStart())
 
   let patients
   if (searchString.trim() === '') {
@@ -46,7 +46,7 @@ export const searchPatients = (searchString: string): AppThunk => async (dispatc
     patients = await PatientRepository.search(searchString)
   }
 
-  dispatch(getAllPatientsSuccess(patients))
+  dispatch(fetchPatientsSuccess(patients))
 }
 
 export default patientsSlice.reducer

--- a/src/patients/view/ViewPatient.tsx
+++ b/src/patients/view/ViewPatient.tsx
@@ -63,8 +63,6 @@ const ViewPatient = () => {
                 color="success"
                 outlined
                 onClick={() => {
-                  console.log('pushying to hsitory patient was:')
-                  console.log(patient)
                   history.push(`/patients/edit/${patient.id}`)
                 }}
               >

--- a/src/scheduling/appointments/appointment-slice.ts
+++ b/src/scheduling/appointments/appointment-slice.ts
@@ -21,10 +21,10 @@ const appointmentSlice = createSlice({
   name: 'appointment',
   initialState: initialAppointmentState,
   reducers: {
-    getAppointmentStart: (state: AppointmentState) => {
+    fetchAppointmentStart: (state: AppointmentState) => {
       state.isLoading = true
     },
-    getAppointmentSuccess: (
+    fetchAppointmentSuccess: (
       state,
       { payload }: PayloadAction<{ appointment: Appointment; patient: Patient }>,
     ) => {
@@ -35,14 +35,14 @@ const appointmentSlice = createSlice({
   },
 })
 
-export const { getAppointmentStart, getAppointmentSuccess } = appointmentSlice.actions
+export const { fetchAppointmentStart, fetchAppointmentSuccess } = appointmentSlice.actions
 
 export const fetchAppointment = (id: string): AppThunk => async (dispatch) => {
-  dispatch(getAppointmentStart())
+  dispatch(fetchAppointmentStart())
   const appointment = await AppointmentRepository.find(id)
   const patient = await PatientRepository.find(appointment.patientId)
 
-  dispatch(getAppointmentSuccess({ appointment, patient }))
+  dispatch(fetchAppointmentSuccess({ appointment, patient }))
 }
 
 export default appointmentSlice.reducer

--- a/src/scheduling/appointments/appointments-slice.ts
+++ b/src/scheduling/appointments/appointments-slice.ts
@@ -22,8 +22,8 @@ const appointmentsSlice = createSlice({
   initialState,
   reducers: {
     createAppointmentStart: startLoading,
-    getAppointmentsStart: startLoading,
-    getAppointmentsSuccess: (state, { payload }: PayloadAction<Appointment[]>) => {
+    fetchAppointmentsStart: startLoading,
+    fetchAppointmentsSuccess: (state, { payload }: PayloadAction<Appointment[]>) => {
       state.isLoading = false
       state.appointments = payload
     },
@@ -32,14 +32,14 @@ const appointmentsSlice = createSlice({
 
 export const {
   createAppointmentStart,
-  getAppointmentsStart,
-  getAppointmentsSuccess,
+  fetchAppointmentsStart,
+  fetchAppointmentsSuccess,
 } = appointmentsSlice.actions
 
 export const fetchAppointments = (): AppThunk => async (dispatch) => {
-  dispatch(getAppointmentsStart())
+  dispatch(fetchAppointmentsStart())
   const appointments = await AppointmentRepository.findAll()
-  dispatch(getAppointmentsSuccess(appointments))
+  dispatch(fetchAppointmentsSuccess(appointments))
 }
 
 export const createAppointment = (appointment: Appointment, history: any): AppThunk => async (


### PR DESCRIPTION
Fixes #1804 partially

- Add better coverage for `GeneralInformation` that tests both editable and non-editable functionality
- Cleanup and standardize component test code
- Add assertions for Thunk actions using mock store's `store.getActions()` as described here https://medium.com/@philihp/testing-a-redux-connected-component-with-thunk-actions-with-enzyme-41be4cc0bdce
- Standardized naming of Redux actions such as `getAppointmentStart` to `fetchAppointmentStart` so actions that fetch data are named `fetch` consistently
- Removed `i18n` log messages from test output
- Removed some warnings from test output, but not all