### PR TITLE
fix(./locales/enus/translations/scheduling/index.ts): changed 'Walk Up'

### DIFF
--- a/src/locales/enUs/translations/scheduling/index.ts
+++ b/src/locales/enUs/translations/scheduling/index.ts
@@ -15,7 +15,7 @@ export default {
         emergency: 'Emergency',
         followUp: 'Follow Up',
         routine: 'Routine',
-        walkUp: 'Walk Up',
+        walkIn: 'Walk In',
       },
       errors: {
         patientRequired: 'Patient is required.',


### PR DESCRIPTION
scheduling/appointments/AppointmentDetailForm.tsx label for 'walk in' is trying to consume
scheduling.appointment.types.walkIn but the translation file lists 'walkUp'. I changed the
translation file to reflect the value 'walk in'

