### PR TITLE
feat(visits): add "request imaging button" that auto-populate imaging…

### DIFF
--- a/src/patients/visits/ViewVisit.tsx
+++ b/src/patients/visits/ViewVisit.tsx
@@ -1,7 +1,12 @@
+import { Button } from '@hospitalrun/components'
 import React from 'react'
-import { useParams } from 'react-router-dom'
+import { useSelector } from 'react-redux'
+import { useHistory, useParams } from 'react-router-dom'
 
 import Loading from '../../shared/components/Loading'
+import useTranslator from '../../shared/hooks/useTranslator'
+import Permissions from '../../shared/model/Permissions'
+import { RootState } from '../../shared/store'
 import useVisit from '../hooks/useVisit'
 import VisitForm from './VisitForm'
 
@@ -10,6 +15,9 @@ interface Props {
 }
 const ViewVisit = ({ patientId }: Props) => {
   const { visitId } = useParams()
+  const history = useHistory()
+  const { permissions } = useSelector((state: RootState) => state.user)
+  const { t } = useTranslator()
 
   const { data: visit, status } = useVisit(patientId, visitId)
 
@@ -19,7 +27,20 @@ const ViewVisit = ({ patientId }: Props) => {
 
   return (
     <>
-      <h2>{visit.reason}</h2>
+      <div className="col d-flex justify-content-between">
+        <h2>{visit.reason}</h2>
+        {permissions.includes(Permissions.RequestImaging) && (
+          <Button
+            outlined
+            color="success"
+            icon="add"
+            iconLocation="left"
+            onClick={() => history.push('/imaging/new', { patientId, visitId })}
+          >
+            {t('patient.visits.newImaging')}
+          </Button>
+        )}
+      </div>
       <VisitForm visit={visit} disabled />
     </>
   )

--- a/src/patients/visits/VisitTab.tsx
+++ b/src/patients/visits/VisitTab.tsx
@@ -1,11 +1,6 @@
-import { Button } from '@hospitalrun/components'
 import React, { useState } from 'react'
-import { useSelector } from 'react-redux'
 import { Route, Switch } from 'react-router-dom'
 
-import useTranslator from '../../shared/hooks/useTranslator'
-import Permissions from '../../shared/model/Permissions'
-import { RootState } from '../../shared/store'
 import AddVisitModal from './AddVisitModal'
 import ViewVisit from './ViewVisit'
 import VisitTable from './VisitTable'
@@ -15,26 +10,9 @@ interface Props {
 }
 
 const VisitTab = ({ patientId }: Props) => {
-  const { t } = useTranslator()
-  const { permissions } = useSelector((state: RootState) => state.user)
   const [showAddVisitModal, setShowAddVisitModal] = useState(false)
   return (
     <>
-      <div className="row">
-        <div className="col-md-12 d-flex justify-content-end">
-          {permissions.includes(Permissions.AddVisit) && (
-            <Button
-              outlined
-              color="success"
-              icon="add"
-              iconLocation="left"
-              onClick={() => setShowAddVisitModal(true)}
-            >
-              {t('patient.visits.new')}
-            </Button>
-          )}
-        </div>
-      </div>
       <br />
       <Switch>
         <Route exact path="/patients/:id/visits">

--- a/src/shared/locales/enUs/translations/patient/index.ts
+++ b/src/shared/locales/enUs/translations/patient/index.ts
@@ -199,6 +199,7 @@ export default {
       status: 'Status',
       reason: 'Reason',
       location: 'Location',
+      newImaging: 'New Imaging Request',
       error: {
         unableToAdd: 'Unable to add a new visit.',
         startDateRequired: 'Start date is required.',


### PR DESCRIPTION
… request

**Changes proposed in this pull request:**

- Remove "add visit" button from visits tab (since there's one already) and add a "add imaging request" button instead
- Implement logic that populates the fields in `NewImagingRequest` if the user is redirected there from the visits tab
