### PR TITLE
feat(new scripts and updated contributing.md): added scripts to init and cleanup couchdb

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -18,14 +18,14 @@ root of this project to launch CouchDB. Below are the steps:
 
 1. Start [Docker](https://docs.docker.com/get-docker/). Install it if you don't have it yet.
 2. Install [Docker Compose](https://docs.docker.com/compose/install/) if you don't have it yet.
-3. Run `docker-compose up --build -d` in the root directory.
+3. Run `./couchdb/couchdb-init.sh` in the root directory.
 
 This should launch a new CouchDB instance on `http://localhost:5984`, create system database, configure CouchDB as Single Node, enable CORS, create `hospitalrun` database, create a default admin with a username of `admin` and password of 'password', create a sample user with a username of `username` and password of 'password' to use new login page [#2137](https://github.com/HospitalRun/hospitalrun-frontend/pull/2137).
 
 Go to `http://localhost:5984/_utils` in your browser to view Fauxton and perform administrative tasks.
 
 **_Cleanup_**
-To delete the development database, go to the root of the project and run `docker-compose down -v --rmi all --remove-orphans`
+To delete the development database, go to the root of the project and run `./couchdb/couchdb-cleanup.sh`
 
 ### Install dependencies & start the application
 

--- a/couchdb/couchdb-cleanup.sh
+++ b/couchdb/couchdb-cleanup.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+docker-compose down -v --rmi all --remove-orphans

--- a/couchdb/couchdb-init.sh
+++ b/couchdb/couchdb-init.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+docker-compose up --build -d


### PR DESCRIPTION
Added couchdb-init.sh to initialize couchdb and couchdb-cleanup.sh to cleanup couchdb according to instructions in CONTRIBUTING.md. 
I also updated the instructions in CONTRIBUTING.md to use those scripts.

**Changes proposed in this pull request:**

- encapsulated the calls to docker-compose for initializing and cleaning the database in their own scripts
- changed CONTRIBUTING.md accordingly

**Newly added dependencies with [Bundlephobia](https://bundlephobia.com/) links:**

NONE