### PR TITLE
fix(image): enforce visit field when create image

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": false,
   "license": "MIT",
   "dependencies": {
-    "@hospitalrun/components": "~3.3.0",
+    "@hospitalrun/components": "~3.4.0",
     "@reduxjs/toolkit": "~1.5.0",
     "@types/escape-string-regexp": "~2.0.1",
     "@types/json2csv": "~5.0.1",

--- a/src/__tests__/imagings/util/validate-imaging-request.test.ts
+++ b/src/__tests__/imagings/util/validate-imaging-request.test.ts
@@ -8,6 +8,8 @@ describe('imaging request validator', () => {
       patient: 'imagings.requests.error.patientRequired',
       status: 'imagings.requests.error.statusRequired',
       type: 'imagings.requests.error.typeRequired',
+      visit: 'imagings.requests.error.visitRequired',
+      message: 'imagings.requests.error.unableToRequest',
     }
 
     const actualError = validateImagingRequest(newImagingRequest)

--- a/src/imagings/requests/NewImagingRequest.tsx
+++ b/src/imagings/requests/NewImagingRequest.tsx
@@ -163,6 +163,7 @@ const NewImagingRequest = () => {
                 options={visitOption || []}
                 defaultSelected={defaultSelectedVisitsOption()}
                 isInvalid={!!error?.visit}
+                feedback={t(error?.visit)}
                 onChange={(values) => {
                   onVisitChange(values[0])
                 }}

--- a/src/imagings/requests/NewImagingRequest.tsx
+++ b/src/imagings/requests/NewImagingRequest.tsx
@@ -163,7 +163,6 @@ const NewImagingRequest = () => {
                 options={visitOption || []}
                 defaultSelected={defaultSelectedVisitsOption()}
                 isInvalid={!!error?.visit}
-                feedback={t(error?.visit)}
                 onChange={(values) => {
                   onVisitChange(values[0])
                 }}

--- a/src/imagings/requests/NewImagingRequest.tsx
+++ b/src/imagings/requests/NewImagingRequest.tsx
@@ -162,6 +162,8 @@ const NewImagingRequest = () => {
                 isEditable={newImagingRequest.patient !== undefined}
                 options={visitOption || []}
                 defaultSelected={defaultSelectedVisitsOption()}
+                isInvalid={!!error?.visit}
+                feedback={t(error?.visit)}
                 onChange={(values) => {
                   onVisitChange(values[0])
                 }}

--- a/src/imagings/util/validate-imaging-request.ts
+++ b/src/imagings/util/validate-imaging-request.ts
@@ -1,3 +1,5 @@
+import { isEmpty } from 'lodash'
+
 import Imaging from '../../shared/model/Imaging'
 
 const statusType: string[] = ['requested', 'completed', 'canceled']
@@ -9,21 +11,27 @@ export class ImagingRequestError extends Error {
 
   status?: string
 
-  constructor(message: string, patient?: string, type?: string, status?: string) {
+  visit?: string
+
+  constructor(message: string, patient?: string, type?: string, status?: string, visit?: string) {
     super(message)
     this.patient = patient
     this.type = type
     this.status = status
+    this.visit = visit
     Object.setPrototypeOf(this, ImagingRequestError.prototype)
   }
 }
 
-export default function validateImagingRequest(request: Partial<Imaging>) {
-  const imagingRequestError = {} as any
+export default function validateImagingRequest(request: Partial<Imaging>): ImagingRequestError {
+  const imagingRequestError = {} as ImagingRequestError
+
   if (!request.patient) {
     imagingRequestError.patient = 'imagings.requests.error.patientRequired'
   }
-
+  if (!request.visitId) {
+    imagingRequestError.visit = 'imagings.requests.error.visitRequired'
+  }
   if (!request.type) {
     imagingRequestError.type = 'imagings.requests.error.typeRequired'
   }
@@ -32,6 +40,10 @@ export default function validateImagingRequest(request: Partial<Imaging>) {
     imagingRequestError.status = 'imagings.requests.error.statusRequired'
   } else if (!statusType.includes(request.status)) {
     imagingRequestError.status = 'imagings.requests.error.incorrectStatus'
+  }
+
+  if (!isEmpty(imagingRequestError)) {
+    imagingRequestError.message = 'imagings.requests.error.unableToRequest'
   }
 
   return imagingRequestError

--- a/src/shared/components/input/SelectWithLabelFormGroup.tsx
+++ b/src/shared/components/input/SelectWithLabelFormGroup.tsx
@@ -18,6 +18,7 @@ interface Props {
   multiple?: boolean
   isEditable?: boolean
   isInvalid?: boolean
+  feedback?: string
 }
 
 const SelectWithLabelFormGroup = (props: Props) => {
@@ -32,6 +33,7 @@ const SelectWithLabelFormGroup = (props: Props) => {
     multiple,
     isEditable,
     isInvalid,
+    feedback,
   } = props
   const id = `${name}Select`
   return (
@@ -46,6 +48,7 @@ const SelectWithLabelFormGroup = (props: Props) => {
         multiple={multiple}
         disabled={!isEditable}
         isInvalid={isInvalid}
+        feedback={feedback}
       />
     </div>
   )

--- a/src/shared/components/input/SelectWithLabelFormGroup.tsx
+++ b/src/shared/components/input/SelectWithLabelFormGroup.tsx
@@ -18,7 +18,6 @@ interface Props {
   multiple?: boolean
   isEditable?: boolean
   isInvalid?: boolean
-  feedback?: string
 }
 
 const SelectWithLabelFormGroup = (props: Props) => {
@@ -33,7 +32,6 @@ const SelectWithLabelFormGroup = (props: Props) => {
     multiple,
     isEditable,
     isInvalid,
-    feedback,
   } = props
   const id = `${name}Select`
   return (
@@ -48,7 +46,6 @@ const SelectWithLabelFormGroup = (props: Props) => {
         multiple={multiple}
         disabled={!isEditable}
         isInvalid={isInvalid}
-        feedback={feedback}
       />
     </div>
   )

--- a/src/shared/locales/enUs/translations/imagings/index.ts
+++ b/src/shared/locales/enUs/translations/imagings/index.ts
@@ -19,6 +19,7 @@ export default {
         typeRequired: 'Type is required.',
         statusRequired: 'Status is required.',
         patientRequired: 'Patient name is required.',
+        visitRequired: 'Visit is required.',
       },
     },
     imaging: {


### PR DESCRIPTION
Fixes #2556

Changes proposed in this pull request:

- validated `visit` field when creating the image request.
- Added warning message `Visit is required` and `Unable to create new imaging request`



