### PR TITLE
feat: auto populate patients

### DIFF
--- a/src/__tests__/patients/appointments/AppointmentsList.test.tsx
+++ b/src/__tests__/patients/appointments/AppointmentsList.test.tsx
@@ -56,7 +56,7 @@ const setup = async (patient = expectedPatient, appointments = expectedAppointme
     wrapper = await mount(
       <Router history={history}>
         <Provider store={store}>
-          <AppointmentsList patientId={patient.id} />
+          <AppointmentsList patient={patient} />
         </Provider>
       </Router>,
     )

--- a/src/__tests__/patients/view/ViewPatient.test.tsx
+++ b/src/__tests__/patients/view/ViewPatient.test.tsx
@@ -204,7 +204,7 @@ describe('ViewPatient', () => {
     expect(history.location.pathname).toEqual(`/patients/${patient.id}/appointments`)
     expect(tabs.at(2).prop('active')).toBeTruthy()
     expect(appointmentsTab).toHaveLength(1)
-    expect(appointmentsTab.prop('patientId')).toEqual(patient.id)
+    expect(appointmentsTab.prop('patient')).toEqual(patient)
   })
 
   it('should mark the allergies tab as active when it is clicked and render the allergies component when route is /patients/:id/allergies', async () => {

--- a/src/patients/appointments/AppointmentsList.tsx
+++ b/src/patients/appointments/AppointmentsList.tsx
@@ -6,15 +6,17 @@ import { useHistory } from 'react-router-dom'
 import useAddBreadcrumbs from '../../page-header/breadcrumbs/useAddBreadcrumbs'
 import Loading from '../../shared/components/Loading'
 import useTranslator from '../../shared/hooks/useTranslator'
+import Patient from '../../shared/model/Patient'
 import usePatientsAppointments from '../hooks/usePatientAppointments'
 
 interface Props {
-  patientId: string
+  patient: Patient
 }
 
-const AppointmentsList = ({ patientId }: Props) => {
+const AppointmentsList = ({ patient }: Props) => {
   const history = useHistory()
   const { t } = useTranslator()
+  const patientId = patient.id
 
   const { data, status } = usePatientsAppointments(patientId)
 
@@ -40,7 +42,7 @@ const AppointmentsList = ({ patientId }: Props) => {
             outlined
             color="success"
             icon="appointment-add"
-            onClick={() => history.push('/appointments/new')}
+            onClick={() => history.push({ pathname: '/appointments/new', state: { patient } })}
           >
             {t('scheduling.appointments.new')}
           </Button>

--- a/src/patients/view/ViewPatient.tsx
+++ b/src/patients/view/ViewPatient.tsx
@@ -150,7 +150,7 @@ const ViewPatient = () => {
             <RelatedPerson patient={patient} />
           </Route>
           <Route exact path={`${path}/appointments`}>
-            <AppointmentsList patientId={patient.id} />
+            <AppointmentsList patient={patient} />
           </Route>
           <Route path={`${path}/allergies`}>
             <Allergies patient={patient} />

--- a/src/scheduling/appointments/new/NewAppointment.tsx
+++ b/src/scheduling/appointments/new/NewAppointment.tsx
@@ -3,12 +3,13 @@ import addMinutes from 'date-fns/addMinutes'
 import roundToNearestMinutes from 'date-fns/roundToNearestMinutes'
 import _ from 'lodash'
 import React, { useEffect, useState } from 'react'
-import { useHistory } from 'react-router-dom'
+import { useHistory, useLocation } from 'react-router-dom'
 
 import useAddBreadcrumbs from '../../../page-header/breadcrumbs/useAddBreadcrumbs'
 import { useUpdateTitle } from '../../../page-header/title/TitleContext'
 import useTranslator from '../../../shared/hooks/useTranslator'
 import Appointment from '../../../shared/model/Appointment'
+import Patient from '../../../shared/model/Patient'
 import useScheduleAppointment from '../../hooks/useScheduleAppointment'
 import AppointmentDetailForm from '../AppointmentDetailForm'
 import { AppointmentError } from '../util/validate-appointment'
@@ -18,9 +19,18 @@ const breadcrumbs = [
   { i18nKey: 'scheduling.appointments.new', location: '/appointments/new' },
 ]
 
+interface LocationProps {
+  pathname: string
+  state?: {
+    patient: Patient
+  }
+}
+
 const NewAppointment = () => {
   const { t } = useTranslator()
   const history = useHistory()
+  const location: LocationProps = useLocation()
+  const patient = location.state?.patient
   const updateTitle = useUpdateTitle()
   useEffect(() => {
     updateTitle(t('scheduling.appointments.new'))
@@ -32,7 +42,7 @@ const NewAppointment = () => {
   const [saved, setSaved] = useState(false)
   const [newAppointmentMutateError, setError] = useState<AppointmentError>({} as AppointmentError)
   const [newAppointment, setAppointment] = useState({
-    patient: '',
+    patient: patient || '',
     startDateTime: startDateTime.toISOString(),
     endDateTime: endDateTime.toISOString(),
     location: '',
@@ -95,6 +105,7 @@ const NewAppointment = () => {
       <form>
         <AppointmentDetailForm
           appointment={newAppointment as Appointment}
+          patient={patient as Patient}
           error={newAppointmentMutateError}
           onFieldChange={onFieldChange}
         />


### PR DESCRIPTION
Fixes #2350 .

**Changes proposed in this pull request:**

- Passing patient to `NewAppointment` through `history.push` and accessing it using `useLocation`
- Using this prop as the default in `AppointmentDetailForm`

**Newly added dependencies with [Bundlephobia](https://bundlephobia.com/) links:**
None


![screencast-localhost_3000-2020 11 01-16_33_05](https://user-images.githubusercontent.com/54525505/97801974-2c44a100-1c62-11eb-8b4a-e5c23a6d79c9.gif)

