### PR TITLE
refactor(patient): decouple patient validator from redux code

### DIFF
--- a/src/__tests__/patients/util/validate-patient.test.ts
+++ b/src/__tests__/patients/util/validate-patient.test.ts
@@ -1,0 +1,83 @@
+import { addDays } from 'date-fns'
+
+import validatePatient from '../../../patients/util/validate-patient'
+
+const patient = {
+  id: 'abc123',
+  sex: 'Male',
+  givenName: 'John',
+  dateOfBirth: '01/11/1988',
+  isApproximateDateOfBirth: false,
+  code: 'abc123',
+  index: '1',
+  carePlans: [],
+  careGoals: [],
+  bloodType: 'A+',
+  visits: [],
+  rev: 'asd',
+  createdAt: '01/01/2020',
+  updatedAt: '01/01/2020',
+  phoneNumbers: [],
+  emails: [],
+  addresses: [],
+}
+
+describe('validate patient', () => {
+  it('should validate the patient required fields', () => {
+    const error = validatePatient({ ...patient, givenName: '' })
+
+    expect(error).toEqual({
+      givenName: 'patient.errors.patientGivenNameFeedback',
+    })
+  })
+
+  it('should validate that the patient birthday is not a future date', () => {
+    const error = validatePatient({
+      ...patient,
+      dateOfBirth: addDays(new Date(), 4).toISOString(),
+    })
+
+    expect(error).toEqual({
+      dateOfBirth: 'patient.errors.patientDateOfBirthFeedback',
+    })
+  })
+
+  it('should validate that the patient phone number is a valid phone number', () => {
+    const error = validatePatient({
+      ...patient,
+      phoneNumbers: [{ id: 'abc', value: 'not a phone number' }],
+    })
+
+    expect(error).toEqual({
+      phoneNumbers: ['patient.errors.invalidPhoneNumber'],
+    })
+  })
+
+  it('should validate that the patient email is a valid email', () => {
+    const error = validatePatient({
+      ...patient,
+      emails: [{ id: 'abc', value: 'not a phone number' }],
+    })
+
+    expect(error).toEqual({
+      emails: ['patient.errors.invalidEmail'],
+    })
+  })
+
+  it('should validate fields that should only contian alpha characters', () => {
+    const error = validatePatient({
+      ...patient,
+      suffix: 'A123',
+      familyName: 'B456',
+      prefix: 'C987',
+      preferredLanguage: 'D321',
+    })
+
+    expect(error).toEqual({
+      suffix: 'patient.errors.patientNumInSuffixFeedback',
+      familyName: 'patient.errors.patientNumInFamilyNameFeedback',
+      prefix: 'patient.errors.patientNumInPrefixFeedback',
+      preferredLanguage: 'patient.errors.patientNumInPreferredLanguageFeedback',
+    })
+  })
+})

