### PR TITLE
fix: weird spacing issue in quick add icon

### DIFF
--- a/src/shared/components/navbar/Navbar.tsx
+++ b/src/shared/components/navbar/Navbar.tsx
@@ -19,7 +19,6 @@ const Navbar = () => {
   }
 
   const dividerAboveLabels = [
-    'patients.newPatient',
     'scheduling.appointments.new',
     'labs.requests.new',
     'incidents.reports.new',
@@ -35,7 +34,7 @@ const Navbar = () => {
         onClick: () => {
           navigateTo(page.path)
         },
-        dividerAbove: dividerAboveLabels.indexOf(page.label) > -1,
+        dividerAbove: dividerAboveLabels.includes(page.label),
       }))
   }
 


### PR DESCRIPTION
Fixes #2210 

**Changes proposed in this pull request:**
- Fixed weird spacing issue in quick add icon

**Newly added dependencies with [Bundlephobia](https://bundlephobia.com/) links:**
- No new dependencies added
