### PR TITLE
fix: styling the Navbar to make it Sticky

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -70,6 +70,8 @@ code {
 
 .navbar {
   z-index: 1000;
+  position: sticky;
+  top: 0;
 }
 
 .navbar .form-control {


### PR DESCRIPTION
**Styling the Navbar to make it Sticky so as to cover the Empty Top-Left Corner of the Webpage after Scrolling**

**Fixes this [issue](https://github.com/HospitalRun/hospitalrun/issues/319).**

**Styling the Navbar to make it Sticky**

**Before Making the Navbar Sticky the Top-Left corner looks something like this on Scrolling:**
<img width="960" alt="before" src="https://user-images.githubusercontent.com/58421086/81292781-d4015d80-9089-11ea-9c01-3da85062dc39.PNG">

**After Making the Navbar Sticky the Top-Left corner looks something like this on Scrolling:**
<img width="960" alt="after" src="https://user-images.githubusercontent.com/58421086/81292823-eaa7b480-9089-11ea-859f-36ced9aff220.PNG">

