### PR TITLE
fix(bug) add the translation key for 'logout'

### DIFF
--- a/src/shared/components/navbar/Navbar.tsx
+++ b/src/shared/components/navbar/Navbar.tsx
@@ -107,7 +107,7 @@ const Navbar = () => {
             },
             {
               type: 'link',
-              label: t('logout'),
+              label: t('actions.logout'),
               onClick: () => {
                 dispatch(logout())
                 navigateTo('/login')

--- a/src/shared/locales/enUs/translations/actions/index.ts
+++ b/src/shared/locales/enUs/translations/actions/index.ts
@@ -16,5 +16,6 @@ export default {
     page: 'Page',
     add: 'Add',
     view: 'View',
+    logout: 'logout',
   },
 }


### PR DESCRIPTION
Add the translation key for 'logout' in
_src/shared/locales/translations/actions_ folder and made the appropriate
changes where the 'logout' text appears (like in navbar)

✅ Closes: #2188 




