### PR TITLE
fix(medications): enUs locale spelling of canceled

### DIFF
--- a/src/shared/locales/enUs/translations/medications/index.ts
+++ b/src/shared/locales/enUs/translations/medications/index.ts
@@ -7,7 +7,7 @@ export default {
       draft: 'Draft',
       active: 'Active',
       onHold: 'On Hold',
-      cancelled: 'Cancelled',
+      canceled: 'Canceled',
       completed: 'Completed',
       enteredInError: 'Entered In Error',
       stopped: 'Stopped',


### PR DESCRIPTION
Fixes #2495 (i85n enUs locale spelling of 'canceled')

**Changes proposed in this pull request:**

- Changed spelling of _"cancelled"_ to _"canceled"_ in the `src/shared/locales/enUs/medications/index.ts` file.

**Newly added dependencies with [Bundlephobia](https://bundlephobia.com/) links:**

-None-

_Note: pull requests without proper descriptions may simply be closed without further discussion. We appreciate your contributions, but need to know what you are offering in clearly described format. Provide tests for all code that you add/modify. If you add/modify any components update the storybook. Thanks! (you can delete this text)_
