### PR TITLE
ci(gitpod): enhance gitpod setup.

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -22,6 +22,12 @@ To contribute,
 5. Install dependencies: `yarn`
 6. Run the application `yarn start`
 
+## Online one-click setup for contributing
+
+Contribute to HospitalRun using a fully featured online development environment that will automatically: clone the repo, install the dependencies and start the webserver.
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
+
 ### Optionally configure HospitalRun Server
 
 In most cases, this is not needed to contribute to the HospitalRun Frontend Repository. The following instructions are for connecting to HospitalRun Server during development and are not intended to be for production use. For production deployments, see the deployment instructions/

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,3 +1,11 @@
+tasks:
+  - init: yarn
+    command: yarn run start
+
+ports:
+  - port: 3000
+    onOpen: open-preview
+
 github:
   prebuilds:
     master: true

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![GitHub CI](https://github.com/HospitalRun/frontend/workflows/GitHub%20CI/badge.svg)](https://github.com/HospitalRun/frontend/actions) [![Coverage Status](https://coveralls.io/repos/github/HospitalRun/hospitalrun-frontend/badge.svg?branch=master)](https://coveralls.io/github/HospitalRun/hospitalrun-frontend?branch=master) [![Language grade: JavaScript](https://img.shields.io/lgtm/grade/javascript/g/HospitalRun/hospitalrun-frontend.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/HospitalRun/hospitalrun-frontend/context:javascript) [![Documentation Status](https://readthedocs.org/projects/hospitalrun-frontend/badge/?version=latest)](https://hospitalrun-frontend.readthedocs.io)
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2FHospitalRun%2Fhospitalrun-frontend.svg?type=shield)](https://app.fossa.io/projects/git%2Bgithub.com%2FHospitalRun%2Fhospitalrun-frontend?ref=badge_large) [![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/)
 ![dependabot](https://api.dependabot.com/badges/status?host=github&repo=HospitalRun/hospitalrun-frontend) [![Slack](https://hospitalrun-slack.herokuapp.com/badge.svg)](https://hospitalrun-slack.herokuapp.com) [![Run on Repl.it](https://repl.it/badge/github/HospitalRun/hospitalrun-frontend)](https://repl.it/github/HospitalRun/hospitalrun-frontend)
+[![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/from-referrer/)
 
 </div>
 
@@ -32,6 +33,12 @@ Contributions are always welcome. Before contributing please read our [contribut
 2. Navigate to the cloned folder: `cd hospitalrun-frontend`
 3. Install the dependencies: `yarn`
 4. Run `yarn run start` to build and watch for code changes
+
+## Online one-click setup for contributing
+
+Contribute to HospitalRun using a fully featured online development environment that will automatically: clone the repo, install the dependencies and start the webserver.
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
 
 ## Connecting to HospitalRun Server
 


### PR DESCRIPTION
Hi! 

This Pr enhances Gitpod setup it updates the config so that on the workspace startup Gitpod should pre-install all the dependencies and start the webserver. 

I have also added some description about it in the README and CONTRIBUTING.md so that people who are interested in contributing can benefit from Gitpod and start coding straight away without any friction in a single-click.

You can give the enhanced setup a try on my fork of the repo via this link:

https://gitpod.io/#https://github.com/nisarhassan12/hospitalrun-frontend

This is how it looks:

![image](https://user-images.githubusercontent.com/46004116/80267810-70a42280-86bc-11ea-839e-4a33612c0b94.png)

