### PR TITLE
refactor(lab): rename lab request related buttons

### DIFF
--- a/src/__tests__/labs/requests/NewLabRequest.test.tsx
+++ b/src/__tests__/labs/requests/NewLabRequest.test.tsx
@@ -97,7 +97,7 @@ describe('New Lab Request', () => {
     it('should render a save button', () => {
       const saveButton = wrapper.find(Button).at(0)
       expect(saveButton).toBeDefined()
-      expect(saveButton.text().trim()).toEqual('actions.save')
+      expect(saveButton.text().trim()).toEqual('labs.requests.save')
     })
 
     it('should render a cancel button', () => {

--- a/src/labs/requests/NewLabRequest.tsx
+++ b/src/labs/requests/NewLabRequest.tsx
@@ -121,7 +121,7 @@ const NewLabRequest = () => {
         <div className="row float-right">
           <div className="btn-group btn-group-lg mt-3">
             <Button className="mr-2" color="success" onClick={onSave}>
-              {t('actions.save')}
+              {t('labs.requests.save')}
             </Button>
 
             <Button color="danger" onClick={onCancel}>

--- a/src/shared/locales/enUs/translations/labs/index.ts
+++ b/src/shared/locales/enUs/translations/labs/index.ts
@@ -13,7 +13,8 @@ export default {
     },
     requests: {
       label: 'Lab Requests',
-      new: 'New Lab Request',
+      new: 'Request Lab',
+      save: 'Request',
       view: 'View Lab',
       cancel: 'Cancel Lab',
       complete: 'Complete Lab',


### PR DESCRIPTION
fix #2296

**Changes proposed in this pull request:**
- Rename `New Lab Request` button to `Request Lab` in sidebar and quickAdd (Navbar)
- Rename `Save` button to `Request` in the new lab request page