### PR TITLE
feat(patient): patient history tab

### DIFF
--- a/src/__tests__/patients/history/HistoryTab.test.tsx
+++ b/src/__tests__/patients/history/HistoryTab.test.tsx
@@ -1,0 +1,61 @@
+import { mount, ReactWrapper } from 'enzyme'
+import { createMemoryHistory } from 'history'
+import React from 'react'
+import { Provider } from 'react-redux'
+import { Router } from 'react-router-dom'
+import createMockStore from 'redux-mock-store'
+import thunk from 'redux-thunk'
+import HistoryTab from '../../../patients/history/HistoryTab'
+import HistoryTable from '../../../patients/history/HistoryTable'
+
+import PatientRepository from '../../../shared/db/PatientRepository'
+import Patient from '../../../shared/model/Patient'
+import Permissions from '../../../shared/model/Permissions'
+import { RootState } from '../../../shared/store'
+
+const mockStore = createMockStore<RootState, any>([thunk])
+const history = createMemoryHistory()
+const expectedPatient = ({
+  id: '123',
+  rev: '123',
+  labs: [
+    { id: '1', type: 'lab type 1' },
+    { id: '2', type: 'lab type 2' },
+  ],
+} as unknown) as Patient
+
+let store: any
+
+const setup = async (
+  patient = expectedPatient,
+  permissions = [Permissions.ViewPatientHistory],
+  route = '/patients/123/history',
+) => {
+  store = mockStore({ patient: { patient }, user: { permissions } } as any)
+  history.push(route)
+
+  const wrapper = await mount(
+    <Router history={history}>
+      <Provider store={store}>
+        <HistoryTab patientId={patient.id} />
+      </Provider>
+    </Router>,
+  )
+  return { wrapper: wrapper as ReactWrapper }
+}
+
+describe('HistoryTab', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+    jest.spyOn(PatientRepository, 'find').mockResolvedValue(expectedPatient)
+    jest.spyOn(PatientRepository, 'saveOrUpdate')
+  })
+
+  describe('patient history list', () => {
+    it('should render patient history', async () => {
+      const { wrapper } = await setup()
+
+      expect(wrapper.exists(HistoryTable)).toBeTruthy()
+    })
+  })
+})

