### PR TITLE
refactor(patient): refactor patient appointments to use react query

### DIFF
--- a/src/__tests__/patients/appointments/AppointmentsList.test.tsx
+++ b/src/__tests__/patients/appointments/AppointmentsList.test.tsx
@@ -1,6 +1,6 @@
 import * as components from '@hospitalrun/components'
 import { Table } from '@hospitalrun/components'
-import { mount } from 'enzyme'
+import { mount, ReactWrapper } from 'enzyme'
 import { createMemoryHistory } from 'history'
 import React from 'react'
 import { act } from 'react-dom/test-utils'
@@ -64,13 +64,13 @@ const setup = async (patient = expectedPatient, appointments = expectedAppointme
 
   wrapper.update()
 
-  return wrapper
+  return { wrapper: wrapper as ReactWrapper }
 }
 
 describe('AppointmentsList', () => {
   describe('Table', () => {
     it('should render a list of appointments', async () => {
-      const wrapper = await setup()
+      const { wrapper } = await setup()
 
       const table = wrapper.find(Table)
 
@@ -100,7 +100,7 @@ describe('AppointmentsList', () => {
     })
 
     it('should navigate to appointment profile on appointment click', async () => {
-      const wrapper = await setup()
+      const { wrapper } = await setup()
       const tr = wrapper.find('tr').at(1)
 
       act(() => {
@@ -114,7 +114,7 @@ describe('AppointmentsList', () => {
 
   describe('Empty list', () => {
     it('should render a warning message if there are no appointments', async () => {
-      const wrapper = await setup(expectedPatient, [])
+      const { wrapper } = await setup(expectedPatient, [])
       const alert = wrapper.find(components.Alert)
 
       expect(alert).toHaveLength(1)
@@ -125,7 +125,7 @@ describe('AppointmentsList', () => {
 
   describe('New appointment button', () => {
     it('should render a new appointment button', async () => {
-      const wrapper = await setup()
+      const { wrapper } = await setup()
 
       const addNewAppointmentButton = wrapper.find(components.Button).at(0)
       expect(addNewAppointmentButton).toHaveLength(1)
@@ -133,7 +133,7 @@ describe('AppointmentsList', () => {
     })
 
     it('should navigate to new appointment page', async () => {
-      const wrapper = await setup()
+      const { wrapper } = await setup()
 
       await act(async () => {
         await wrapper.find(components.Button).at(0).simulate('click')

--- a/src/__tests__/patients/appointments/AppointmentsList.test.tsx
+++ b/src/__tests__/patients/appointments/AppointmentsList.test.tsx
@@ -45,26 +45,35 @@ const history = createMemoryHistory()
 
 let store: any
 
-const setup = (patient = expectedPatient, appointments = expectedAppointments) => {
+const setup = async (patient = expectedPatient, appointments = expectedAppointments) => {
   jest.resetAllMocks()
   jest.spyOn(PatientRepository, 'getAppointments').mockResolvedValue(appointments)
   store = mockStore({ patient, appointments: { appointments } } as any)
-  const wrapper = mount(
-    <Router history={history}>
-      <Provider store={store}>
-        <AppointmentsList patientId={patient.id} />
-      </Provider>
-    </Router>,
-  )
+
+  let wrapper: any
+
+  await act(async () => {
+    wrapper = await mount(
+      <Router history={history}>
+        <Provider store={store}>
+          <AppointmentsList patientId={patient.id} />
+        </Provider>
+      </Router>,
+    )
+  })
+
+  wrapper.update()
+
   return wrapper
 }
 
 describe('AppointmentsList', () => {
   describe('Table', () => {
-    it('should render a list of appointments', () => {
-      const wrapper = setup()
+    it('should render a list of appointments', async () => {
+      const wrapper = await setup()
 
       const table = wrapper.find(Table)
+
       const columns = table.prop('columns')
       const actions = table.prop('actions') as any
 
@@ -91,7 +100,7 @@ describe('AppointmentsList', () => {
     })
 
     it('should navigate to appointment profile on appointment click', async () => {
-      const wrapper = setup()
+      const wrapper = await setup()
       const tr = wrapper.find('tr').at(1)
 
       act(() => {
@@ -104,8 +113,8 @@ describe('AppointmentsList', () => {
   })
 
   describe('Empty list', () => {
-    it('should render a warning message if there are no appointments', () => {
-      const wrapper = setup(expectedPatient, [])
+    it('should render a warning message if there are no appointments', async () => {
+      const wrapper = await setup(expectedPatient, [])
       const alert = wrapper.find(components.Alert)
 
       expect(alert).toHaveLength(1)
@@ -115,8 +124,8 @@ describe('AppointmentsList', () => {
   })
 
   describe('New appointment button', () => {
-    it('should render a new appointment button', () => {
-      const wrapper = setup()
+    it('should render a new appointment button', async () => {
+      const wrapper = await setup()
 
       const addNewAppointmentButton = wrapper.find(components.Button).at(0)
       expect(addNewAppointmentButton).toHaveLength(1)
@@ -124,7 +133,7 @@ describe('AppointmentsList', () => {
     })
 
     it('should navigate to new appointment page', async () => {
-      const wrapper = setup()
+      const wrapper = await setup()
 
       await act(async () => {
         await wrapper.find(components.Button).at(0).simulate('click')

--- a/src/__tests__/patients/appointments/AppointmentsList.test.tsx
+++ b/src/__tests__/patients/appointments/AppointmentsList.test.tsx
@@ -124,8 +124,16 @@ describe('AppointmentsList', () => {
   })
 
   describe('New appointment button', () => {
-    it('should render a new appointment button', async () => {
+    it('should render a new appointment button if there is an appointment', async () => {
       const { wrapper } = await setup()
+
+      const addNewAppointmentButton = wrapper.find(components.Button).at(0)
+      expect(addNewAppointmentButton).toHaveLength(1)
+      expect(addNewAppointmentButton.text().trim()).toEqual('scheduling.appointments.new')
+    })
+
+    it('should render a new appointment button if there are no appointments', async () => {
+      const { wrapper } = await setup(expectedPatient, [])
 
       const addNewAppointmentButton = wrapper.find(components.Button).at(0)
       expect(addNewAppointmentButton).toHaveLength(1)

--- a/src/__tests__/patients/hooks/usePatientAppointments.test.tsx
+++ b/src/__tests__/patients/hooks/usePatientAppointments.test.tsx
@@ -3,8 +3,8 @@ import PatientRepository from '../../../shared/db/PatientRepository'
 import Appointment from '../../shared/model/Appointment'
 import executeQuery from '../../test-utils/use-query.util'
 
-describe('use patient', () => {
-  it('should return the patient', async () => {
+describe('use patient appointments', () => {
+  it(`should return the should return the patient's appointments`, async () => {
     const expectedPatientId = '123'
 
     const expectedAppointments = [

--- a/src/__tests__/patients/hooks/usePatientAppointments.test.tsx
+++ b/src/__tests__/patients/hooks/usePatientAppointments.test.tsx
@@ -1,0 +1,39 @@
+import usePatientAppointments from '../../../patients/hooks/usePatientAppointments'
+import PatientRepository from '../../../shared/db/PatientRepository'
+import Appointment from '../../shared/model/Appointment'
+import executeQuery from '../../test-utils/use-query.util'
+
+describe('use patient', () => {
+  it('should return the patient', async () => {
+    const expectedPatientId = '123'
+
+    const expectedAppointments = [
+      {
+        id: '456',
+        rev: '1',
+        patient: expectedPatientId,
+        startDateTime: new Date(2020, 1, 1, 9, 0, 0, 0).toISOString(),
+        endDateTime: new Date(2020, 1, 1, 9, 30, 0, 0).toISOString(),
+        location: 'location',
+        reason: 'Follow Up',
+      },
+      {
+        id: '123',
+        rev: '1',
+        patient: expectedPatientId,
+        startDateTime: new Date(2020, 1, 1, 8, 0, 0, 0).toISOString(),
+        endDateTime: new Date(2020, 1, 1, 8, 30, 0, 0).toISOString(),
+        location: 'location',
+        reason: 'Checkup',
+      },
+    ] as Appointment[]
+
+    jest.spyOn(PatientRepository, 'getAppointments').mockResolvedValueOnce(expectedAppointments)
+
+    const actualAppointments = await executeQuery(() => usePatientAppointments(expectedPatientId))
+
+    expect(PatientRepository.getAppointments).toHaveBeenCalledTimes(1)
+    expect(PatientRepository.getAppointments).toHaveBeenCalledWith(expectedPatientId)
+    expect(actualAppointments).toEqual(expectedAppointments)
+  })
+})

--- a/src/patients/appointments/AppointmentsList.tsx
+++ b/src/patients/appointments/AppointmentsList.tsx
@@ -1,9 +1,10 @@
-import { Button, Table, Spinner, Alert } from '@hospitalrun/components'
+import { Button, Table, Alert } from '@hospitalrun/components'
 import format from 'date-fns/format'
 import React from 'react'
 import { useHistory } from 'react-router-dom'
 
 import useAddBreadcrumbs from '../../page-header/breadcrumbs/useAddBreadcrumbs'
+import Loading from '../../shared/components/Loading'
 import useTranslator from '../../shared/hooks/useTranslator'
 import usePatientsAppointments from '../hooks/usePatientAppointments'
 
@@ -29,17 +30,7 @@ const AppointmentsList = (props: Props) => {
   useAddBreadcrumbs(breadcrumbs)
 
   if (data === undefined || status === 'loading') {
-    return <Spinner color="blue" loading size={[10, 25]} type="ScaleLoader" />
-  }
-
-  if (data.length === 0) {
-    return (
-      <Alert
-        color="warning"
-        title={t('patient.appointments.warning.noAppointments')}
-        message={t('patient.appointments.addAppointmentAbove')}
-      />
-    )
+    return <Loading />
   }
 
   return (
@@ -60,36 +51,44 @@ const AppointmentsList = (props: Props) => {
       <br />
       <div className="row">
         <div className="col-md-12">
-          <Table
-            data={data}
-            getID={(row) => row.id}
-            onRowClick={(row) => history.push(`/appointments/${row.id}`)}
-            columns={[
-              {
-                label: t('scheduling.appointment.startDate'),
-                key: 'startDateTime',
-                formatter: (row) =>
-                  row.startDateTime
-                    ? format(new Date(row.startDateTime), 'yyyy-MM-dd, hh:mm a')
-                    : '',
-              },
-              {
-                label: t('scheduling.appointment.endDate'),
-                key: 'endDateTime',
-                formatter: (row) =>
-                  row.endDateTime ? format(new Date(row.endDateTime), 'yyyy-MM-dd, hh:mm a') : '',
-              },
-              { label: t('scheduling.appointment.location'), key: 'location' },
-              { label: t('scheduling.appointment.type'), key: 'type' },
-            ]}
-            actionsHeaderText={t('actions.label')}
-            actions={[
-              {
-                label: t('actions.view'),
-                action: (row) => history.push(`/appointments/${row.id}`),
-              },
-            ]}
-          />
+          {data.length > 0 ? (
+            <Table
+              data={data}
+              getID={(row) => row.id}
+              onRowClick={(row) => history.push(`/appointments/${row.id}`)}
+              columns={[
+                {
+                  label: t('scheduling.appointment.startDate'),
+                  key: 'startDateTime',
+                  formatter: (row) =>
+                    row.startDateTime
+                      ? format(new Date(row.startDateTime), 'yyyy-MM-dd, hh:mm a')
+                      : '',
+                },
+                {
+                  label: t('scheduling.appointment.endDate'),
+                  key: 'endDateTime',
+                  formatter: (row) =>
+                    row.endDateTime ? format(new Date(row.endDateTime), 'yyyy-MM-dd, hh:mm a') : '',
+                },
+                { label: t('scheduling.appointment.location'), key: 'location' },
+                { label: t('scheduling.appointment.type'), key: 'type' },
+              ]}
+              actionsHeaderText={t('actions.label')}
+              actions={[
+                {
+                  label: t('actions.view'),
+                  action: (row) => history.push(`/appointments/${row.id}`),
+                },
+              ]}
+            />
+          ) : (
+            <Alert
+              color="warning"
+              title={t('patient.appointments.warning.noAppointments')}
+              message={t('patient.appointments.addAppointmentAbove')}
+            />
+          )}
         </div>
       </div>
     </>

--- a/src/patients/appointments/AppointmentsList.tsx
+++ b/src/patients/appointments/AppointmentsList.tsx
@@ -1,25 +1,23 @@
 import { Button, Table, Spinner, Alert } from '@hospitalrun/components'
 import format from 'date-fns/format'
-import React, { useEffect } from 'react'
-import { useSelector, useDispatch } from 'react-redux'
+import React from 'react'
 import { useHistory } from 'react-router-dom'
 
 import useAddBreadcrumbs from '../../page-header/breadcrumbs/useAddBreadcrumbs'
-import { fetchPatientAppointments } from '../../scheduling/appointments/appointments-slice'
 import useTranslator from '../../shared/hooks/useTranslator'
-import { RootState } from '../../shared/store'
+import usePatientsAppointments from '../hooks/usePatientAppointments'
 
 interface Props {
   patientId: string
 }
 
 const AppointmentsList = (props: Props) => {
-  const dispatch = useDispatch()
   const history = useHistory()
   const { t } = useTranslator()
 
   const { patientId } = props
-  const { appointments } = useSelector((state: RootState) => state.appointments)
+
+  const { data } = usePatientsAppointments(patientId)
 
   const breadcrumbs = [
     {
@@ -27,11 +25,8 @@ const AppointmentsList = (props: Props) => {
       location: `/patients/${patientId}/appointments`,
     },
   ]
-  useAddBreadcrumbs(breadcrumbs)
 
-  useEffect(() => {
-    dispatch(fetchPatientAppointments(patientId))
-  }, [dispatch, patientId])
+  useAddBreadcrumbs(breadcrumbs)
 
   return (
     <>
@@ -51,10 +46,10 @@ const AppointmentsList = (props: Props) => {
       <br />
       <div className="row">
         <div className="col-md-12">
-          {appointments ? (
-            appointments.length > 0 ? (
+          {data ? (
+            data.length > 0 ? (
               <Table
-                data={appointments}
+                data={data}
                 getID={(row) => row.id}
                 onRowClick={(row) => history.push(`/appointments/${row.id}`)}
                 columns={[

--- a/src/patients/appointments/AppointmentsList.tsx
+++ b/src/patients/appointments/AppointmentsList.tsx
@@ -17,7 +17,7 @@ const AppointmentsList = (props: Props) => {
 
   const { patientId } = props
 
-  const { data } = usePatientsAppointments(patientId)
+  const { data, status } = usePatientsAppointments(patientId)
 
   const breadcrumbs = [
     {
@@ -27,6 +27,20 @@ const AppointmentsList = (props: Props) => {
   ]
 
   useAddBreadcrumbs(breadcrumbs)
+
+  if (data === undefined || status === 'loading') {
+    return <Spinner color="blue" loading size={[10, 25]} type="ScaleLoader" />
+  }
+
+  if (data.length === 0) {
+    return (
+      <Alert
+        color="warning"
+        title={t('patient.appointments.warning.noAppointments')}
+        message={t('patient.appointments.addAppointmentAbove')}
+      />
+    )
+  }
 
   return (
     <>
@@ -46,50 +60,36 @@ const AppointmentsList = (props: Props) => {
       <br />
       <div className="row">
         <div className="col-md-12">
-          {data ? (
-            data.length > 0 ? (
-              <Table
-                data={data}
-                getID={(row) => row.id}
-                onRowClick={(row) => history.push(`/appointments/${row.id}`)}
-                columns={[
-                  {
-                    label: t('scheduling.appointment.startDate'),
-                    key: 'startDateTime',
-                    formatter: (row) =>
-                      row.startDateTime
-                        ? format(new Date(row.startDateTime), 'yyyy-MM-dd, hh:mm a')
-                        : '',
-                  },
-                  {
-                    label: t('scheduling.appointment.endDate'),
-                    key: 'endDateTime',
-                    formatter: (row) =>
-                      row.endDateTime
-                        ? format(new Date(row.endDateTime), 'yyyy-MM-dd, hh:mm a')
-                        : '',
-                  },
-                  { label: t('scheduling.appointment.location'), key: 'location' },
-                  { label: t('scheduling.appointment.type'), key: 'type' },
-                ]}
-                actionsHeaderText={t('actions.label')}
-                actions={[
-                  {
-                    label: t('actions.view'),
-                    action: (row) => history.push(`/appointments/${row.id}`),
-                  },
-                ]}
-              />
-            ) : (
-              <Alert
-                color="warning"
-                title={t('patient.appointments.warning.noAppointments')}
-                message={t('patient.appointments.addAppointmentAbove')}
-              />
-            )
-          ) : (
-            <Spinner color="blue" loading size={[10, 25]} type="ScaleLoader" />
-          )}
+          <Table
+            data={data}
+            getID={(row) => row.id}
+            onRowClick={(row) => history.push(`/appointments/${row.id}`)}
+            columns={[
+              {
+                label: t('scheduling.appointment.startDate'),
+                key: 'startDateTime',
+                formatter: (row) =>
+                  row.startDateTime
+                    ? format(new Date(row.startDateTime), 'yyyy-MM-dd, hh:mm a')
+                    : '',
+              },
+              {
+                label: t('scheduling.appointment.endDate'),
+                key: 'endDateTime',
+                formatter: (row) =>
+                  row.endDateTime ? format(new Date(row.endDateTime), 'yyyy-MM-dd, hh:mm a') : '',
+              },
+              { label: t('scheduling.appointment.location'), key: 'location' },
+              { label: t('scheduling.appointment.type'), key: 'type' },
+            ]}
+            actionsHeaderText={t('actions.label')}
+            actions={[
+              {
+                label: t('actions.view'),
+                action: (row) => history.push(`/appointments/${row.id}`),
+              },
+            ]}
+          />
         </div>
       </div>
     </>

--- a/src/patients/hooks/usePatientAppointments.tsx
+++ b/src/patients/hooks/usePatientAppointments.tsx
@@ -1,0 +1,15 @@
+import { QueryKey, useQuery } from 'react-query'
+
+import PatientRepository from '../../shared/db/PatientRepository'
+import Appointments from '../../shared/model/Appointment'
+
+async function fetchPatientAppointments(
+  _: QueryKey<string>,
+  patientId: string,
+): Promise<Appointments[]> {
+  return PatientRepository.getAppointments(patientId)
+}
+
+export default function usePatientsAppointments(patientId: string) {
+  return useQuery(['appointments', patientId], fetchPatientAppointments)
+}

--- a/src/scheduling/appointments/appointments-slice.ts
+++ b/src/scheduling/appointments/appointments-slice.ts
@@ -1,7 +1,6 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 
 import AppointmentRepository from '../../shared/db/AppointmentRepository'
-import PatientRepository from '../../shared/db/PatientRepository'
 import Appointment from '../../shared/model/Appointment'
 import { AppThunk } from '../../shared/store'
 
@@ -36,14 +35,6 @@ export const { fetchAppointmentsStart, fetchAppointmentsSuccess } = appointments
 export const fetchAppointments = (): AppThunk => async (dispatch) => {
   dispatch(fetchAppointmentsStart())
   const appointments = await AppointmentRepository.findAll()
-  dispatch(fetchAppointmentsSuccess(appointments))
-}
-
-export const fetchPatientAppointments = (patientId: string): AppThunk => async (dispatch) => {
-  dispatch(fetchAppointmentsStart())
-
-  const appointments = await PatientRepository.getAppointments(patientId)
-
   dispatch(fetchAppointmentsSuccess(appointments))
 }
 


### PR DESCRIPTION
Fixes: #2341 

**Changes proposed in this pull request:**

- add new hook `usePatientAppointments` and supporting tests
- Update `AppointmentsList` to use `usePatientAppointments` hook and update supporting tests
- Remove no longer used `fetchPatientAppointments`
