### PR TITLE
fix(i18n): fixed typo of remission text

### DIFF
--- a/src/shared/model/Diagnosis.ts
+++ b/src/shared/model/Diagnosis.ts
@@ -3,7 +3,7 @@ export enum DiagnosisStatus {
   Recurrence = 'recurrence',
   Relapse = 'relapse',
   Inactive = 'inactive',
-  Remission = 'remisison',
+  Remission = 'remission',
   Resolved = 'resolved',
 }
 


### PR DESCRIPTION
Fixes #2463 

**Changes proposed in this pull request:**

- fixed typo of "remission"

Attached screenshot
![updated_typo](https://user-images.githubusercontent.com/51812399/97785968-4896fe00-1bce-11eb-8e10-6c74680ad592.png)
