### PR TITLE
fix(lab): enforce the visit field when create lab

### DIFF
--- a/src/__tests__/labs/hooks/useRequestLab.test.ts
+++ b/src/__tests__/labs/hooks/useRequestLab.test.ts
@@ -11,7 +11,7 @@ describe('Use Request lab', () => {
   const lab = {
     type: 'test',
     patient: '123',
-    visitId: 'test visit id',
+    visitId: 'visit id',
   } as Lab
   const expectedRequestedLab = {
     ...lab,

--- a/src/__tests__/labs/hooks/useRequestLab.test.ts
+++ b/src/__tests__/labs/hooks/useRequestLab.test.ts
@@ -11,6 +11,7 @@ describe('Use Request lab', () => {
   const lab = {
     type: 'test',
     patient: '123',
+    visitId: 'test visit id',
   } as Lab
   const expectedRequestedLab = {
     ...lab,

--- a/src/__tests__/labs/requests/NewLabRequest.test.tsx
+++ b/src/__tests__/labs/requests/NewLabRequest.test.tsx
@@ -34,6 +34,7 @@ const setup = (
   const expectedLab = {
     patient: '1234567',
     type: 'expected type',
+    visitId: 'visit_id',
     status: 'requested',
     notes: [expectedNotes],
     id: '1234',
@@ -224,6 +225,8 @@ describe('New Lab Request', () => {
       userEvent.type(screen.getByPlaceholderText(/labs.lab.patient/i), 'Jim Bob')
       expect(await screen.findByText(/jim bob/i)).toBeVisible()
       userEvent.click(screen.getByText(/jim bob/i))
+      userEvent.click(screen.getByPlaceholderText('-- Choose --')) // click the Visit field
+      userEvent.click(screen.getByText(/visit_type/i))
       userEvent.type(screen.getByLabelText(/labs\.lab\.type/i), expectedLab.type)
       userEvent.type(screen.getByLabelText(/labs\.lab\.notes/i), (expectedLab.notes as string[])[0])
       userEvent.click(screen.getByRole('button', { name: /labs\.requests\.new/i }))

--- a/src/__tests__/labs/utils/validate-lab.test.ts
+++ b/src/__tests__/labs/utils/validate-lab.test.ts
@@ -7,6 +7,7 @@ describe('lab validator', () => {
       const lab = {
         patient: 'some patient',
         type: 'type test',
+        visitId: 'test visit id',
       } as Lab
 
       const expectedError = {} as LabError
@@ -23,6 +24,7 @@ describe('lab validator', () => {
         patient: 'labs.requests.error.patientRequired',
         type: 'labs.requests.error.typeRequired',
         message: 'labs.requests.error.unableToRequest',
+        visit: 'labs.requests.error.visitRequired',
       } as LabError
 
       const actualError = validateLabRequest(lab)

--- a/src/labs/requests/NewLabRequest.tsx
+++ b/src/labs/requests/NewLabRequest.tsx
@@ -151,6 +151,7 @@ const NewLabRequest = () => {
                 label={t('patient.visit')}
                 isRequired
                 isEditable={newLabRequest.patient !== undefined}
+                isInvalid={!!error?.visit}
                 options={visitOptions || []}
                 defaultSelected={defaultSelectedVisitsOption()}
                 onChange={(values) => {

--- a/src/labs/utils/validate-lab.ts
+++ b/src/labs/utils/validate-lab.ts
@@ -11,6 +11,8 @@ export class LabError extends Error {
 
   type?: string
 
+  visit?: string
+
   constructor(message: string, result: string, patient: string, type: string) {
     super(message)
     this.message = message
@@ -29,6 +31,10 @@ export function validateLabRequest(lab: Partial<Lab>): LabError {
 
   if (!lab.type) {
     labError.type = 'labs.requests.error.typeRequired'
+  }
+
+  if (!lab.visitId) {
+    labError.visit = 'labs.requests.error.visitRequired'
   }
 
   if (!isEmpty(labError)) {

--- a/src/shared/locales/enUs/translations/labs/index.ts
+++ b/src/shared/locales/enUs/translations/labs/index.ts
@@ -27,6 +27,7 @@ export default {
         unableToComplete: 'Unable to complete lab request.',
         typeRequired: 'Type is required.',
         patientRequired: 'Patient is required.',
+        visitRequired: 'Visit is required.',
         resultRequiredToComplete: 'Result is required to complete.',
       },
     },

--- a/src/shared/model/Lab.ts
+++ b/src/shared/model/Lab.ts
@@ -11,5 +11,5 @@ export default interface Lab extends AbstractDBModel {
   requestedOn: string
   completedOn?: string
   canceledOn?: string
-  visitId?: string
+  visitId: string
 }


### PR DESCRIPTION
Fixes #2557

**Changes proposed in this pull request:**

- validate the `visit` field when saving the Lab.
