### PR TITLE
fix: resolve TitleProvider warnings logged in the browser console

### DIFF
--- a/src/dashboard/Dashboard.tsx
+++ b/src/dashboard/Dashboard.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 
 import { useUpdateTitle } from '../page-header/title/TitleContext'
 import useTranslator from '../shared/hooks/useTranslator'
@@ -6,7 +6,12 @@ import useTranslator from '../shared/hooks/useTranslator'
 const Dashboard: React.FC = () => {
   const { t } = useTranslator()
   const updateTitle = useUpdateTitle()
-  updateTitle(t('dashboard.label'))
+
+  // set dashboard page label
+  useEffect(() => {
+    updateTitle(t('dashboard.label'))
+  })
+  
   return <h3>Example</h3>
 }
 

--- a/src/dashboard/Dashboard.tsx
+++ b/src/dashboard/Dashboard.tsx
@@ -6,12 +6,9 @@ import useTranslator from '../shared/hooks/useTranslator'
 const Dashboard: React.FC = () => {
   const { t } = useTranslator()
   const updateTitle = useUpdateTitle()
-
-  // set dashboard page label
   useEffect(() => {
     updateTitle(t('dashboard.label'))
   })
-  
   return <h3>Example</h3>
 }
 

--- a/src/imagings/requests/NewImagingRequest.tsx
+++ b/src/imagings/requests/NewImagingRequest.tsx
@@ -1,6 +1,6 @@
 import { Typeahead, Label, Button, Alert, Column, Row } from '@hospitalrun/components'
 import format from 'date-fns/format'
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import { useHistory } from 'react-router-dom'
 
 import useAddBreadcrumbs from '../../page-header/breadcrumbs/useAddBreadcrumbs'
