### PR TITLE
feat(lab): link visit to labs

### DIFF
--- a/src/__tests__/labs/requests/NewLabRequest.test.tsx
+++ b/src/__tests__/labs/requests/NewLabRequest.test.tsx
@@ -164,6 +164,55 @@ describe('New Lab Request', () => {
       // The visits dropdown option should be reset when the patient is changed.
       expect(wrapper.find(SelectWithLabelFormGroup).prop('options')).toEqual([])
     })
+
+    it('should support selecting a visit', async () => {
+      const { wrapper } = await setup()
+      const patientTypeahead = wrapper.find(Typeahead)
+      const expectedDate = new Date()
+      const expectedNotes = 'expected notes'
+      const expectedLab = {
+        patient: '123456789',
+        type: 'expected type',
+        status: 'requested',
+        notes: [expectedNotes],
+        id: '1234',
+        requestedOn: expectedDate.toISOString(),
+      } as Lab
+
+      const visits = [
+        {
+          startDateTime: new Date().toISOString(),
+          id: 'visit_id',
+          type: 'visit_type',
+        },
+      ] as Visit[]
+      const visitOptions = [
+        {
+          label: `${visits[0].type} at ${format(
+            new Date(visits[0].startDateTime),
+            'yyyy-MM-dd hh:mm a',
+          )}`,
+          value: 'visit_id',
+        },
+      ]
+      expect(wrapper.find(SelectWithLabelFormGroup).prop('defaultSelected')).toEqual([])
+      await act(async () => {
+        const onChange = patientTypeahead.prop('onChange') as any
+        await onChange([{ id: expectedLab.patient, visits }] as Patient[])
+      })
+      wrapper.update()
+      expect(wrapper.find(SelectWithLabelFormGroup).prop('defaultSelected')).toEqual([])
+      const dropdown = wrapper.find(SelectWithLabelFormGroup)
+      await act(async () => {
+        // The onChange method takes a list of possible values,
+        // but our dropdown is single-select, so the argument passed to onChange()
+        // is a list with just one element. This is why we pass
+        // the whole array `visitOptions` as opposed to `visitOptions[0]`.
+        await (dropdown.prop('onChange') as any)(visitOptions.map((option) => option.value))
+      })
+      wrapper.update()
+      expect(wrapper.find(SelectWithLabelFormGroup).prop('defaultSelected')).toEqual(visitOptions)
+    })
   })
 
   describe('errors', () => {

--- a/src/__tests__/labs/requests/NewLabRequest.test.tsx
+++ b/src/__tests__/labs/requests/NewLabRequest.test.tsx
@@ -12,6 +12,7 @@ import NewLabRequest from '../../../labs/requests/NewLabRequest'
 import * as validationUtil from '../../../labs/utils/validate-lab'
 import { LabError } from '../../../labs/utils/validate-lab'
 import * as titleUtil from '../../../page-header/title/TitleContext'
+import SelectWithLabelFormGroup from '../../../shared/components/input/SelectWithLabelFormGroup'
 import TextFieldWithLabelFormGroup from '../../../shared/components/input/TextFieldWithLabelFormGroup'
 import TextInputWithLabelFormGroup from '../../../shared/components/input/TextInputWithLabelFormGroup'
 import LabRepository from '../../../shared/db/LabRepository'
@@ -88,6 +89,15 @@ describe('New Lab Request', () => {
       expect(notesTextField.prop('label')).toEqual('labs.lab.notes')
       expect(notesTextField.prop('isRequired')).toBeFalsy()
       expect(notesTextField.prop('isEditable')).toBeTruthy()
+    })
+
+    it('should render a visit select', async () => {
+      const { wrapper } = await setup()
+      const visitSelect = wrapper.find(SelectWithLabelFormGroup)
+
+      expect(visitSelect).toBeDefined()
+      expect(visitSelect.prop('label') as string).toEqual('patient.visit')
+      expect(visitSelect.prop('isRequired')).toBeTruthy()
     })
 
     it('should render a save button', async () => {

--- a/src/labs/requests/NewLabRequest.tsx
+++ b/src/labs/requests/NewLabRequest.tsx
@@ -50,17 +50,26 @@ const NewLabRequest = () => {
   useAddBreadcrumbs(breadcrumbs)
 
   const onPatientChange = (patient: Patient) => {
-    const visits = patient.visits?.map((v) => ({
-      label: `${v.type} at ${format(new Date(v.startDateTime), 'yyyy-MM-dd hh:mm a')}`,
-      value: v.id,
-    })) as Option[]
-    setVisitOptions(visits)
+    if (patient) {
+      const visits = patient.visits.map((v) => ({
+        label: `${v.type} at ${format(new Date(v.startDateTime), 'yyyy-MM-dd hh:mm a')}`,
+        value: v.id,
+      })) as Option[]
 
-    setNewLabRequest((previousNewLabRequest) => ({
-      ...previousNewLabRequest,
-      patient: patient.id,
-      fullName: patient.fullName,
-    }))
+      setVisitOptions(visits)
+      setNewLabRequest((previousNewLabRequest) => ({
+        ...previousNewLabRequest,
+        patient: patient.id,
+        fullName: patient.fullName,
+      }))
+    } else {
+      setVisitOptions([])
+      setNewLabRequest((previousNewLabRequest) => ({
+        ...previousNewLabRequest,
+        patient: '',
+        visitId: '',
+      }))
+    }
   }
 
   const onLabTypeChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -97,10 +106,10 @@ const NewLabRequest = () => {
     }
   }
 
-  const onVisitChange = (value: string) => {
+  const onVisitChange = (visitId: string) => {
     setNewLabRequest((previousNewLabRequest) => ({
       ...previousNewLabRequest,
-      visitId: value,
+      visitId,
     }))
   }
 
@@ -140,9 +149,8 @@ const NewLabRequest = () => {
               <SelectWithLabelFormGroup
                 name="visit"
                 label={t('patient.visit')}
-                isRequired
                 isEditable={newLabRequest.patient !== undefined}
-                options={visitOptions || []}
+                options={visitOptions}
                 defaultSelected={defaultSelectedVisitsOption()}
                 onChange={(values) => {
                   onVisitChange(values[0])

--- a/src/shared/model/Lab.ts
+++ b/src/shared/model/Lab.ts
@@ -11,4 +11,5 @@ export default interface Lab extends AbstractDBModel {
   requestedOn: string
   completedOn?: string
   canceledOn?: string
+  visitId?: string
 }


### PR DESCRIPTION
Add functionality to link visit to lab, and updated the schema to have a visitId in the Lab model.

fix #2184

Fixes #2184.

**Changes proposed in this pull request:**

- Updated Lab db model to have an optional `visitId`
- In the "New Lab Request" screen, added a required dropdown to associate the lab request with a visit id.
