### PR TITLE
fix(navbar): removed duplicate Report Incident link from quick create menu

### DIFF
--- a/src/shared/components/navbar/Navbar.tsx
+++ b/src/shared/components/navbar/Navbar.tsx
@@ -51,7 +51,6 @@ const Navbar = () => {
     pageMap.newLab,
     pageMap.newMedication,
     pageMap.newIncident,
-    pageMap.newIncident,
     pageMap.newImaging,
   ]
 


### PR DESCRIPTION
Fixes #2306 

**Changes proposed in this pull request:**

- Remove duplicated link from navbar quick create menu

**Newly added dependencies with [Bundlephobia](https://bundlephobia.com/) links:**

NONE

