### PR TITLE
fix(patientview): add visit button height fix

### DIFF
--- a/src/patients/view/ImportantPatientInfo.tsx
+++ b/src/patients/view/ImportantPatientInfo.tsx
@@ -81,7 +81,7 @@ const ImportantPatientInfo = (props: Props) => {
             <h6>{getPatientCode(patient)}</h6>
           </div>
         </div>
-        <div className="col d-flex justify-content-end">
+        <div className="col d-flex justify-content-end h-100">
           {permissions.includes(Permissions.AddVisit) && (
             <Button
               outlined


### PR DESCRIPTION
Fixes #[2438](https://github.com/HospitalRun/hospitalrun-frontend/issues/2438).

**Changes proposed in this pull request:**

-  Fixed the "Add Visit" button container height so that the button doesn't grow to fit the container
<img width="1280" alt="Screen Shot 2020-10-26 at 1 08 43 PM" src="https://user-images.githubusercontent.com/18673328/97225134-78d63b00-178f-11eb-89df-e8167954d65a.png">


**Newly added dependencies with [Bundlephobia](https://bundlephobia.com/) links:**

NONE

