### PR TITLE
fix(breadcrumb label): edit Appointment label on breadcrumb

### DIFF
--- a/src/locales/enUs/translations/scheduling/index.ts
+++ b/src/locales/enUs/translations/scheduling/index.ts
@@ -5,6 +5,8 @@ export default {
       label: 'Appointments',
       new: 'New Appointment',
       schedule: 'Appointment Schedule',
+      editAppointment: 'Edit Appointment',
+      deleteAppointment: 'Delete Appointment',
     },
     appointment: {
       startDate: 'Start Date',


### PR DESCRIPTION
Fixes #[[1996](https://github.com/HospitalRun/hospitalrun-frontend/issues/1996)].

**Changes proposed in this pull request:**

- Added missing scheduling.appointments.editAppointment label
- Added missing scheduling.appointments.deleteAppointment label
