### PR TITLE
fix(viewpatients): call PatientRepository.findAll() only once

### DIFF
--- a/src/__tests__/patients/list/ViewPatients.test.tsx
+++ b/src/__tests__/patients/list/ViewPatients.test.tsx
@@ -53,6 +53,18 @@ describe('Patients', () => {
     mockedPatientRepository.findAll.mockResolvedValue([])
   })
 
+  describe('initalLoad', () => {
+    afterEach(() => {
+      jest.restoreAllMocks()
+    })
+
+    it('should call fetchPatients only once', () => {
+      setup()
+      const findAllPagedSpy = jest.spyOn(PatientRepository, 'findAll')
+      expect(findAllPagedSpy).toHaveBeenCalledTimes(1)
+    })
+  })
+
   describe('layout', () => {
     afterEach(() => {
       jest.restoreAllMocks()

--- a/src/patients/list/ViewPatients.tsx
+++ b/src/patients/list/ViewPatients.tsx
@@ -6,7 +6,7 @@ import { Spinner, Button, Container, Row, TextInput, Column } from '@hospitalrun
 import { useButtonToolbarSetter } from 'page-header/ButtonBarProvider'
 import format from 'date-fns/format'
 import { RootState } from '../../store'
-import { fetchPatients, searchPatients } from '../patients-slice'
+import { searchPatients } from '../patients-slice'
 import useTitle from '../../page-header/useTitle'
 import useAddBreadcrumbs from '../../breadcrumbs/useAddBreadcrumbs'
 import useDebounce from '../../hooks/debounce'
@@ -32,8 +32,6 @@ const ViewPatients = () => {
   }, [dispatch, debouncedSearchText])
 
   useEffect(() => {
-    dispatch(fetchPatients())
-
     setButtonToolBar([
       <Button
         key="newPatientButton"


### PR DESCRIPTION
fix #2043

**Changes proposed in this pull request:**

- Remove redundant db call in `ViewPatients`
- Add test case