@@ -20,7 +20,12 @@ const NewImagingRequest = () => {
   const { t } = useTranslator()
   const history = useHistory()
   const updateTitle = useUpdateTitle()
-  updateTitle(t('imagings.requests.new'))
+
+  // set new imaging request page label
+  useEffect(() => {
+    updateTitle(t('imagings.requests.new'))
+  })
+
   const [mutate] = useRequestImaging()
   const [error, setError] = useState<ImagingRequestError>()
   const [visitOption, setVisitOption] = useState([] as Option[])

--- a/src/imagings/requests/NewImagingRequest.tsx
+++ b/src/imagings/requests/NewImagingRequest.tsx
@@ -20,12 +20,9 @@ const NewImagingRequest = () => {
   const { t } = useTranslator()
   const history = useHistory()
   const updateTitle = useUpdateTitle()
-
-  // set new imaging request page label
   useEffect(() => {
     updateTitle(t('imagings.requests.new'))
   })
-
   const [mutate] = useRequestImaging()
   const [error, setError] = useState<ImagingRequestError>()
   const [visitOption, setVisitOption] = useState([] as Option[])

--- a/src/imagings/search/ViewImagings.tsx
+++ b/src/imagings/search/ViewImagings.tsx
@@ -17,12 +17,9 @@ const ViewImagings = () => {
   const history = useHistory()
   const setButtons = useButtonToolbarSetter()
   const updateTitle = useUpdateTitle()
-
-  // set imagings page label
   useEffect(() => {
     updateTitle(t('imagings.label'))
   })
-
   const [searchRequest, setSearchRequest] = useState<ImagingSearchRequest>({
     status: 'all',
     text: '',

--- a/src/imagings/search/ViewImagings.tsx
+++ b/src/imagings/search/ViewImagings.tsx
@@ -17,7 +17,11 @@ const ViewImagings = () => {
   const history = useHistory()
   const setButtons = useButtonToolbarSetter()
   const updateTitle = useUpdateTitle()
-  updateTitle(t('imagings.label'))
+
+  // set imagings page label
+  useEffect(() => {
+    updateTitle(t('imagings.label'))
+  })
 
   const [searchRequest, setSearchRequest] = useState<ImagingSearchRequest>({
     status: 'all',

--- a/src/incidents/list/ViewIncidents.tsx
+++ b/src/incidents/list/ViewIncidents.tsx
@@ -16,12 +16,9 @@ const ViewIncidents = () => {
   const history = useHistory()
   const setButtonToolBar = useButtonToolbarSetter()
   const updateTitle = useUpdateTitle()
-
-  // set incidents page label
   useEffect(() => {
     updateTitle(t('incidents.reports.label'))
   })
-
   const [searchFilter, setSearchFilter] = useState(IncidentFilter.reported)
 
   useEffect(() => {

--- a/src/incidents/list/ViewIncidents.tsx
+++ b/src/incidents/list/ViewIncidents.tsx
@@ -16,7 +16,12 @@ const ViewIncidents = () => {
   const history = useHistory()
   const setButtonToolBar = useButtonToolbarSetter()
   const updateTitle = useUpdateTitle()
-  updateTitle(t('incidents.reports.label'))
+
+  // set incidents page label
+  useEffect(() => {
+    updateTitle(t('incidents.reports.label'))
+  })
+
   const [searchFilter, setSearchFilter] = useState(IncidentFilter.reported)
 
   useEffect(() => {

--- a/src/incidents/report/ReportIncident.tsx
+++ b/src/incidents/report/ReportIncident.tsx
@@ -1,5 +1,5 @@
 import { Button, Row, Column } from '@hospitalrun/components'
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import { useHistory } from 'react-router-dom'
 
 import useAddBreadcrumbs from '../../page-header/breadcrumbs/useAddBreadcrumbs'
@@ -17,7 +17,12 @@ const ReportIncident = () => {
   const history = useHistory()
   const { t } = useTranslator()
   const updateTitle = useUpdateTitle()
-  updateTitle(t('incidents.reports.new'))
+
+  // set report incident page label
+  useEffect(() => {
+    updateTitle(t('incidents.reports.new'))
+  })
+
   const breadcrumbs = [
     {
       i18nKey: 'incidents.reports.new',

--- a/src/incidents/report/ReportIncident.tsx
+++ b/src/incidents/report/ReportIncident.tsx
@@ -17,12 +17,9 @@ const ReportIncident = () => {
   const history = useHistory()
   const { t } = useTranslator()
   const updateTitle = useUpdateTitle()
-
-  // set report incident page label
   useEffect(() => {
     updateTitle(t('incidents.reports.new'))
   })
-
   const breadcrumbs = [
     {
       i18nKey: 'incidents.reports.new',

--- a/src/incidents/visualize/VisualizeIncidents.tsx
+++ b/src/incidents/visualize/VisualizeIncidents.tsx
@@ -10,12 +10,9 @@ import IncidentSearchRequest from '../model/IncidentSearchRequest'
 const VisualizeIncidents = () => {
   const { t } = useTranslator()
   const updateTitle = useUpdateTitle()
-
-  // set visualize incidents page label
   useEffect(() => {
     updateTitle(t('incidents.visualize.view'))
   })
-
   const searchFilter = IncidentFilter.reported
   const searchRequest: IncidentSearchRequest = { status: searchFilter }
   const { data, isLoading } = useIncidents(searchRequest)

--- a/src/incidents/visualize/VisualizeIncidents.tsx
+++ b/src/incidents/visualize/VisualizeIncidents.tsx
@@ -10,7 +10,11 @@ import IncidentSearchRequest from '../model/IncidentSearchRequest'
 const VisualizeIncidents = () => {
   const { t } = useTranslator()
   const updateTitle = useUpdateTitle()
-  updateTitle(t('incidents.visualize.view'))
+
+  // set visualize incidents page label
+  useEffect(() => {
+    updateTitle(t('incidents.visualize.view'))
+  })
 
   const searchFilter = IncidentFilter.reported
   const searchRequest: IncidentSearchRequest = { status: searchFilter }

--- a/src/labs/ViewLabs.tsx
+++ b/src/labs/ViewLabs.tsx
@@ -23,12 +23,9 @@ const ViewLabs = () => {
   const history = useHistory()
   const setButtons = useButtonToolbarSetter()
   const updateTitle = useUpdateTitle()
-
-  // set labs page label
   useEffect(() => {
     updateTitle(t('labs.label'))
   })
-
   const { permissions } = useSelector((state: RootState) => state.user)
   const [searchFilter, setSearchFilter] = useState<LabFilter>('all')
   const [searchText, setSearchText] = useState<string>('')

--- a/src/labs/ViewLabs.tsx
+++ b/src/labs/ViewLabs.tsx
@@ -23,7 +23,11 @@ const ViewLabs = () => {
   const history = useHistory()
   const setButtons = useButtonToolbarSetter()
   const updateTitle = useUpdateTitle()
-  updateTitle(t('labs.label'))
+
+  // set labs page label
+  useEffect(() => {
+    updateTitle(t('labs.label'))
+  })
 
   const { permissions } = useSelector((state: RootState) => state.user)
   const [searchFilter, setSearchFilter] = useState<LabFilter>('all')

--- a/src/labs/requests/NewLabRequest.tsx
+++ b/src/labs/requests/NewLabRequest.tsx
@@ -23,12 +23,9 @@ const NewLabRequest = () => {
   const [newNote, setNewNote] = useState('')
   const [error, setError] = useState<LabError | undefined>(undefined)
   const updateTitle = useUpdateTitle()
-
-  // set request lab page label
   useEffect(() => {
     updateTitle(t('labs.requests.new'))
   })
-
   const [newLabRequest, setNewLabRequest] = useState({
     patient: '',
     type: '',

--- a/src/labs/requests/NewLabRequest.tsx
+++ b/src/labs/requests/NewLabRequest.tsx
@@ -1,5 +1,5 @@
 import { Typeahead, Label, Button, Alert, Toast } from '@hospitalrun/components'
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import { useSelector } from 'react-redux'
 import { useHistory } from 'react-router-dom'
 
@@ -23,7 +23,11 @@ const NewLabRequest = () => {
   const [newNote, setNewNote] = useState('')
   const [error, setError] = useState<LabError | undefined>(undefined)
   const updateTitle = useUpdateTitle()
-  updateTitle(t('labs.requests.new'))
+
+  // set request lab page label
+  useEffect(() => {
+    updateTitle(t('labs.requests.new'))
+  })
 
   const [newLabRequest, setNewLabRequest] = useState({
     patient: '',

--- a/src/medications/requests/NewMedicationRequest.tsx
+++ b/src/medications/requests/NewMedicationRequest.tsx
@@ -1,5 +1,5 @@
 import { Typeahead, Label, Button, Alert, Column, Row } from '@hospitalrun/components'
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { useHistory } from 'react-router-dom'
 
@@ -22,7 +22,12 @@ const NewMedicationRequest = () => {
   const dispatch = useDispatch()
   const history = useHistory()
   const updateTitle = useUpdateTitle()
-  updateTitle(t('medications.requests.new'))
+
+  // set request medication page label
+  useEffect(() => {
+    updateTitle(t('medications.requests.new'))
+  })
+
   const { status, error } = useSelector((state: RootState) => state.medication)
 
   const [newMedicationRequest, setNewMedicationRequest] = useState(({

--- a/src/medications/requests/NewMedicationRequest.tsx
+++ b/src/medications/requests/NewMedicationRequest.tsx
@@ -22,12 +22,9 @@ const NewMedicationRequest = () => {
   const dispatch = useDispatch()
   const history = useHistory()
   const updateTitle = useUpdateTitle()
-
-  // set request medication page label
   useEffect(() => {
     updateTitle(t('medications.requests.new'))
   })
-
   const { status, error } = useSelector((state: RootState) => state.medication)
 
   const [newMedicationRequest, setNewMedicationRequest] = useState(({

--- a/src/medications/search/ViewMedications.tsx
+++ b/src/medications/search/ViewMedications.tsx
@@ -17,12 +17,9 @@ const ViewMedications = () => {
   const history = useHistory()
   const setButtons = useButtonToolbarSetter()
   const updateTitle = useUpdateTitle()
-
-  // set medications page label
   useEffect(() => {
     updateTitle(t('medications.label'))
   })
-
   const { permissions } = useSelector((state: RootState) => state.user)
 
   const getButtons = useCallback(() => {

--- a/src/medications/search/ViewMedications.tsx
+++ b/src/medications/search/ViewMedications.tsx
@@ -17,7 +17,11 @@ const ViewMedications = () => {
   const history = useHistory()
   const setButtons = useButtonToolbarSetter()
   const updateTitle = useUpdateTitle()
-  updateTitle(t('medications.label'))
+
+  // set medications page label
+  useEffect(() => {
+    updateTitle(t('medications.label'))
+  })
 
   const { permissions } = useSelector((state: RootState) => state.user)
 

--- a/src/patients/new/NewPatient.tsx
+++ b/src/patients/new/NewPatient.tsx
@@ -37,12 +37,9 @@ const NewPatient = () => {
   } as Patient
 
   const updateTitle = useUpdateTitle()
-
-  // set new patient page label
   useEffect(() => {
     updateTitle(t('patients.newPatient'))
   })
-
   useAddBreadcrumbs(breadcrumbs, true)
 
   const onCancel = () => {

--- a/src/patients/new/NewPatient.tsx
+++ b/src/patients/new/NewPatient.tsx
@@ -1,5 +1,5 @@
 import { Button, Toast } from '@hospitalrun/components'
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { useHistory } from 'react-router-dom'
 
@@ -37,7 +37,12 @@ const NewPatient = () => {
   } as Patient
 
   const updateTitle = useUpdateTitle()
-  updateTitle(t('patients.newPatient'))
+
+  // set new patient page label
+  useEffect(() => {
+    updateTitle(t('patients.newPatient'))
+  })
+
   useAddBreadcrumbs(breadcrumbs, true)
 
   const onCancel = () => {

--- a/src/patients/search/ViewPatients.tsx
+++ b/src/patients/search/ViewPatients.tsx
@@ -15,7 +15,12 @@ const ViewPatients = () => {
   const { t } = useTranslator()
   const history = useHistory()
   const updateTitle = useUpdateTitle()
-  updateTitle(t('patients.label'))
+
+  // set patients page label
+  useEffect(() => {
+    updateTitle(t('patients.label'))
+  })
+
   const dispatch = useDispatch()
   const setButtonToolBar = useButtonToolbarSetter()
 

--- a/src/patients/search/ViewPatients.tsx
+++ b/src/patients/search/ViewPatients.tsx
@@ -15,12 +15,9 @@ const ViewPatients = () => {
   const { t } = useTranslator()
   const history = useHistory()
   const updateTitle = useUpdateTitle()
-
-  // set patients page label
   useEffect(() => {
     updateTitle(t('patients.label'))
   })
-
   const dispatch = useDispatch()
   const setButtonToolBar = useButtonToolbarSetter()
 

--- a/src/scheduling/appointments/ViewAppointments.tsx
+++ b/src/scheduling/appointments/ViewAppointments.tsx
@@ -25,7 +25,12 @@ const ViewAppointments = () => {
   const { t } = useTranslator()
   const history = useHistory()
   const updateTitle = useUpdateTitle()
-  updateTitle(t('scheduling.appointments.label'))
+
+  // set scheduling page label
+   useEffect(() => {
+    updateTitle(t('scheduling.appointments.label'))
+  })
+
   const { data: appointments, isLoading } = useAppointments()
   const [events, setEvents] = useState<Event[]>([])
   const setButtonToolBar = useButtonToolbarSetter()

--- a/src/scheduling/appointments/ViewAppointments.tsx
+++ b/src/scheduling/appointments/ViewAppointments.tsx
@@ -25,12 +25,9 @@ const ViewAppointments = () => {
   const { t } = useTranslator()
   const history = useHistory()
   const updateTitle = useUpdateTitle()
-
-  // set scheduling page label
-   useEffect(() => {
+  useEffect(() => {
     updateTitle(t('scheduling.appointments.label'))
   })
-
   const { data: appointments, isLoading } = useAppointments()
   const [events, setEvents] = useState<Event[]>([])
   const setButtonToolBar = useButtonToolbarSetter()

--- a/src/settings/Settings.tsx
+++ b/src/settings/Settings.tsx
@@ -8,12 +8,9 @@ import useTranslator from '../shared/hooks/useTranslator'
 const Settings = () => {
   const { t } = useTranslator()
   const updateTitle = useUpdateTitle()
-
-  // set settings page label
   useEffect(() => {
     updateTitle(t('settings.label'))
   })
-
   return (
     <>
       <Row>

--- a/src/settings/Settings.tsx
+++ b/src/settings/Settings.tsx
@@ -1,5 +1,5 @@
 import { Row, Column } from '@hospitalrun/components'
-import React from 'react'
+import React, { useEffect } from 'react'
 
 import { useUpdateTitle } from '../page-header/title/TitleContext'
 import LanguageSelector from '../shared/components/input/LanguageSelector'
@@ -8,7 +8,11 @@ import useTranslator from '../shared/hooks/useTranslator'
 const Settings = () => {
   const { t } = useTranslator()
   const updateTitle = useUpdateTitle()
-  updateTitle(t('settings.label'))
+
+  // set settings page label
+  useEffect(() => {
+    updateTitle(t('settings.label'))
+  })
 
   return (
     <>


### PR DESCRIPTION
unable to update componenets , which are using updateTitle to set
the label of the page.

Fixes #2417.

**Changes proposed in this pull request:**

- Add updateTitle(t('label')) into effect hook(useEffect).
