### PR TITLE
fix(lab): In New lab request make the visit field required

### DIFF
--- a/src/__tests__/labs/requests/NewLabRequest.test.tsx
+++ b/src/__tests__/labs/requests/NewLabRequest.test.tsx
@@ -122,7 +122,7 @@ describe('New Lab Request', () => {
       expect(selectInput).toBeInTheDocument()
       expect(selectInput).toHaveDisplayValue([''])
       expect(selectLabel).toBeInTheDocument()
-      expect(selectLabel).not.toHaveAttribute('title', 'This is a required input')
+      expect(selectLabel).toHaveAttribute('title', 'This is a required input')
     })
 
     it('should render a save button', () => {

--- a/src/labs/requests/NewLabRequest.tsx
+++ b/src/labs/requests/NewLabRequest.tsx
@@ -51,7 +51,7 @@ const NewLabRequest = () => {
 
   const onPatientChange = (patient: Patient) => {
     if (patient) {
-      const visits = patient.visits.map((v) => ({
+      const visits = patient.visits?.map((v) => ({
         label: `${v.type} at ${format(new Date(v.startDateTime), 'yyyy-MM-dd hh:mm a')}`,
         value: v.id,
       })) as Option[]
@@ -150,7 +150,7 @@ const NewLabRequest = () => {
                 name="visit"
                 label={t('patient.visit')}
                 isEditable={newLabRequest.patient !== undefined}
-                options={visitOptions}
+                options={visitOptions || []}
                 defaultSelected={defaultSelectedVisitsOption()}
                 onChange={(values) => {
                   onVisitChange(values[0])

--- a/src/labs/requests/NewLabRequest.tsx
+++ b/src/labs/requests/NewLabRequest.tsx
@@ -149,6 +149,7 @@ const NewLabRequest = () => {
               <SelectWithLabelFormGroup
                 name="visit"
                 label={t('patient.visit')}
+                isRequired
                 isEditable={newLabRequest.patient !== undefined}
                 options={visitOptions || []}
                 defaultSelected={defaultSelectedVisitsOption()}


### PR DESCRIPTION
Fixes #2551 .

**Changes proposed in this pull request:**

- I make the `NewLabRequest` use the exact same method to solve the `null` visit issue. [`NewImagingRequest.tsx` line65](https://github.com/HospitalRun/hospitalrun-frontend/blob/45647d3b4a15ca8d9c57ebda66b3712658d62f19/src/imagings/requests/NewImagingRequest.tsx#L65)
- My concern is, we use the `as Option[]` at line 57. So that the type of the variable `visits` is not right. It should be `Option[] | null`. Maybe we should do some refactor in `NewImagingRequest.tsx` and `NewLabRequest.tsx` to fix this wrong type. Otherwise, it may lead to other bugs in the future.