--- a/src/__tests__/patients/history/HistoryTable.test.tsx
+++ b/src/__tests__/patients/history/HistoryTable.test.tsx
@@ -1,0 +1,137 @@
+import { Table } from '@hospitalrun/components'
+import { mount, ReactWrapper } from 'enzyme'
+import { createMemoryHistory } from 'history'
+import React from 'react'
+import { act } from 'react-dom/test-utils'
+import { Provider } from 'react-redux'
+import { Router } from 'react-router-dom'
+import createMockStore from 'redux-mock-store'
+import thunk from 'redux-thunk'
+import HistoryTable from '../../../patients/history/HistoryTable'
+
+import PatientRepository from '../../../shared/db/PatientRepository'
+import Appointment from '../../../shared/model/Appointment'
+import Lab from '../../../shared/model/Lab'
+import Patient from '../../../shared/model/Patient'
+import { HistoryRecordType, PatientHistoryRecord } from '../../../shared/model/PatientHistoryRecord'
+import { RootState } from '../../../shared/store'
+
+const expectedLab: Lab = 
+  {
+    id: '123',
+    rev: '1',
+    patient: '1234',
+    requestedOn: new Date(2020, 1, 1).toISOString(),
+    requestedBy: 'someone',
+    type: 'lab type',
+    code: '',
+    status: 'requested',
+    createdAt: '',
+    updatedAt: ''
+  }
+
+const expectedPatient = {
+    id: '1234'
+  } as Patient
+
+const expectedAppointment: Appointment = {
+  id: 'id',
+  startDateTime: new Date(2020, 6, 3).toISOString(),
+  endDateTime: new Date(2020, 6, 5).toISOString(),
+  createdAt: new Date(2020, 6, 1).toISOString(),
+  updatedAt: new Date(2020, 6, 1).toISOString(),
+  type: 'standard type',
+  reason: 'some reason',
+  location: 'main building',
+  patient: expectedPatient.id,
+  rev: ''
+}
+
+const expectedPatientHistory: PatientHistoryRecord[] = 
+[{
+  date: new Date(expectedAppointment.startDateTime),
+  type: HistoryRecordType.APPOINTMENT,
+  info: expectedAppointment.type,
+  recordId: expectedAppointment.id,
+}, {
+  date: new Date(expectedLab.requestedOn),
+  type: HistoryRecordType.LAB,
+  info: expectedLab.type,
+  recordId: expectedLab.id
+}]
+
+const mockStore = createMockStore<RootState, any>([thunk])
+const history = createMemoryHistory()
+
+let store: any
+
+const setup = async (patient = expectedPatient, lab = expectedLab, appointment = expectedAppointment) => {
+  jest.resetAllMocks()
+  jest.spyOn(PatientRepository, 'getLabs').mockResolvedValue([lab])
+  jest.spyOn(PatientRepository, 'getAppointments').mockResolvedValue([appointment])
+  jest.spyOn(PatientRepository, 'find').mockResolvedValue(patient)
+  history.push(`/patients/${patient.id}/history`)
+  store = mockStore({ patient, labs: [lab], appointments: [appointment]  } as any)
+
+  let wrapper: any
+
+  await act(async () => {
+    wrapper = await mount(
+      <Router history={history}>
+        <Provider store={store}>
+          <HistoryTable patientId={patient.id} />
+        </Provider>
+      </Router>,
+    )
+  })
+
+  wrapper.update()
+
+  return { wrapper: wrapper as ReactWrapper }
+}
+
+describe('HistoryTable', () => {
+  describe('Table', () => {
+    it('should render a list of history records', async () => {
+      const { wrapper } = await setup()
+
+      const table = wrapper.find(Table)
+
+      const columns = table.prop('columns')
+      const actions = table.prop('actions') as any
+
+      expect(table).toHaveLength(1)
+
+      expect({label: columns[0].label, key: columns[0].key}).toEqual({ label: 'patient.history.entryDate', key: 'date' })
+      expect(columns[1]).toEqual({ label: 'patient.history.recordType', key: 'type' })
+      expect(columns[2]).toEqual({ label: 'patient.history.information', key: 'info' })
+      expect(actions[0].label).toEqual('actions.view')
+      expect(table.prop('actionsHeaderText')).toEqual('actions.label')
+      expect(table.prop('data')).toEqual(expectedPatientHistory)
+    })
+
+    it('should navigate to appointment view on history record click', async () => {
+      const { wrapper } = await setup()
+      const tr = wrapper.find('tr').at(1)
+
+      act(() => {
+        const onClick = tr.find('button').at(0).prop('onClick') as any
+        onClick({ stopPropagation: jest.fn() })
+      })
+
+      expect(history.location.pathname).toEqual('/appointments/'+expectedAppointment.id)
+    })
+
+    it('should navigate to lab view on history record click', async () => {
+      const { wrapper } = await setup()
+      const tr = wrapper.find('tr').at(2)
+
+      act(() => {
+        const onClick = tr.find('button').at(0).prop('onClick') as any
+        onClick({ stopPropagation: jest.fn() })
+      })
+
+      expect(history.location.pathname).toEqual('/labs/'+expectedLab.id)
+    })
+  })
+})

--- a/src/__tests__/patients/history/mappers/HistoryRecordsMapper.test.tsx
+++ b/src/__tests__/patients/history/mappers/HistoryRecordsMapper.test.tsx
@@ -1,0 +1,63 @@
+import { mapHistoryRecords } from '../../../../patients/history/mappers/HistoryRecordsMapper'
+import PatientRepository from '../../../../shared/db/PatientRepository'
+import Appointment from '../../../../shared/model/Appointment'
+import Lab from '../../../../shared/model/Lab'
+import Patient from '../../../../shared/model/Patient'
+import { HistoryRecordType, PatientHistoryRecord } from '../../../../shared/model/PatientHistoryRecord'
+
+const expectedLab: Lab = 
+  {
+    id: '123',
+    rev: '1',
+    patient: '1234',
+    requestedOn: new Date(2020, 1, 1).toISOString(),
+    requestedBy: 'someone',
+    type: 'lab type',
+    code: '',
+    status: 'requested',
+    createdAt: '',
+    updatedAt: ''
+  }
+
+const expectedPatient = {
+    id: '1234'
+  } as Patient
+
+const expectedAppointment: Appointment = {
+  id: 'id',
+  startDateTime: new Date(2020, 6, 3).toISOString(),
+  endDateTime: new Date(2020, 6, 5).toISOString(),
+  createdAt: new Date(2020, 6, 1).toISOString(),
+  updatedAt: new Date(2020, 6, 1).toISOString(),
+  type: 'standard type',
+  reason: 'some reason',
+  location: 'main building',
+  patient: expectedPatient.id,
+  rev: ''
+}
+
+const expectedPatientHistory: PatientHistoryRecord[] = 
+[{
+  date: new Date(expectedAppointment.startDateTime),
+  type: HistoryRecordType.APPOINTMENT,
+  info: expectedAppointment.type,
+  recordId: expectedAppointment.id,
+}, {
+  date: new Date(expectedLab.requestedOn),
+  type: HistoryRecordType.LAB,
+  info: expectedLab.type,
+  recordId: expectedLab.id
+}]
+
+
+describe('use patient history', () => {
+  it('should get patient history', async () => {
+    jest.spyOn(PatientRepository, 'getLabs').mockResolvedValue([expectedLab])
+    jest.spyOn(PatientRepository, 'getAppointments').mockResolvedValue([expectedAppointment])
+    jest.spyOn(PatientRepository, 'find').mockResolvedValue(expectedPatient)
+
+    const actualHistory = mapHistoryRecords([expectedLab], [expectedAppointment])
+
+    expect(actualHistory).toEqual(expectedPatientHistory)
+  })
+})

