### PR TITLE
feat(navbar): display currently logged in user name

### DIFF
--- a/src/__tests__/shared/components/navbar/Navbar.test.tsx
+++ b/src/__tests__/shared/components/navbar/Navbar.test.tsx
@@ -170,13 +170,22 @@ describe('Navbar', () => {
   })
 
   describe('account', () => {
-    it('should render an account link list', () => {
+    it("should render a link with the user's identification", () => {
       const wrapper = setup(allPermissions)
       const hospitalRunNavbar = wrapper.find(HospitalRunNavbar)
       const accountLinkList = hospitalRunNavbar.find('.nav-account')
       const { children } = accountLinkList.first().props() as any
 
-      expect(children[0].props.children).toEqual([undefined, 'settings.label'])
+      expect(children[0].props.children).not.toBeUndefined()
+    })
+
+    it('should render a setting link list', () => {
+      const wrapper = setup(allPermissions)
+      const hospitalRunNavbar = wrapper.find(HospitalRunNavbar)
+      const accountLinkList = hospitalRunNavbar.find('.nav-account')
+      const { children } = accountLinkList.first().props() as any
+
+      expect(children[1].props.children).toEqual([undefined, 'settings.label'])
     })
 
     it('should navigate to /settings when the list option is selected', () => {
@@ -187,6 +196,7 @@ describe('Navbar', () => {
 
       act(() => {
         children[0].props.onClick()
+        children[1].props.onClick()
       })
 
       expect(history.location.pathname).toEqual('/settings')

--- a/src/__tests__/shared/components/navbar/Navbar.test.tsx
+++ b/src/__tests__/shared/components/navbar/Navbar.test.tsx
@@ -11,6 +11,7 @@ import thunk from 'redux-thunk'
 
 import Navbar from '../../../../shared/components/navbar/Navbar'
 import Permissions from '../../../../shared/model/Permissions'
+import User from '../../../../shared/model/User'
 import { RootState } from '../../../../shared/store'
 
 const mockStore = createMockStore<RootState, any>([thunk])
@@ -18,10 +19,10 @@ const mockStore = createMockStore<RootState, any>([thunk])
 describe('Navbar', () => {
   const history = createMemoryHistory()
 
-  const setup = (permissions: Permissions[]) => {
+  const setup = (permissions: Permissions[], user?: User) => {
     const store = mockStore({
       title: '',
-      user: { permissions },
+      user: { permissions, user },
     } as any)
 
     const wrapper = mount(
@@ -33,6 +34,11 @@ describe('Navbar', () => {
     )
     return wrapper
   }
+
+  const userName = {
+    givenName: 'givenName',
+    familyName: 'familyName',
+  } as User
 
   const allPermissions = [
     Permissions.ReadPatients,
@@ -171,12 +177,14 @@ describe('Navbar', () => {
 
   describe('account', () => {
     it("should render a link with the user's identification", () => {
-      const wrapper = setup(allPermissions)
+      const expectedUserName = `user.login.currentlySignedInAs ${userName.givenName} ${userName.familyName}`
+
+      const wrapper = setup(allPermissions, userName)
       const hospitalRunNavbar = wrapper.find(HospitalRunNavbar)
       const accountLinkList = hospitalRunNavbar.find('.nav-account')
       const { children } = accountLinkList.first().props() as any
 
-      expect(children[0].props.children).not.toBeUndefined()
+      expect(children[0].props.children).toEqual([undefined, expectedUserName])
     })
 
     it('should render a setting link list', () => {

--- a/src/shared/components/navbar/Navbar.tsx
+++ b/src/shared/components/navbar/Navbar.tsx
@@ -100,7 +100,9 @@ const Navbar = () => {
           children: [
             {
               type: 'link',
-              label: `${t('user.login.success')}${user?.givenName} ${user?.familyName}`,
+              label: `${t('user.login.currentlySignedInAs')} ${user?.givenName} ${
+                user?.familyName
+              }`,
               onClick: () => {
                 navigateTo('/settings')
               },

--- a/src/shared/components/navbar/Navbar.tsx
+++ b/src/shared/components/navbar/Navbar.tsx
@@ -12,7 +12,7 @@ const Navbar = () => {
   const dispatch = useDispatch()
   const history = useHistory()
   const { t } = useTranslator()
-  const { permissions } = useSelector((state: RootState) => state.user)
+  const { permissions, user } = useSelector((state: RootState) => state.user)
 
   const navigateTo = (location: string) => {
     history.push(location)
@@ -98,6 +98,13 @@ const Navbar = () => {
           type: 'link-list-icon',
           alignRight: true,
           children: [
+            {
+              type: 'link',
+              label: `${t('user.login.success')}${user?.givenName} ${user?.familyName}`,
+              onClick: () => {
+                navigateTo('/settings')
+              },
+            },
             {
               type: 'link',
               label: t('settings.label'),

--- a/src/shared/locales/enUs/translations/user/index.ts
+++ b/src/shared/locales/enUs/translations/user/index.ts
@@ -13,7 +13,7 @@ export default {
           required: 'Password is required.',
         },
       },
-      success: 'Currently signed in as ',
+      currentlySignedInAs: 'Currently signed in as',
     },
   },
 }

--- a/src/shared/locales/enUs/translations/user/index.ts
+++ b/src/shared/locales/enUs/translations/user/index.ts
@@ -13,6 +13,7 @@ export default {
           required: 'Password is required.',
         },
       },
+      success: 'Currently signed in as ',
     },
   },
 }


### PR DESCRIPTION
Fixes #2225 .

**Changes proposed in this pull request:**

- add ability to display user name in profile dropdown
- add ability to navigate to the setting route
- add new test for display user name 
- add translation key to display profile message


**No new dependency added**
