### PR TITLE
feat(labs): delete individual lab notes

### DIFF
--- a/src/labs/ViewLab.tsx
+++ b/src/labs/ViewLab.tsx
@@ -71,6 +71,21 @@ const ViewLab = () => {
     setNewNotes(notes)
   }
 
+  const deleteNote = async (noteIndexToDelete: number) => {
+    if (!labToView || !labToView.notes) {
+      return
+    }
+
+    const updatedNotes = labToView!.notes!.filter((_note, i) => i !== noteIndexToDelete)
+    const newLab = {
+      ...labToView,
+      notes: updatedNotes,
+    }
+
+    await updateLab(newLab as Lab)
+    Toast('success', t('states.success'), t('labs.successfullyDeletedNote'))
+  }
+
   const onUpdate = async () => {
     if (labToView) {
       const newLab = labToView as Lab
@@ -183,9 +198,14 @@ const ViewLab = () => {
 
     const getPastNotes = () => {
       if (labToView.notes && labToView.notes[0] !== '') {
-        return labToView.notes.map((note: string) => (
-          <Callout key={uuid()} data-test="note" color="info">
-            <p data-testid="note">{note}</p>
+        return labToView.notes.map((note, index) => (
+          <Callout key={uuid()} color="info">
+            <div className="d-flex justify-content-between">
+              <p data-testid="note">{note}</p>
+              <Button onClick={async () => deleteNote(index)} color="danger">
+                <span data-testid={`delete-note-index-${index}`}>Delete</span>
+              </Button>
+            </div>
           </Callout>
         ))
       }

--- a/src/shared/locales/enUs/translations/labs/index.ts
+++ b/src/shared/locales/enUs/translations/labs/index.ts
@@ -6,6 +6,7 @@ export default {
     successfullyUpdated: 'Successfully updated',
     successfullyCompleted: 'Successfully completed',
     successfullyCreated: 'Successfully created',
+    successfullyDeletedNote: 'Note was deleted',
     status: {
       requested: 'Requested',
       completed: 'Completed',


### PR DESCRIPTION
Closes #2364

Allows notes on labs to be deleted

## Flow
![image](https://user-images.githubusercontent.com/2770198/106300319-5cc9b600-6224-11eb-804f-0a3dc99d10d9.png)
![image](https://user-images.githubusercontent.com/2770198/106300356-6c48ff00-6224-11eb-816c-0efde42b48cd.png)
![image](https://user-images.githubusercontent.com/2770198/106300374-71a64980-6224-11eb-997b-57a38db86a27.png)

**Changes proposed in this pull request:**
- delete notes from labs