--- a/src/__tests__/patients/view/ViewPatient.test.tsx
+++ b/src/__tests__/patients/view/ViewPatient.test.tsx
@@ -124,7 +124,7 @@ describe('ViewPatient', () => {
     const tabs = tabsHeader.find(Tab)
     expect(tabsHeader).toHaveLength(1)
 
-    expect(tabs).toHaveLength(10)
+    expect(tabs).toHaveLength(11)
     expect(tabs.at(0).prop('label')).toEqual('patient.generalInformation')
     expect(tabs.at(1).prop('label')).toEqual('patient.relatedPersons.label')
     expect(tabs.at(2).prop('label')).toEqual('scheduling.appointments.label')
@@ -135,6 +135,7 @@ describe('ViewPatient', () => {
     expect(tabs.at(7).prop('label')).toEqual('patient.carePlan.label')
     expect(tabs.at(8).prop('label')).toEqual('patient.careGoal.label')
     expect(tabs.at(9).prop('label')).toEqual('patient.visits.label')
+    expect(tabs.at(10).prop('label')).toEqual('patient.history.label')
   })
 
   it('should mark the general information tab as active and render the general information component when route is /patients/:id', async () => {

--- a/src/patients/history/HistoryTab.tsx
+++ b/src/patients/history/HistoryTab.tsx
@@ -1,0 +1,15 @@
+import React from 'react'
+
+import HistoryTable from './HistoryTable'
+
+interface Props {
+  patientId: string
+}
+
+const HistoryTab = ({ patientId }: Props) => (
+  <>
+    <HistoryTable patientId={patientId} />
+  </>
+)
+
+export default HistoryTab

--- a/src/patients/history/HistoryTable.tsx
+++ b/src/patients/history/HistoryTable.tsx
@@ -1,0 +1,56 @@
+import { Table } from '@hospitalrun/components'
+import format from 'date-fns/format'
+import React from 'react'
+import { useHistory } from 'react-router-dom'
+
+import useTranslator from '../../shared/hooks/useTranslator'
+import { HistoryRecordType, PatientHistoryRecord } from '../../shared/model/PatientHistoryRecord'
+import usePatientsAppointments from '../hooks/usePatientAppointments'
+import usePatientLabs from '../hooks/usePatientLabs'
+import { mapHistoryRecords } from './mappers/HistoryRecordsMapper'
+
+interface Props {
+  patientId: string
+}
+
+const HistoryTable = ({ patientId }: Props) => {
+  const { t } = useTranslator()
+  const history = useHistory()
+
+  const { data: labs } = usePatientLabs(patientId)
+  const { data: appointments } = usePatientsAppointments(patientId)
+
+  const historyElements = mapHistoryRecords(labs, appointments)
+
+  return (
+    <Table
+      getID={(row) => row.id}
+      data={historyElements}
+      columns={[
+        {
+          label: t('patient.history.entryDate'),
+          key: 'date',
+          formatter: (row) => format(new Date(row.date), 'yyyy-MM-dd hh:mm a'),
+        },
+        { label: t('patient.history.recordType'), key: 'type' },
+        { label: t('patient.history.information'), key: 'info' },
+      ]}
+      actionsHeaderText = {t('actions.label')}
+      actions={[
+        {
+          label: t('actions.view'),
+          action: (row) => history.push(getRecordPath(row as PatientHistoryRecord)),
+        },
+      ]}
+    />
+  )
+}
+
+const getRecordPath = (historyRecord: PatientHistoryRecord): string => {
+  if (historyRecord.type === HistoryRecordType.LAB) {
+    return `/labs/${historyRecord.recordId}`
+  }
+  return `/appointments/${historyRecord.recordId}`
+}
+
+export default HistoryTable

--- a/src/patients/history/mappers/HistoryRecordsMapper.tsx
+++ b/src/patients/history/mappers/HistoryRecordsMapper.tsx
@@ -1,0 +1,39 @@
+import Appointment from '../../../shared/model/Appointment'
+import Lab from '../../../shared/model/Lab'
+import { HistoryRecordType, PatientHistoryRecord } from '../../../shared/model/PatientHistoryRecord'
+
+export const mapHistoryRecords = (labs: Lab[] | undefined, appointments: Appointment[] | undefined): PatientHistoryRecord[] => {
+
+  const labRecords = mapLabs(labs)
+  const appointmentRecords = mapAppointments(appointments)
+
+  const result = labRecords.concat(appointmentRecords)
+
+  result.sort(
+    (a: PatientHistoryRecord, b: PatientHistoryRecord): number =>
+      b.date.getTime() - a.date.getTime(),
+  )
+
+  return result
+}
+
+const mapLabs = (labs: Lab[] | undefined): PatientHistoryRecord[] => {
+  if (!labs) return []
+  return labs.map((lab) => ({
+    date: new Date(lab.requestedOn),
+    type: HistoryRecordType.LAB,
+    info: lab.type,
+    recordId: lab.id,
+  }))
+}
+
+const mapAppointments = (appointments: Appointment[] | undefined): PatientHistoryRecord[] => {
+  if (!appointments) return []
+
+  return appointments.map((appointment) => ({
+    date: new Date(appointment.startDateTime),
+    type: HistoryRecordType.APPOINTMENT,
+    info: appointment.type,
+    recordId: appointment.id,
+  }))
+}

--- a/src/patients/view/ViewPatient.tsx
+++ b/src/patients/view/ViewPatient.tsx
@@ -22,6 +22,7 @@ import CareGoalTab from '../care-goals/CareGoalTab'
 import CarePlanTab from '../care-plans/CarePlanTab'
 import Diagnoses from '../diagnoses/Diagnoses'
 import GeneralInformation from '../GeneralInformation'
+import HistoryTab from '../history/HistoryTab'
 import usePatient from '../hooks/usePatient'
 import Labs from '../labs/Labs'
 import Note from '../notes/NoteTab'
@@ -135,6 +136,11 @@ const ViewPatient = () => {
             label={t('patient.visits.label')}
             onClick={() => history.push(`/patients/${patient.id}/visits`)}
           />
+          <Tab
+            active={location.pathname === `/patients/${patient.id}/history`}
+            label={t('patient.history.label')}
+            onClick={() => history.push(`/patients/${patient.id}/history`)}
+          />
         </TabsHeader>
         <Panel>
           <Route exact path={path}>
@@ -166,6 +172,9 @@ const ViewPatient = () => {
           </Route>
           <Route path={`${path}/visits`}>
             <VisitTab patientId={patient.id} />
+          </Route>
+          <Route path={`${path}/history`}>
+            <HistoryTab patientId={patient.id} />
           </Route>
         </Panel>
       </div>

--- a/src/shared/locales/enUs/translations/patient/index.ts
+++ b/src/shared/locales/enUs/translations/patient/index.ts
@@ -202,6 +202,12 @@ export default {
         locationRequired: 'Location is required.',
       },
     },
+    history: {
+      label: 'History',
+      entryDate: 'Entry date',
+      recordType: 'Record type',
+      information: 'Information',
+    },
     types: {
       charity: 'Charity',
       private: 'Private',

--- a/src/shared/model/PatientHistoryRecord.tsx
+++ b/src/shared/model/PatientHistoryRecord.tsx
@@ -1,0 +1,11 @@
+export enum HistoryRecordType {
+  APPOINTMENT = 'Appointment',
+  LAB = 'Lab',
+}
+
+export interface PatientHistoryRecord {
+  date: Date
+  type: HistoryRecordType
+  info: string
+  recordId: string
+}

--- a/src/shared/model/Permissions.ts
+++ b/src/shared/model/Permissions.ts
@@ -11,6 +11,7 @@ enum Permissions {
   CompleteLab = 'complete:lab',
   ViewLab = 'read:lab',
   ViewLabs = 'read:labs',
+  ViewPatientHistory = 'read:history', 
   ViewIncidents = 'read:incidents',
   ViewIncident = 'read:incident',
   ReportIncident = 'write:incident',


### PR DESCRIPTION
Fixes #2255 - Create Patient History tab

**Changes proposed in this pull request:**

- Created a patient history tab available in the patient profile.
- Show in chronological order the events (Labs and Appointments) that have happened to the patient
    - The information shown for Labs is the Lab Type
    - The information shown for Appointments is the Appointment Reason
- Added tests for all the code created
