### PR TITLE
fix(breadcrumb): set appointment date precision to minutes in breadcrumb

### DIFF
--- a/src/__tests__/scheduling/appointments/util/scheduling-appointment.util.test.ts
+++ b/src/__tests__/scheduling/appointments/util/scheduling-appointment.util.test.ts
@@ -4,17 +4,24 @@ import { getAppointmentLabel } from '../../../../scheduling/appointments/util/sc
 describe('scheduling appointment util', () => {
   describe('getAppointmentLabel', () => {
     it('should return the locale string representation of the start time and end time', () => {
+      const options = {
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+        hour: '2-digit',
+        minute: '2-digit',
+      }
+
       const appointment = {
         id: '123',
         startDateTime: '2020-03-07T18:15:00.000Z',
         endDateTime: '2020-03-07T20:15:00.000Z',
       } as Appointment
 
-      expect(getAppointmentLabel(appointment)).toEqual(
-        `${new Date(appointment.startDateTime).toLocaleString()} - ${new Date(
-          appointment.endDateTime,
-        ).toLocaleString()}`,
-      )
+      const startDateLabel = new Date(appointment.startDateTime).toLocaleString([], options)
+      const endDateLabel = new Date(appointment.endDateTime).toLocaleString([], options)
+
+      expect(getAppointmentLabel(appointment)).toEqual(`${startDateLabel} - ${endDateLabel}`)
     })
 
     it('should return the appointment id when start time is not defined', () => {

--- a/src/scheduling/appointments/util/scheduling-appointment.util.ts
+++ b/src/scheduling/appointments/util/scheduling-appointment.util.ts
@@ -1,9 +1,21 @@
 import Appointment from '../../../model/Appointment'
 
+const options = {
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+  hour: '2-digit',
+  minute: '2-digit',
+}
+
+function toLocaleString(date: Date) {
+  return date.toLocaleString([], options)
+}
+
 export function getAppointmentLabel(appointment: Appointment) {
   const { id, startDateTime, endDateTime } = appointment
 
   return startDateTime && endDateTime
-    ? `${new Date(startDateTime).toLocaleString()} - ${new Date(endDateTime).toLocaleString()}`
+    ? `${toLocaleString(new Date(startDateTime))} - ${toLocaleString(new Date(endDateTime))}`
     : id
 }


### PR DESCRIPTION
fix #1853

Set appointment date label precision to minutes