### PR TITLE
fix(schedual button): fixed delete appointment button

### DIFF
--- a/src/locales/enUs/translations/scheduling/index.ts
+++ b/src/locales/enUs/translations/scheduling/index.ts
@@ -4,6 +4,7 @@ export default {
     appointments: {
       label: 'Appointments',
       new: 'New Appointment',
+      deleteAppointment: 'Delete Appointment',
     },
     appointment: {
       startDate: 'Start Date',


### PR DESCRIPTION
Delete appointment button no longer displays internationalization keys and instead reads correctly.

Fixes #1901 

**Changes proposed in this pull request:**

- added "Delete Appointment" to localization file