### PR TITLE
feat(labs): add requestedby to new laboratory request

### DIFF
--- a/src/__tests__/labs/lab-slice.test.ts
+++ b/src/__tests__/labs/lab-slice.test.ts
@@ -304,11 +304,19 @@ describe('lab slice', () => {
     })
 
     it('should request a new lab', async () => {
-      const store = mockStore()
+      const store = mockStore({
+        user: {
+          user: {
+            id: 'fake id',
+          },
+        },
+      } as any)
+
       const expectedRequestedLab = {
         ...mockLab,
         requestedOn: new Date(Date.now()).toISOString(),
         status: 'requested',
+        requestedBy: store.getState().user.user.id,
       } as Lab
 
       await store.dispatch(requestLab(mockLab))
@@ -321,7 +329,13 @@ describe('lab slice', () => {
     })
 
     it('should execute the onSuccess callback if provided', async () => {
-      const store = mockStore()
+      const store = mockStore({
+        user: {
+          user: {
+            id: 'fake id',
+          },
+        },
+      } as any)
       const onSuccessSpy = jest.fn()
 
       await store.dispatch(requestLab(mockLab, onSuccessSpy))

--- a/src/__tests__/labs/requests/NewLabRequest.test.tsx
+++ b/src/__tests__/labs/requests/NewLabRequest.test.tsx
@@ -27,7 +27,10 @@ describe('New Lab Request', () => {
     const history = createMemoryHistory()
 
     beforeEach(() => {
-      const store = mockStore({ title: '', lab: { status: 'loading', error: {} } })
+      const store = mockStore({
+        title: '',
+        lab: { status: 'loading', error: {} },
+      })
       titleSpy = jest.spyOn(titleUtil, 'default')
       history.push('/labs/new')
 
@@ -197,7 +200,11 @@ describe('New Lab Request', () => {
         .mockResolvedValue([{ id: expectedLab.patientId, fullName: 'some full name' }] as Patient[])
 
       history.push('/labs/new')
-      const store = mockStore({ title: '', lab: { status: 'loading', error: {} } })
+      const store = mockStore({
+        title: '',
+        lab: { status: 'loading', error: {} },
+        user: { user: { id: 'fake id' } },
+      })
       wrapper = mount(
         <Provider store={store}>
           <Router history={history}>

--- a/src/labs/lab-slice.ts
+++ b/src/labs/lab-slice.ts
@@ -105,6 +105,7 @@ const validateLabRequest = (newLab: Lab): Error => {
 
 export const requestLab = (newLab: Lab, onSuccess?: (lab: Lab) => void): AppThunk => async (
   dispatch,
+  getState,
 ) => {
   dispatch(requestLabStart())
 
@@ -115,6 +116,7 @@ export const requestLab = (newLab: Lab, onSuccess?: (lab: Lab) => void): AppThun
   } else {
     newLab.status = 'requested'
     newLab.requestedOn = new Date(Date.now().valueOf()).toISOString()
+    newLab.requestedBy = getState().user.user.id
     const requestedLab = await LabRepository.save(newLab)
     dispatch(requestLabSuccess(requestedLab))
 

--- a/src/model/Lab.ts
+++ b/src/model/Lab.ts
@@ -4,6 +4,7 @@ export default interface Lab extends AbstractDBModel {
   code: string
   patientId: string
   type: string
+  requestedBy: string
   notes?: string
   result?: string
   status: 'requested' | 'completed' | 'canceled'


### PR DESCRIPTION
Add new field `requestedBy` into the model. 
The field is auto filled by system when a new lab request is created.
The new field will contain the user id of the current user

fix #2082


**Changes proposed in this pull request:**

- add field to model
- update request lab action to fill the filed
- update tests

