### PR TITLE
fix(navigation): align quick menu with sidebar and mobile version

### DIFF
--- a/src/shared/components/navbar/Navbar.tsx
+++ b/src/shared/components/navbar/Navbar.tsx
@@ -48,10 +48,10 @@ const Navbar = () => {
   const addPages = [
     pageMap.newPatient,
     pageMap.newAppointment,
-    pageMap.newLab,
     pageMap.newMedication,
-    pageMap.newIncident,
+    pageMap.newLab,
     pageMap.newImaging,
+    pageMap.newIncident,
   ]
 
   return (

--- a/src/shared/components/navbar/pageMap.tsx
+++ b/src/shared/components/navbar/pageMap.tsx
@@ -35,6 +35,18 @@ const pageMap: {
     path: '/appointments',
     icon: 'appointment',
   },
+  newMedication: {
+    permission: Permissions.RequestMedication,
+    label: 'medications.requests.new',
+    path: '/medications/new',
+    icon: 'add',
+  },
+  viewMedications: {
+    permission: Permissions.ViewMedications,
+    label: 'medications.requests.label',
+    path: '/medications',
+    icon: 'medication',
+  },
   newLab: {
     permission: Permissions.RequestLab,
     label: 'labs.requests.new',
@@ -47,17 +59,17 @@ const pageMap: {
     path: '/labs',
     icon: 'lab',
   },
-  newMedication: {
-    permission: Permissions.RequestMedication,
-    label: 'medications.requests.new',
-    path: '/medications/new',
+  newImaging: {
+    permission: Permissions.RequestImaging,
+    label: 'imagings.requests.new',
+    path: '/imaging/new',
     icon: 'add',
   },
-  viewMedications: {
-    permission: Permissions.ViewMedications,
-    label: 'medications.requests.label',
-    path: '/medications',
-    icon: 'medication',
+  viewImagings: {
+    permission: Permissions.ReadPatients,
+    label: 'imagings.requests.label',
+    path: '/imaging',
+    icon: 'image',
   },
   newIncident: {
     permission: Permissions.ReportIncident,
@@ -82,18 +94,6 @@ const pageMap: {
     label: 'visits.visit.label',
     path: '/visits',
     icon: 'visit',
-  },
-  newImaging: {
-    permission: Permissions.RequestImaging,
-    label: 'imagings.requests.new',
-    path: '/imaging/new',
-    icon: 'add',
-  },
-  viewImagings: {
-    permission: Permissions.ReadPatients,
-    label: 'imagings.requests.label',
-    path: '/imaging',
-    icon: 'image',
   },
   settings: {
     permission: null,


### PR DESCRIPTION
The corrects the issue #2326
https://github.com/HospitalRun/hospitalrun-frontend/issues/2326

Fixes #2326

**Changes proposed in this pull request:**
- Reordered the navigation menu items

### Before
![image](https://user-images.githubusercontent.com/6052223/91320776-e6fc8280-e78b-11ea-99e2-17da51d73345.png)

### After
![image](https://user-images.githubusercontent.com/6052223/91320654-cdf3d180-e78b-11ea-8ec1-9a4ecc6e766e.png)