--- a/src/patients/patient-slice.ts
+++ b/src/patients/patient-slice.ts
@@ -114,7 +114,7 @@ export const createPatient = (
   const cleanPatient = cleanupPatient(patient)
   const newPatientError = validatePatient(cleanPatient)
 
-  if (isEmpty(newPatientError)) {
+  if (!newPatientError) {
     const newPatient = await PatientRepository.save(cleanPatient)
     dispatch(createPatientSuccess())
 
@@ -122,8 +122,12 @@ export const createPatient = (
       onSuccess(newPatient)
     }
   } else {
-    newPatientError.message = 'patient.errors.createPatientError'
-    dispatch(createPatientError(newPatientError))
+    dispatch(
+      createPatientError({
+        ...newPatientError.fieldErrors,
+        message: 'patient.errors.createPatientError',
+      }),
+    )
   }
 }
 
@@ -136,7 +140,7 @@ export const updatePatient = (
   const cleanPatient = cleanupPatient(patient)
   const updateError = validatePatient(cleanPatient)
 
-  if (isEmpty(updateError)) {
+  if (!updateError) {
     const updatedPatient = await PatientRepository.saveOrUpdate(cleanPatient)
     dispatch(updatePatientSuccess(updatedPatient))
 
@@ -144,8 +148,12 @@ export const updatePatient = (
       onSuccess(updatedPatient)
     }
   } else {
-    updateError.message = 'patient.errors.updatePatientError'
-    dispatch(updatePatientError(updateError))
+    dispatch(
+      updatePatientError({
+        ...updateError.fieldErrors,
+        message: 'patient.errors.updatePatientError',
+      }),
+    )
   }
 }
 

--- a/src/patients/patient-slice.ts
+++ b/src/patients/patient-slice.ts
@@ -1,7 +1,5 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit'
-import { isAfter, parseISO } from 'date-fns'
 import { isEmpty } from 'lodash'
-import validator from 'validator'
 
 import PatientRepository from '../shared/db/PatientRepository'
 import Diagnosis from '../shared/model/Diagnosis'
@@ -9,6 +7,7 @@ import Patient from '../shared/model/Patient'
 import { AppThunk } from '../shared/store'
 import { uuid } from '../shared/util/uuid'
 import { cleanupPatient } from './util/set-patient-helper'
+import validatePatient from './util/validate-patient'
 
 interface PatientState {
   status: 'loading' | 'error' | 'completed'
@@ -105,80 +104,6 @@ export const {
   updatePatientError,
   addDiagnosisError,
 } = patientSlice.actions
-
-function validatePatient(patient: Patient) {
-  const error: Error = {}
-
-  const regexContainsNumber = /\d/
-
-  if (!patient.givenName) {
-    error.givenName = 'patient.errors.patientGivenNameFeedback'
-  }
-
-  if (patient.dateOfBirth) {
-    const today = new Date(Date.now())
-    const dob = parseISO(patient.dateOfBirth)
-    if (isAfter(dob, today)) {
-      error.dateOfBirth = 'patient.errors.patientDateOfBirthFeedback'
-    }
-  }
-
-  if (patient.suffix) {
-    if (regexContainsNumber.test(patient.suffix)) {
-      error.suffix = 'patient.errors.patientNumInSuffixFeedback'
-    }
-  }
-
-  if (patient.prefix) {
-    if (regexContainsNumber.test(patient.prefix)) {
-      error.prefix = 'patient.errors.patientNumInPrefixFeedback'
-    }
-  }
-
-  if (patient.familyName) {
-    if (regexContainsNumber.test(patient.familyName)) {
-      error.familyName = 'patient.errors.patientNumInFamilyNameFeedback'
-    }
-  }
-
-  if (patient.preferredLanguage) {
-    if (regexContainsNumber.test(patient.preferredLanguage)) {
-      error.preferredLanguage = 'patient.errors.patientNumInPreferredLanguageFeedback'
-    }
-  }
-
-  if (patient.emails) {
-    const errors: (string | undefined)[] = []
-    patient.emails.forEach((email) => {
-      if (!validator.isEmail(email.value)) {
-        errors.push('patient.errors.invalidEmail')
-      } else {
-        errors.push(undefined)
-      }
-    })
-    // Only add to error obj if there's an error
-    if (errors.some((value) => value !== undefined)) {
-      error.emails = errors
-    }
-  }
-
-  if (patient.phoneNumbers) {
-    const errors: (string | undefined)[] = []
-    patient.phoneNumbers.forEach((phoneNumber) => {
-      if (!validator.isMobilePhone(phoneNumber.value)) {
-        errors.push('patient.errors.invalidPhoneNumber')
-      } else {
-        errors.push(undefined)
-      }
-    })
-    // Only add to error obj if there's an error
-    if (errors.some((value) => value !== undefined)) {
-      error.phoneNumbers = errors
-    }
-  }
-
-  return error
-}
 
 export const createPatient = (
   patient: Patient,

--- a/src/patients/util/validate-patient.ts
+++ b/src/patients/util/validate-patient.ts
@@ -1,0 +1,90 @@
+import { isAfter, parseISO } from 'date-fns'
+import validator from 'validator'
+
+import Patient from '../../shared/model/Patient'
+
+interface Error {
+  message?: string
+  givenName?: string
+  dateOfBirth?: string
+  suffix?: string
+  prefix?: string
+  familyName?: string
+  preferredLanguage?: string
+  emails?: (string | undefined)[]
+  phoneNumbers?: (string | undefined)[]
+}
+
+export default function validatePatient(patient: Patient) {
+  const error: Error = {}
+
+  const regexContainsNumber = /\d/
+
+  if (!patient.givenName) {
+    error.givenName = 'patient.errors.patientGivenNameFeedback'
+  }
+
+  if (patient.dateOfBirth) {
+    const today = new Date(Date.now())
+    const dob = parseISO(patient.dateOfBirth)
+    if (isAfter(dob, today)) {
+      error.dateOfBirth = 'patient.errors.patientDateOfBirthFeedback'
+    }
+  }
+
+  if (patient.suffix) {
+    if (regexContainsNumber.test(patient.suffix)) {
+      error.suffix = 'patient.errors.patientNumInSuffixFeedback'
+    }
+  }
+
+  if (patient.prefix) {
+    if (regexContainsNumber.test(patient.prefix)) {
+      error.prefix = 'patient.errors.patientNumInPrefixFeedback'
+    }
+  }
+
+  if (patient.familyName) {
+    if (regexContainsNumber.test(patient.familyName)) {
+      error.familyName = 'patient.errors.patientNumInFamilyNameFeedback'
+    }
+  }
+
+  if (patient.preferredLanguage) {
+    if (regexContainsNumber.test(patient.preferredLanguage)) {
+      error.preferredLanguage = 'patient.errors.patientNumInPreferredLanguageFeedback'
+    }
+  }
+
+  if (patient.emails) {
+    const errors: (string | undefined)[] = []
+    patient.emails.forEach((email) => {
+      if (!validator.isEmail(email.value)) {
+        errors.push('patient.errors.invalidEmail')
+      } else {
+        errors.push(undefined)
+      }
+    })
+    // Only add to error obj if there's an error
+    if (errors.some((value) => value !== undefined)) {
+      error.emails = errors
+    }
+  }
+
+  if (patient.phoneNumbers) {
+    const errors: (string | undefined)[] = []
+    patient.phoneNumbers.forEach((phoneNumber) => {
+      if (!validator.isMobilePhone(phoneNumber.value)) {
+        errors.push('patient.errors.invalidPhoneNumber')
+      } else {
+        errors.push(undefined)
+      }
+    })
+    // Only add to error obj if there's an error
+    if (errors.some((value) => value !== undefined)) {
+      error.phoneNumbers = errors
+    }
+  }
+
+  return error
+}


### PR DESCRIPTION
This change is an intermediate step to solve #2378, #2382.

**Changes proposed in this pull request:**
- Create a shared patient validator to be able to use on different hooks