### PR TITLE
chore(lint): turn off @typescript-eslint/explicit-module-boundary-types

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -43,6 +43,7 @@ module.exports = {
     'prettier/prettier': 'error',
     '@typescript-eslint/member-delimiter-style': 'off',
     '@typescript-eslint/explicit-function-return-type': 'off',
+    "@typescript-eslint/explicit-module-boundary-types": 'off',
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/no-unused-vars': ['error', { ignoreRestSiblings: true }],
     '@typescript-eslint/unified-signatures': 'error',

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,3 @@
-## Don't open the PR until it is ready for review.
-
 Fixes #[replace brackets with the issue number that your pull request addresses].
 
 **Changes proposed in this pull request:**


### PR DESCRIPTION
**Changes proposed in this pull request:**

- turns of `@typescript-eslint/explicit-module-boundary-types` to remove warnings occurring in linting process. This rule is similar to other requirements for not needing a return type on functions that we have already turned off.
