### PR TITLE
fix: search views width inconsistency

### DIFF
--- a/src/imagings/search/ViewImagings.tsx
+++ b/src/imagings/search/ViewImagings.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@hospitalrun/components'
+import { Button, Container, Row } from '@hospitalrun/components'
 import React, { useState, useEffect, useCallback } from 'react'
 import { useSelector } from 'react-redux'
 import { useHistory } from 'react-router-dom'
@@ -57,9 +57,11 @@ const ViewImagings = () => {
   }, [getButtons, setButtons])
 
   return (
-    <div className="row">
-      <ImagingRequestTable searchRequest={searchRequest} />
-    </div>
+    <Container>
+      <Row>
+        <ImagingRequestTable searchRequest={searchRequest} />
+      </Row>
+    </Container>
   )
 }
 

--- a/src/incidents/list/ViewIncidents.tsx
+++ b/src/incidents/list/ViewIncidents.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@hospitalrun/components'
+import { Button, Container, Row, Column } from '@hospitalrun/components'
 import React, { useEffect, useState } from 'react'
 import { useHistory } from 'react-router-dom'
 
@@ -45,9 +45,9 @@ const ViewIncidents = () => {
   }))
 
   return (
-    <>
-      <div className="row">
-        <div className="col-md-3 col-lg-2">
+    <Container>
+      <Row>
+        <Column md={3} lg={2}>
           <SelectWithLabelFormGroup
             name="type"
             label={t('incidents.filterTitle')}
@@ -56,12 +56,12 @@ const ViewIncidents = () => {
             onChange={(values) => setSearchFilter(values[0] as IncidentFilter)}
             isEditable
           />
-        </div>
-      </div>
-      <div className="row">
+        </Column>
+      </Row>
+      <Row>
         <ViewIncidentsTable searchRequest={{ status: searchFilter }} />
-      </div>
-    </>
+      </Row>
+    </Container>
   )
 }
 

--- a/src/labs/ViewLabs.tsx
+++ b/src/labs/ViewLabs.tsx
@@ -1,4 +1,4 @@
-import { Button, Table } from '@hospitalrun/components'
+import { Button, Table, Container, Row, Column } from '@hospitalrun/components'
 import format from 'date-fns/format'
 import React, { useState, useEffect, useCallback } from 'react'
 import { useSelector } from 'react-redux'
@@ -78,9 +78,9 @@ const ViewLabs = () => {
   ]
 
   return (
-    <>
-      <div className="row">
-        <div className="col-md-3 col-lg-2">
+    <Container>
+      <Row>
+        <Column md={3} lg={2}>
           <SelectWithLabelFormGroup
             name="type"
             label={t('labs.filterTitle')}
@@ -89,8 +89,8 @@ const ViewLabs = () => {
             onChange={(values) => setSearchFilter(values[0] as LabFilter)}
             isEditable
           />
-        </div>
-        <div className="col">
+        </Column>
+        <Column>
           <TextInputWithLabelFormGroup
             name="searchbox"
             label={t('labs.search')}
@@ -99,9 +99,9 @@ const ViewLabs = () => {
             isEditable
             onChange={onSearchBoxChange}
           />
-        </div>
-      </div>
-      <div className="row">
+        </Column>
+      </Row>
+      <Row>
         <Table
           getID={(row) => row.id}
           columns={[
@@ -119,8 +119,8 @@ const ViewLabs = () => {
           actionsHeaderText={t('actions.label')}
           actions={[{ label: t('actions.view'), action: (row) => onViewClick(row as Lab) }]}
         />
-      </div>
-    </>
+      </Row>
+    </Container>
   )
 }
 

--- a/src/medications/search/MedicationRequestSearch.tsx
+++ b/src/medications/search/MedicationRequestSearch.tsx
@@ -1,3 +1,4 @@
+import { Row, Column } from '@hospitalrun/components'
 import React, { ChangeEvent } from 'react'
 
 import SelectWithLabelFormGroup, {
@@ -43,8 +44,8 @@ const MedicationRequestSearch = (props: Props) => {
   }
 
   return (
-    <div className="row">
-      <div className="col-md-3 col-lg-2">
+    <Row>
+      <Column md={3} lg={2}>
         <SelectWithLabelFormGroup
           name="filterStatus"
           label={t('medications.filterTitle')}
@@ -53,8 +54,8 @@ const MedicationRequestSearch = (props: Props) => {
           onChange={(values) => onFilterChange(values[0] as MedicationStatus)}
           isEditable
         />
-      </div>
-      <div className="col">
+      </Column>
+      <Column>
         <TextInputWithLabelFormGroup
           name="searchbox"
           label={t('medications.search')}
@@ -63,8 +64,8 @@ const MedicationRequestSearch = (props: Props) => {
           isEditable
           onChange={onSearchQueryChange}
         />
-      </div>
-    </div>
+      </Column>
+    </Row>
   )
 }
 

--- a/src/medications/search/ViewMedications.tsx
+++ b/src/medications/search/ViewMedications.tsx
@@ -1,4 +1,4 @@
-import { Button, Column, Container, Row } from '@hospitalrun/components'
+import { Button, Container, Row } from '@hospitalrun/components'
 import React, { useEffect, useCallback, useState } from 'react'
 import { useSelector } from 'react-redux'
 import { useHistory } from 'react-router-dom'
@@ -62,9 +62,7 @@ const ViewMedications = () => {
     <Container>
       <MedicationRequestSearch searchRequest={searchRequest} onChange={onSearchRequestChange} />
       <Row>
-        <Column md={12}>
-          <MedicationRequestTable searchRequest={searchRequest} />
-        </Column>
+        <MedicationRequestTable searchRequest={searchRequest} />
       </Row>
     </Container>
   )


### PR DESCRIPTION
Medications, Labs, Imagings, and Incidents search views made consistent with @hospitalrun/components

Fixes #2503. 

**Changes proposed in this pull request:**

- Medications search view component changed to common style using components from `@hospitalrun/components`
- Labs search view component changed to common style using components from `@hospitalrun/components`
- Imagings search view component changed to common style using components from `@hospitalrun/components`
- Incidents search view component changed to common style using components from `@hospitalrun/components`

**Newly added dependencies with [Bundlephobia](https://bundlephobia.com/) links:**
_-None-_

_Note: pull requests without proper descriptions may simply be closed without further discussion. We appreciate your contributions, but need to know what you are offering in clearly described format. Provide tests for all code that you add/modify. If you add/modify any components update the storybook. Thanks! (you can delete this text)_
