### PR TITLE
Fix for issue #2593

### DIFF
--- a/src/__tests__/patients/care-goals/CareGoalTab.test.tsx
+++ b/src/__tests__/patients/care-goals/CareGoalTab.test.tsx
@@ -116,7 +116,7 @@ describe('Care Goals Tab', () => {
     expect(cells[0]).toHaveTextContent(expectedCareGoal.description)
     expect(cells[1]).toHaveTextContent(format(expectedCareGoal.startDate, 'yyyy-MM-dd'))
     expect(cells[2]).toHaveTextContent(format(expectedCareGoal.dueDate, 'yyyy-MM-dd'))
-    expect(cells[3]).toHaveTextContent(expectedCareGoal.status)
+    expect(cells[3]).toHaveTextContent(expectedCareGoal.status) 
   }, 50000)
 
   it('should open and close the modal when the add care goal and close buttons are clicked', async () => {

--- a/src/__tests__/patients/care-goals/CareGoalTab.test.tsx
+++ b/src/__tests__/patients/care-goals/CareGoalTab.test.tsx
@@ -116,7 +116,7 @@ describe('Care Goals Tab', () => {
     expect(cells[0]).toHaveTextContent(expectedCareGoal.description)
     expect(cells[1]).toHaveTextContent(format(expectedCareGoal.startDate, 'yyyy-MM-dd'))
     expect(cells[2]).toHaveTextContent(format(expectedCareGoal.dueDate, 'yyyy-MM-dd'))
-    expect(cells[3]).toHaveTextContent(expectedCareGoal.status) 
+    expect(cells[3]).toHaveTextContent(expectedCareGoal.status)
   }, 50000)
 
   it('should open and close the modal when the add care goal and close buttons are clicked', async () => {

--- a/src/__tests__/patients/care-goals/CareGoalTab.test.tsx
+++ b/src/__tests__/patients/care-goals/CareGoalTab.test.tsx
@@ -117,7 +117,7 @@ describe('Care Goals Tab', () => {
     expect(cells[1]).toHaveTextContent(format(expectedCareGoal.startDate, 'yyyy-MM-dd'))
     expect(cells[2]).toHaveTextContent(format(expectedCareGoal.dueDate, 'yyyy-MM-dd'))
     expect(cells[3]).toHaveTextContent(expectedCareGoal.status)
-  }, 30000)
+  }, 50000)
 
   it('should open and close the modal when the add care goal and close buttons are clicked', async () => {
     setup('/patients/123/care-goals', [Permissions.AddCareGoal])


### PR DESCRIPTION
Fixes the failed test for patients/care-goals/CareGoalTab.test.tsx on Mac OSX.

**Changes proposed in this pull request:**

- Increased timeout allowed for the failed test from 30000 ms to 50000 ms.