### PR TITLE
fix(patients): changed Add Diagnoses button to Add Diagnosis

### DIFF
--- a/src/locales/enUs/translations/patient/index.ts
+++ b/src/locales/enUs/translations/patient/index.ts
@@ -50,7 +50,7 @@ export default {
     },
     diagnoses: {
       label: 'Diagnoses',
-      new: 'Add Diagnoses',
+      new: 'Add Diagnosis',
       diagnosisName: 'Diagnosis Name',
       diagnosisDate: 'Diagnosis Date',
       warning: {


### PR DESCRIPTION
Changed the spelling of the Add Diagnoses Button to Add Diagnosis for Issue Number 1929.

Fixes #1929 
